### PR TITLE
feature: new auth routes

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -60,19 +60,15 @@ func (a *API) router() http.Handler {
 	r.Group(func(r chi.Router) {
 		// Seek, verify and validate JWT tokens
 		r.Use(jwtauth.Verifier(a.auth))
-
 		// Handle valid JWT tokens.
 		r.Use(a.authenticator)
-
 		// Refresh the token
-		log.Infow("new route", "method", "POST", "path", "/user/refresh")
-		r.Post("/user/refresh", a.refreshHandler)
-
+		log.Infow("new route", "method", "POST", "path", authRefresToken)
+		r.Post(authRefresToken, a.refreshHandler)
 		// Get the address
-		log.Infow("new route", "method", "GET", "path", "/user/address")
-		r.Get("/user/address", a.addressHandler)
+		log.Infow("new route", "method", "GET", "path", userAddress)
+		r.Get(userAddress, a.addressHandler)
 	})
-
 	// Public routes
 	r.Group(func(r chi.Router) {
 		r.Get("/ping", func(w http.ResponseWriter, r *http.Request) {
@@ -81,13 +77,11 @@ func (a *API) router() http.Handler {
 			}
 		})
 		// Register new users
-		log.Infow("new route", "method", "POST", "path", "/user/register")
-		r.Post("/user/register", a.registerHandler)
-
+		log.Infow("new route", "method", "POST", "path", userRegister)
+		r.Post(userRegister, a.registerHandler)
 		// Login
-		log.Infow("new route", "method", "POST", "path", "/user/login")
-		r.Post("/user/login", a.loginHandler)
+		log.Infow("new route", "method", "POST", "path", authLogin)
+		r.Post(authLogin, a.loginHandler)
 	})
-
 	return r
 }

--- a/api/api.go
+++ b/api/api.go
@@ -63,11 +63,11 @@ func (a *API) router() http.Handler {
 		// Handle valid JWT tokens.
 		r.Use(a.authenticator)
 		// Refresh the token
-		log.Infow("new route", "method", "POST", "path", authRefresToken)
-		r.Post(authRefresToken, a.refreshHandler)
+		log.Infow("new route", "method", "POST", "path", authRefresTokenEndpoint)
+		r.Post(authRefresTokenEndpoint, a.refreshTokenHandler)
 		// Get the address
-		log.Infow("new route", "method", "GET", "path", userAddress)
-		r.Get(userAddress, a.addressHandler)
+		log.Infow("new route", "method", "GET", "path", currentUserAddressEndpoint)
+		r.Get(currentUserAddressEndpoint, a.addressHandler)
 	})
 	// Public routes
 	r.Group(func(r chi.Router) {
@@ -77,11 +77,11 @@ func (a *API) router() http.Handler {
 			}
 		})
 		// Register new users
-		log.Infow("new route", "method", "POST", "path", userRegister)
-		r.Post(userRegister, a.registerHandler)
+		log.Infow("new route", "method", "POST", "path", usersEndpoint)
+		r.Post(usersEndpoint, a.registerHandler)
 		// Login
-		log.Infow("new route", "method", "POST", "path", authLogin)
-		r.Post(authLogin, a.loginHandler)
+		log.Infow("new route", "method", "POST", "path", authLoginEndpoint)
+		r.Post(authLoginEndpoint, a.authLoginHandler)
 	})
 	return r
 }

--- a/api/auth.go
+++ b/api/auth.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+)
+
+// refresh handles the refresh request. It returns a new JWT token.
+func (a *API) refreshTokenHandler(w http.ResponseWriter, r *http.Request) {
+	// Retrieve the user identifier from the HTTP header
+	userID := r.Header.Get("X-User-Id")
+	if userID == "" {
+		ErrUnauthorized.Write(w)
+		return
+	}
+	// Generate a new token with the user name as the subject
+	res, err := a.buildLoginResponse(userID)
+	if err != nil {
+		ErrGenericInternalServerError.Write(w)
+		return
+	}
+	// Send the token back to the user
+	httpWriteJSON(w, res)
+}
+
+// login handles the login request. It returns a JWT token if the login is successful.
+func (a *API) authLoginHandler(w http.ResponseWriter, r *http.Request) {
+	// Get the user name from the request body
+	loginInfo := &Login{}
+	if err := json.NewDecoder(r.Body).Decode(loginInfo); err != nil {
+		ErrMalformedBody.Write(w)
+		return
+	}
+	// Retrieve the user from the database
+	if _, ok := userMapForTest[loginInfo.Email]; !ok {
+		ErrUnauthorized.Write(w)
+		return
+	}
+	// Check the password
+	if !bytes.Equal(userMapForTest[loginInfo.Email], hashPassword(loginInfo.Password)) {
+		ErrUnauthorized.Write(w)
+		return
+	}
+	// Generate a new token with the user name as the subject
+	res, err := a.buildLoginResponse(loginInfo.Email)
+	if err != nil {
+		ErrGenericInternalServerError.Write(w)
+		return
+	}
+	// Send the token back to the user
+	httpWriteJSON(w, res)
+}

--- a/api/authenticator.go
+++ b/api/authenticator.go
@@ -31,10 +31,10 @@ func (a *API) authenticator(next http.Handler) http.Handler {
 	})
 }
 
-// makeToken creates a JWT token for the given user identifier.
+// buildLoginResponse creates a JWT token for the given user identifier.
 // The token is signed with the API secret, following the JWT specification.
 // The token is valid for the period specified on jwtExpiration constant.
-func (a *API) makeToken(id string) (*LoginResponse, error) {
+func (a *API) buildLoginResponse(id string) (*LoginResponse, error) {
 	j := jwt.New()
 	if err := j.Set("userId", id); err != nil {
 		return nil, err

--- a/api/routes.go
+++ b/api/routes.go
@@ -2,9 +2,9 @@ package api
 
 const (
 	// auth routes
-	authRefresToken = "/auth/refresh"
-	authLogin       = "/auth/login"
+	authRefresTokenEndpoint = "/auth/refresh"
+	authLoginEndpoint       = "/auth/login"
 	// user routes
-	userRegister = "/users/register"
-	userAddress  = "/users/address"
+	usersEndpoint              = "/users"
+	currentUserAddressEndpoint = "/users/address"
 )

--- a/api/routes.go
+++ b/api/routes.go
@@ -2,9 +2,16 @@ package api
 
 const (
 	// auth routes
+
+	// POST /auth/refresh to refresh the JWT token
 	authRefresTokenEndpoint = "/auth/refresh"
-	authLoginEndpoint       = "/auth/login"
+	// POST /auth/login to login and get a JWT token
+	authLoginEndpoint = "/auth/login"
+
 	// user routes
-	usersEndpoint              = "/users"
+
+	// POST /users to register a new user
+	usersEndpoint = "/users"
+	// GET /users/address to get the address of the current user
 	currentUserAddressEndpoint = "/users/address"
 )

--- a/api/routes.go
+++ b/api/routes.go
@@ -1,0 +1,10 @@
+package api
+
+const (
+	// auth routes
+	authRefresToken = "/auth/refresh"
+	authLogin       = "/auth/login"
+	// user routes
+	userRegister = "/users/register"
+	userAddress  = "/users/address"
+)

--- a/api/types.go
+++ b/api/types.go
@@ -21,3 +21,8 @@ type LoginResponse struct {
 	Token    string    `json:"token"`
 	Expirity time.Time `json:"expirity"`
 }
+
+// UserAddressResponse is the response of the address request for a user
+type UserAddressResponse struct {
+	Address string `json:"address"`
+}

--- a/api/user.go
+++ b/api/user.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,6 +11,19 @@ import (
 
 // userMapForTest is a map of user email to hashed password. It is used for testing purposes.
 var userMapForTest = make(map[string][]byte)
+
+// addUser adds a new user to the database. It returns an error if the user already exists.
+func addUser(u *Register) error {
+	log.Debugw("new user", "email", u.Email)
+	if _, ok := userMapForTest[u.Email]; ok {
+		return fmt.Errorf("user already exists")
+	}
+	if len(u.Password) < 8 {
+		return fmt.Errorf("password too short")
+	}
+	userMapForTest[u.Email] = hashPassword(u.Password)
+	return nil
+}
 
 // registerHandler handles the register request. It creates a new user in the database.
 func (a *API) registerHandler(w http.ResponseWriter, r *http.Request) {
@@ -31,71 +43,12 @@ func (a *API) registerHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// add the user to the database
-	if err := a.addUser(userInfo); err != nil {
+	if err := addUser(userInfo); err != nil {
 		ErrInvalidUserData.WithErr(err).Write(w)
 		return
 	}
 	// Generate a new token with the user name as the subject
 	res, err := a.buildLoginResponse(userInfo.Email)
-	if err != nil {
-		ErrGenericInternalServerError.Write(w)
-		return
-	}
-	// Send the token back to the user
-	httpWriteJSON(w, res)
-}
-
-// addUser adds a new user to the database. It returns an error if the user already exists.
-func (a *API) addUser(u *Register) error {
-	log.Debugw("new user", "email", u.Email)
-	if _, ok := userMapForTest[u.Email]; ok {
-		return fmt.Errorf("user already exists")
-	}
-	if len(u.Password) < 8 {
-		return fmt.Errorf("password too short")
-	}
-	userMapForTest[u.Email] = hashPassword(u.Password)
-	return nil
-}
-
-// refresh handles the refresh request. It returns a new JWT token.
-func (a *API) refreshHandler(w http.ResponseWriter, r *http.Request) {
-	// Retrieve the user identifier from the HTTP header
-	userID := r.Header.Get("X-User-Id")
-	if userID == "" {
-		ErrUnauthorized.Write(w)
-		return
-	}
-	// Generate a new token with the user name as the subject
-	res, err := a.buildLoginResponse(userID)
-	if err != nil {
-		ErrGenericInternalServerError.Write(w)
-		return
-	}
-	// Send the token back to the user
-	httpWriteJSON(w, res)
-}
-
-// login handles the login request. It returns a JWT token if the login is successful.
-func (a *API) loginHandler(w http.ResponseWriter, r *http.Request) {
-	// Get the user name from the request body
-	loginInfo := &Login{}
-	if err := json.NewDecoder(r.Body).Decode(loginInfo); err != nil {
-		ErrMalformedBody.Write(w)
-		return
-	}
-	// Retrieve the user from the database
-	if _, ok := userMapForTest[loginInfo.Email]; !ok {
-		ErrUnauthorized.Write(w)
-		return
-	}
-	// Check the password
-	if !bytes.Equal(userMapForTest[loginInfo.Email], hashPassword(loginInfo.Password)) {
-		ErrUnauthorized.Write(w)
-		return
-	}
-	// Generate a new token with the user name as the subject
-	res, err := a.buildLoginResponse(loginInfo.Email)
 	if err != nil {
 		ErrGenericInternalServerError.Write(w)
 		return


### PR DESCRIPTION
Changes made:
 - `POST /user/login` -> `POST /auth/login`
 - `POST /user/refresh` -> `POST /auth/refresh`
 - `POST /user/register` -> `POST /users`
 - `GET /user/address` -> `GET /users/address`
 
In the future, the routes definition will be here [api/routes.go](https://github.com/vocdoni/saas-backend/blob/f/new-auth-routes/api/routes.go)