### PR TITLE
feature: members invitations

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -132,8 +132,8 @@ func (a *API) initRouter() http.Handler {
 		log.Infow("new route", "method", "PUT", "path", organizationEndpoint)
 		r.Put(organizationEndpoint, a.updateOrganizationHandler)
 		// invite a new admin member to the organization
-		log.Infow("new route", "method", "POST", "path", organizationAddAdminEndpoint)
-		r.Post(organizationAddAdminEndpoint, a.inviteOrganizationAdminHandler)
+		log.Infow("new route", "method", "POST", "path", organizationAddMemberEndpoint)
+		r.Post(organizationAddMemberEndpoint, a.inviteOrganizationMemberHandler)
 	})
 
 	// Public routes
@@ -170,6 +170,9 @@ func (a *API) initRouter() http.Handler {
 		// get organization members
 		log.Infow("new route", "method", "GET", "path", organizationMembersEndpoint)
 		r.Get(organizationMembersEndpoint, a.organizationMembersHandler)
+		// accept organization invitation
+		log.Infow("new route", "method", "POST", "path", organizationAcceptMemberEndpoint)
+		r.Post(organizationAcceptMemberEndpoint, a.acceptOrganizationMemberInvitationHandler)
 	})
 	a.router = r
 	return r

--- a/api/api.go
+++ b/api/api.go
@@ -131,6 +131,9 @@ func (a *API) initRouter() http.Handler {
 		// update the organization
 		log.Infow("new route", "method", "PUT", "path", organizationEndpoint)
 		r.Put(organizationEndpoint, a.updateOrganizationHandler)
+		// invite a new admin member to the organization
+		log.Infow("new route", "method", "POST", "path", organizationAddAdminEndpoint)
+		r.Post(organizationAddAdminEndpoint, a.inviteOrganizationAdminHandler)
 	})
 
 	// Public routes

--- a/api/api.go
+++ b/api/api.go
@@ -30,7 +30,6 @@ type APIConfig struct {
 	Client      *apiclient.HTTPclient
 	Account     *account.Account
 	MailService notifications.NotificationService
-	SMSService  notifications.NotificationService
 	// FullTransparentMode if true allows signing all transactions and does not
 	// modify any of them.
 	FullTransparentMode bool
@@ -46,7 +45,6 @@ type API struct {
 	client          *apiclient.HTTPclient
 	account         *account.Account
 	mail            notifications.NotificationService
-	sms             notifications.NotificationService
 	secret          string
 	transparentMode bool
 }
@@ -64,7 +62,6 @@ func New(conf *APIConfig) *API {
 		client:          conf.Client,
 		account:         conf.Account,
 		mail:            conf.MailService,
-		sms:             conf.SMSService,
 		secret:          conf.Secret,
 		transparentMode: conf.FullTransparentMode,
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -30,6 +30,7 @@ const (
 	testPass      = "password123"
 	testFirstName = "test"
 	testLastName  = "user"
+	testPhone     = "+1234567890"
 	testHost      = "0.0.0.0"
 	testPort      = 7788
 

--- a/api/const.go
+++ b/api/const.go
@@ -13,4 +13,10 @@ const (
 	VerificationCodeEmailSubject = "Vocdoni verification code"
 	// VerificationCodeTextBody is the body of the verification code email
 	VerificationCodeTextBody = "Your Vocdoni verification code is: "
+	// InvitationEmailSubject is the subject of the invitation email
+	InvitationEmailSubject = "Vocdoni organization invitation"
+	// InvitationTextBody is the body of the invitation email
+	InvitationTextBody = "You code to join to '%s' organization is: %s"
+	// InvitationExpiration is the duration of the invitation code before it is invalidated
+	InvitationExpiration = 5 * 24 * time.Hour // 5 days
 )

--- a/api/docs.md
+++ b/api/docs.md
@@ -595,7 +595,7 @@ Only the following parameters can be changed. Every parameter is optional.
 | `409` | `40901` | `duplicate conflict` |
 | `500` | `50002` | `internal server error` |
 
-### 🧑‍💼 Accept organization invitation
+### 🤝 Accept organization invitation
 
 * **Path** `/organizations/{address}/members/accept`
 * **Method** `POST`

--- a/api/docs.md
+++ b/api/docs.md
@@ -26,7 +26,8 @@
   - [⚙️ Update organization](#-update-organization)
   - [🔍 Organization info](#-organization-info)
   - [🧑‍🤝‍🧑 Organization members](#-organization-members)
-  - [🧑‍💼 Invite organization admin](#-invite-organization-admin)
+  - [🧑‍💼 Invite organization member](#-invite-organization-member)
+  - [🤝 Accept organization invitation](#-accept-organization-invitation)
 
 </details>
 
@@ -189,7 +190,8 @@ This endpoint only returns the addresses of the organizations where the current 
     "email": "my@email.me",
     "firstName": "Steve",
     "lastName": "Urkel",
-    "password": "secretpass1234"
+    "password": "secretpass1234",
+    "phone": "123456789"
 }
 ```
 
@@ -566,20 +568,15 @@ Only the following parameters can be changed. Every parameter is optional.
 | `400` | `4012` | `no organization provided` |
 | `500` | `50002` | `internal server error` |
 
-### 🧑‍💼 Invite organization admin
+### 🧑‍💼 Invite organization member
 
-* **Path** `/organizations/{address}/members/admin`
+* **Path** `/organizations/{address}/members`
 * **Method** `POST`
 * **Response**
 ```json
 {
   "role": "admin",
-  "user": { 
-    "email": "newadmin@email.com",
-    "firstName": "Steve", // only if the user does not exists yet
-    "lastName": "Urkel",  // only if the user does not exists yet
-    "phone": "123456789",
-  },
+  "email": "newadmin@email.com"
 }
 ```
 
@@ -594,5 +591,40 @@ Only the following parameters can be changed. Every parameter is optional.
 | `400` | `40009` | `organization not found` |
 | `400` | `40011` | `no organization provided` |
 | `401` | `40014` | `user account not verified` |
+| `400` | `40019` | `inviation code expired` |
+| `409` | `40901` | `duplicate conflict` |
+| `500` | `50002` | `internal server error` |
+
+### 🧑‍💼 Accept organization invitation
+
+* **Path** `/organizations/{address}/members/accept`
+* **Method** `POST`
+* **Response**
+```json
+{
+  "code": "a3f3b5",
+  "user": { // only if the invited user is not already registered
+    "email": "my@email.me",
+    "firstName": "Steve",
+    "lastName": "Urkel",
+    "password": "secretpass1234",
+    "phone": "123456789"
+  }
+}
+```
+`user` object is only required if invited user is not registered yet.
+
+* **Errors**
+
+| HTTP Status | Error code | Message |
+|:---:|:---:|:---|
+| `401` | `40001` | `user not authorized` |
+| `400` | `40002` | `email malformed` |
+| `400` | `40004` | `malformed JSON body` |
+| `400` | `40005` | `invalid user data` |
+| `400` | `40009` | `organization not found` |
+| `400` | `40011` | `no organization provided` |
+| `401` | `40014` | `user account not verified` |
+| `400` | `40019` | `inviation code expired` |
 | `409` | `40901` | `duplicate conflict` |
 | `500` | `50002` | `internal server error` |

--- a/api/docs.md
+++ b/api/docs.md
@@ -26,6 +26,7 @@
   - [⚙️ Update organization](#-update-organization)
   - [🔍 Organization info](#-organization-info)
   - [🧑‍🤝‍🧑 Organization members](#-organization-members)
+  - [🧑‍💼 Invite organization admin](#-invite-organization-admin)
 
 </details>
 
@@ -563,4 +564,35 @@ Only the following parameters can be changed. Every parameter is optional.
 | `400` | `40009` | `organization not found` |
 | `400` | `40010` | `malformed URL parameter` |
 | `400` | `4012` | `no organization provided` |
+| `500` | `50002` | `internal server error` |
+
+### 🧑‍💼 Invite organization admin
+
+* **Path** `/organizations/{address}/members/admin`
+* **Method** `POST`
+* **Response**
+```json
+{
+  "role": "admin",
+  "user": { 
+    "email": "newadmin@email.com",
+    "firstName": "Steve", // only if the user does not exists yet
+    "lastName": "Urkel",  // only if the user does not exists yet
+    "phone": "123456789",
+  },
+}
+```
+
+* **Errors**
+
+| HTTP Status | Error code | Message |
+|:---:|:---:|:---|
+| `401` | `40001` | `user not authorized` |
+| `400` | `40002` | `email malformed` |
+| `400` | `40004` | `malformed JSON body` |
+| `400` | `40005` | `invalid user data` |
+| `400` | `40009` | `organization not found` |
+| `400` | `40011` | `no organization provided` |
+| `401` | `40014` | `user account not verified` |
+| `409` | `40901` | `duplicate conflict` |
 | `500` | `50002` | `internal server error` |

--- a/api/errors_definition.go
+++ b/api/errors_definition.go
@@ -44,6 +44,7 @@ var (
 	ErrVerificationCodeExpired = Error{Code: 40016, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("verification code expired")}
 	ErrVerificationCodeValid   = Error{Code: 40017, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("last verification code still valid")}
 	ErrUserNotFound            = Error{Code: 40018, HTTPstatus: http.StatusNotFound, Err: fmt.Errorf("user not found")}
+	ErrInvitationExpired       = Error{Code: 40019, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("inviation code expired")}
 
 	ErrMarshalingServerJSONFailed  = Error{Code: 50001, HTTPstatus: http.StatusInternalServerError, Err: fmt.Errorf("marshaling (server-side) JSON failed")}
 	ErrGenericInternalServerError  = Error{Code: 50002, HTTPstatus: http.StatusInternalServerError, Err: fmt.Errorf("internal server error")}

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -282,7 +282,7 @@ func (a *API) inviteOrganizationAdminHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	// check the role is valid
-	if valid := db.ValidRoles[db.UserRole(invite.Role)]; !valid {
+	if valid := db.IsValidUserRole(db.UserRole(invite.Role)); !valid {
 		ErrInvalidUserData.Withf("invalid role").Write(w)
 		return
 	}

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -242,9 +242,8 @@ func (a *API) updateOrganizationHandler(w http.ResponseWriter, r *http.Request) 
 
 // inviteOrganizationMemberHandler handles the request to invite a new admin
 // member to an organization. Only the admin of the organization can invite a
-// new admin member. The new admin will be created as a verified user if it
-// does not exist yet (with a random password), and an email will be sent to
-// the new admin with the invitation code to change that password.
+// new member. It stores the invitation in the database and sends an email to
+// the new member with the invitation code.
 func (a *API) inviteOrganizationMemberHandler(w http.ResponseWriter, r *http.Request) {
 	// get the user from the request context
 	user, ok := userFromContext(r.Context())
@@ -319,6 +318,12 @@ func (a *API) inviteOrganizationMemberHandler(w http.ResponseWriter, r *http.Req
 	httpWriteOK(w)
 }
 
+// acceptOrganizationMemberInvitationHandler handles the request to accept an
+// invitation to an organization. It checks if the invitation is valid and not
+// expired, and if the user is not already a member of the organization. If the
+// user does not exist, it creates a new user with the provided information.
+// If the user already exists and is verified, it adds the organization to the
+// user.
 func (a *API) acceptOrganizationMemberInvitationHandler(w http.ResponseWriter, r *http.Request) {
 	// get the organization info from the request context
 	org, _, ok := a.organizationFromRequest(r)

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -351,7 +351,7 @@ func (a *API) acceptOrganizationMemberInvitationHandler(w http.ResponseWriter, r
 	// create a helper function to remove the invitation from the database in
 	// case of error or expiration
 	removeInvitation := func() {
-		if err := a.db.DeclineInvitation(invitationReq.Code); err != nil {
+		if err := a.db.DeleteInvitation(invitationReq.Code); err != nil {
 			log.Warnf("could not delete invitation: %v", err)
 		}
 	}
@@ -383,7 +383,6 @@ func (a *API) acceptOrganizationMemberInvitationHandler(w http.ResponseWriter, r
 		hPassword := internal.HexHashPassword(passwordSalt, invitationReq.User.Password)
 		dbUser = &db.User{
 			Email:     invitationReq.User.Email,
-			Phone:     invitationReq.User.Phone,
 			Password:  hPassword,
 			FirstName: invitationReq.User.FirstName,
 			LastName:  invitationReq.User.LastName,

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -260,6 +260,11 @@ func (a *API) inviteOrganizationAdminHandler(w http.ResponseWriter, r *http.Requ
 		ErrUnauthorized.Withf("user is not admin of organization").Write(w)
 		return
 	}
+	// check if the user is already verified
+	if !user.Verified {
+		ErrUserNoVerified.With("user account not verified").Write(w)
+		return
+	}
 	// get new admin info from the request body
 	invite := &OrganizationInvite{}
 	body, err := io.ReadAll(r.Body)

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -2,11 +2,14 @@ package api
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"time"
 
 	"github.com/vocdoni/saas-backend/account"
 	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/internal"
+	"go.vocdoni.io/dvote/log"
 )
 
 // createOrganizationHandler handles the request to create a new organization.
@@ -231,6 +234,119 @@ func (a *API) updateOrganizationHandler(w http.ResponseWriter, r *http.Request) 
 			ErrGenericInternalServerError.Withf("could not update organization: %v", err).Write(w)
 			return
 		}
+	}
+	httpWriteOK(w)
+}
+
+// inviteOrganizationAdminHandler handles the request to invite a new admin
+// member to an organization. Only the admin of the organization can invite a
+// new admin member. The new admin will be created as a verified user if it
+// does not exist yet (with a random password), and an email will be sent to
+// the new admin with the invitation code to change that password.
+func (a *API) inviteOrganizationAdminHandler(w http.ResponseWriter, r *http.Request) {
+	// get the user from the request context
+	user, ok := userFromContext(r.Context())
+	if !ok {
+		ErrUnauthorized.Write(w)
+		return
+	}
+	// get the organization info from the request context
+	org, _, ok := a.organizationFromRequest(r)
+	if !ok {
+		ErrNoOrganizationProvided.Write(w)
+		return
+	}
+	if !user.HasRoleFor(org.Address, db.AdminRole) {
+		ErrUnauthorized.Withf("user is not admin of organization").Write(w)
+		return
+	}
+	// get new admin info from the request body
+	invite := &OrganizationInvite{}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		ErrMalformedBody.Write(w)
+		return
+	}
+	if err := json.Unmarshal(body, invite); err != nil {
+		ErrMalformedBody.Write(w)
+		return
+	}
+	// check the email is correct format
+	if !internal.ValidEmail(invite.User.Email) {
+		ErrEmailMalformed.Write(w)
+		return
+	}
+	// check the phone is not empty
+	if invite.User.Phone == "" {
+		ErrMalformedBody.Withf("phone is empty").Write(w)
+		return
+	}
+	// check the role is valid
+	if valid := db.ValidRoles[db.UserRole(invite.Role)]; !valid {
+		ErrInvalidUserData.Withf("invalid role").Write(w)
+		return
+	}
+	// check if the user already exists, if so, add it to the organization and
+	// return
+	admin, err := a.db.UserByEmail(invite.User.Email)
+	if err == nil {
+		// check if the user is already a member of the organization
+		if _, err := a.db.IsMemberOf(invite.User.Email, org.Address, db.AdminRole); err == nil {
+			ErrDuplicateConflict.With("user is already admin of organization").Write(w)
+			return
+		}
+		// check if the user is already verified
+		if !admin.Verified {
+			ErrUserNoVerified.With("new admin account not verified").Write(w)
+			return
+		}
+		// if the user exists and is not a member of the organization, add it
+		admin.Organizations = append(admin.Organizations, db.OrganizationMember{
+			Address: org.Address,
+			Role:    db.UserRole(invite.Role),
+		})
+		// update the user info in the database
+		if _, err := a.db.SetUser(admin); err != nil {
+			ErrGenericInternalServerError.Withf("could not add user to organization: %v", err).Write(w)
+			return
+		}
+		httpWriteOK(w)
+		return
+	}
+	// if the user does not exist, create a new verified user with the desired
+	// role and send an email to the user to set the password
+
+	// check the first name is not empty
+	if invite.User.FirstName == "" {
+		ErrMalformedBody.Withf("first name is empty").Write(w)
+		return
+	}
+	// check the last name is not empty
+	if invite.User.LastName == "" {
+		ErrMalformedBody.Withf("last name is empty").Write(w)
+		return
+	}
+	newUser := &db.User{
+		Email:     invite.User.Email,
+		FirstName: invite.User.FirstName,
+		LastName:  invite.User.LastName,
+		Phone:     invite.User.Phone,
+		Password:  internal.RandomHex(8),
+		Verified:  true,
+		Organizations: []db.OrganizationMember{
+			{Address: org.Address, Role: db.UserRole(invite.Role)},
+		},
+	}
+	// create the user in the database
+	if newUser.ID, err = a.db.SetUser(newUser); err != nil {
+		ErrGenericInternalServerError.Withf("could not create user: %v", err).Write(w)
+		return
+	}
+	// generate a code for the user to set the password
+	if err := a.sendUserCode(r.Context(), newUser, db.CodeTypePasswordReset); err != nil {
+		log.Warnw("could not send verification code", "error", err)
+		ErrGenericInternalServerError.Write(w)
+		return
 	}
 	httpWriteOK(w)
 }

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -281,11 +281,6 @@ func (a *API) inviteOrganizationAdminHandler(w http.ResponseWriter, r *http.Requ
 		ErrEmailMalformed.Write(w)
 		return
 	}
-	// check the phone is not empty
-	if invite.User.Phone == "" {
-		ErrMalformedBody.Withf("phone is empty").Write(w)
-		return
-	}
 	// check the role is valid
 	if valid := db.ValidRoles[db.UserRole(invite.Role)]; !valid {
 		ErrInvalidUserData.Withf("invalid role").Write(w)
@@ -329,6 +324,11 @@ func (a *API) inviteOrganizationAdminHandler(w http.ResponseWriter, r *http.Requ
 	// check the last name is not empty
 	if invite.User.LastName == "" {
 		ErrMalformedBody.Withf("last name is empty").Write(w)
+		return
+	}
+	// check the phone is not empty
+	if invite.User.Phone == "" {
+		ErrMalformedBody.Withf("phone is empty").Write(w)
 		return
 	}
 	newUser := &db.User{

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -286,7 +286,7 @@ func (a *API) inviteOrganizationMemberHandler(w http.ResponseWriter, r *http.Req
 			ToName:    fmt.Sprintf("%s %s", user.FirstName, user.LastName),
 			ToAddress: invite.Email,
 			Subject:   InvitationEmailSubject,
-			Body:      fmt.Sprintf(InvitationTextBody, org.Name, inviteCode),
+			Body:      fmt.Sprintf(InvitationTextBody, org.Address, inviteCode),
 		}); err != nil {
 			ErrGenericInternalServerError.Withf("could not send verification code: %v", err).Write(w)
 			return

--- a/api/routes.go
+++ b/api/routes.go
@@ -46,4 +46,6 @@ const (
 	organizationEndpoint = "/organizations/{address}"
 	// GET /organizations/{address}/members to get the organization members
 	organizationMembersEndpoint = "/organizations/{address}/members"
+	// POST /organizations/{address}/members/admin to add a new admin member
+	organizationAddAdminEndpoint = "/organizations/{address}/members/admin"
 )

--- a/api/routes.go
+++ b/api/routes.go
@@ -46,6 +46,8 @@ const (
 	organizationEndpoint = "/organizations/{address}"
 	// GET /organizations/{address}/members to get the organization members
 	organizationMembersEndpoint = "/organizations/{address}/members"
-	// POST /organizations/{address}/members/admin to add a new admin member
-	organizationAddAdminEndpoint = "/organizations/{address}/members/admin"
+	// POST /organizations/{address}/members/invite to add a new member
+	organizationAddMemberEndpoint = "/organizations/{address}/members"
+	// POST /organizations/{address}/members/invite/accept to accept the invitation
+	organizationAcceptMemberEndpoint = "/organizations/{address}/members/accept"
 )

--- a/api/types.go
+++ b/api/types.go
@@ -64,6 +64,13 @@ type UserInfo struct {
 	Organizations []*UserOrganization `json:"organizations"`
 }
 
+// OrganizationInvite is the struct that represents an invitation to an
+// organization in the API.
+type OrganizationInvite struct {
+	User *UserInfo `json:"user"`
+	Role string    `json:"role"`
+}
+
 // UserPasswordUpdate is the request to update the password of a user.
 type UserPasswordUpdate struct {
 	OldPassword string `json:"oldPassword"`

--- a/api/types.go
+++ b/api/types.go
@@ -56,7 +56,6 @@ type UserOrganization struct {
 // UserInfo is the request to register a new user.
 type UserInfo struct {
 	Email         string              `json:"email,omitempty"`
-	Phone         string              `json:"phone,omitempty"`
 	Password      string              `json:"password,omitempty"`
 	FirstName     string              `json:"firstName,omitempty"`
 	LastName      string              `json:"lastName,omitempty"`
@@ -88,7 +87,6 @@ type UserPasswordUpdate struct {
 type UserVerification struct {
 	Email      string    `json:"email,omitempty"`
 	Code       string    `json:"code,omitempty"`
-	Phone      string    `json:"phone,omitempty"`
 	Expiration time.Time `json:"expiration,omitempty"`
 	Valid      bool      `json:"valid"`
 }

--- a/api/types.go
+++ b/api/types.go
@@ -67,8 +67,15 @@ type UserInfo struct {
 // OrganizationInvite is the struct that represents an invitation to an
 // organization in the API.
 type OrganizationInvite struct {
+	Email string `json:"email"`
+	Role  string `json:"role"`
+}
+
+// AcceptOrganizationInvitation is the request to accept an invitation to an
+// organization.
+type AcceptOrganizationInvitation struct {
+	Code string    `json:"code"`
 	User *UserInfo `json:"user"`
-	Role string    `json:"role"`
 }
 
 // UserPasswordUpdate is the request to update the password of a user.

--- a/api/users.go
+++ b/api/users.go
@@ -29,7 +29,7 @@ func (a *API) sendUserCode(ctx context.Context, user *db.User, t db.CodeType) er
 	// the verification code will not be sent but stored in the database
 	// generated with just the user email to mock the verification process
 	var code string
-	if a.mail != nil || a.sms != nil {
+	if a.mail != nil {
 		code = util.RandomHex(VerificationCodeLength)
 	}
 	// store the verification code in the database
@@ -136,11 +136,10 @@ func (a *API) verifyUserAccountHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// check the email and verification code are not empty
-	if (a.mail != nil || a.sms != nil) &&
-		(verification.Code == "" || verification.Email == "" ||
-			(a.mail == nil && verification.Email != "")) {
-		ErrInvalidUserData.With("no verification code or email/phone provided").Write(w)
+	// check the email and verification code are not empty only if the mail
+	// service is available
+	if a.mail != nil && (verification.Code == "" || verification.Email == "") {
+		ErrInvalidUserData.With("no verification code or email provided").Write(w)
 		return
 	}
 	// get the user information from the database by email

--- a/api/users.go
+++ b/api/users.go
@@ -94,6 +94,11 @@ func (a *API) registerHandler(w http.ResponseWriter, r *http.Request) {
 		ErrMalformedBody.Withf("last name is empty").Write(w)
 		return
 	}
+	// check the phone is not empty
+	if userInfo.Phone == "" {
+		ErrMalformedBody.Withf("phone is empty").Write(w)
+		return
+	}
 	// hash the password
 	hPassword := internal.HexHashPassword(passwordSalt, userInfo.Password)
 	// add the user to the database
@@ -144,7 +149,7 @@ func (a *API) verifyUserAccountHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// check the email and verification code are not empty
-	if verification.Email == "" || verification.Code == "" {
+	if verification.Email == "" || (verification.Code == "" && (a.mail != nil || a.sms != nil)) {
 		ErrInvalidUserData.With("no verification code or email provided").Write(w)
 		return
 	}

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -273,7 +273,6 @@ func TestRecoverAndResetPassword(t *testing.T) {
 	// create a regex to find the verification code in the email
 	mailCodeRgx := regexp.MustCompile(fmt.Sprintf(`%s(.{%d})`, VerificationCodeTextBody, VerificationCodeLength*2))
 	verifyMailCode := mailCodeRgx.FindStringSubmatch(mailBody)
-	c.Log(verifyMailCode[1])
 	// verify the user
 	verification := mustMarshal(&UserVerification{
 		Email: testEmail,

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -39,7 +39,6 @@ func TestRegisterHandler(t *testing.T) {
 				Password:  "password",
 				FirstName: "first",
 				LastName:  "last",
-				Phone:     "123456789",
 			}),
 			expectedStatus: http.StatusOK,
 		},
@@ -51,7 +50,6 @@ func TestRegisterHandler(t *testing.T) {
 				Password:  "password",
 				FirstName: "first",
 				LastName:  "last",
-				Phone:     "123456789",
 			}),
 			expectedStatus: http.StatusInternalServerError,
 			expectedBody:   mustMarshal(ErrGenericInternalServerError),
@@ -64,7 +62,6 @@ func TestRegisterHandler(t *testing.T) {
 				Password:  "password",
 				FirstName: "first",
 				LastName:  "",
-				Phone:     "123456789",
 			}),
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   mustMarshal(ErrMalformedBody.Withf("last name is empty")),
@@ -77,7 +74,6 @@ func TestRegisterHandler(t *testing.T) {
 				Password:  "password",
 				FirstName: "",
 				LastName:  "last",
-				Phone:     "123456789",
 			}),
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   mustMarshal(ErrMalformedBody.Withf("first name is empty")),
@@ -90,7 +86,6 @@ func TestRegisterHandler(t *testing.T) {
 				Password:  "password",
 				FirstName: "first",
 				LastName:  "last",
-				Phone:     "123456789",
 			}),
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   mustMarshal(ErrEmailMalformed),
@@ -103,7 +98,6 @@ func TestRegisterHandler(t *testing.T) {
 				Password:  "password",
 				FirstName: "first",
 				LastName:  "last",
-				Phone:     "123456789",
 			}),
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   mustMarshal(ErrEmailMalformed),
@@ -116,7 +110,6 @@ func TestRegisterHandler(t *testing.T) {
 				Password:  "short",
 				FirstName: "first",
 				LastName:  "last",
-				Phone:     "123456789",
 			}),
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   mustMarshal(ErrPasswordTooShort),
@@ -129,7 +122,6 @@ func TestRegisterHandler(t *testing.T) {
 				Password:  "",
 				FirstName: "first",
 				LastName:  "last",
-				Phone:     "123456789",
 			}),
 			expectedStatus: http.StatusBadRequest,
 		},
@@ -157,7 +149,6 @@ func TestRegisterHandler(t *testing.T) {
 				c.Errorf("error closing response body: %v", err)
 			}
 		}()
-
 		c.Assert(resp.StatusCode, qt.Equals, testCase.expectedStatus)
 		if testCase.expectedBody != nil {
 			body, err := io.ReadAll(resp.Body)
@@ -181,7 +172,6 @@ func TestVerifyAccountHandler(t *testing.T) {
 		Password:  testPass,
 		FirstName: testFirstName,
 		LastName:  testLastName,
-		Phone:     testPhone,
 	})
 	req, err := http.NewRequest(http.MethodPost, testURL(usersEndpoint), bytes.NewBuffer(jsonUser))
 	c.Assert(err, qt.IsNil)
@@ -271,7 +261,6 @@ func TestRecoverAndResetPassword(t *testing.T) {
 		Password:  testPass,
 		FirstName: testFirstName,
 		LastName:  testLastName,
-		Phone:     testPhone,
 	})
 	req, err := http.NewRequest(http.MethodPost, testURL(usersEndpoint), bytes.NewBuffer(jsonUser))
 	c.Assert(err, qt.IsNil)

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -39,6 +39,7 @@ func TestRegisterHandler(t *testing.T) {
 				Password:  "password",
 				FirstName: "first",
 				LastName:  "last",
+				Phone:     "123456789",
 			}),
 			expectedStatus: http.StatusOK,
 		},
@@ -50,6 +51,7 @@ func TestRegisterHandler(t *testing.T) {
 				Password:  "password",
 				FirstName: "first",
 				LastName:  "last",
+				Phone:     "123456789",
 			}),
 			expectedStatus: http.StatusInternalServerError,
 			expectedBody:   mustMarshal(ErrGenericInternalServerError),
@@ -62,6 +64,7 @@ func TestRegisterHandler(t *testing.T) {
 				Password:  "password",
 				FirstName: "first",
 				LastName:  "",
+				Phone:     "123456789",
 			}),
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   mustMarshal(ErrMalformedBody.Withf("last name is empty")),
@@ -74,6 +77,7 @@ func TestRegisterHandler(t *testing.T) {
 				Password:  "password",
 				FirstName: "",
 				LastName:  "last",
+				Phone:     "123456789",
 			}),
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   mustMarshal(ErrMalformedBody.Withf("first name is empty")),
@@ -86,6 +90,7 @@ func TestRegisterHandler(t *testing.T) {
 				Password:  "password",
 				FirstName: "first",
 				LastName:  "last",
+				Phone:     "123456789",
 			}),
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   mustMarshal(ErrEmailMalformed),
@@ -98,6 +103,7 @@ func TestRegisterHandler(t *testing.T) {
 				Password:  "password",
 				FirstName: "first",
 				LastName:  "last",
+				Phone:     "123456789",
 			}),
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   mustMarshal(ErrEmailMalformed),
@@ -110,6 +116,7 @@ func TestRegisterHandler(t *testing.T) {
 				Password:  "short",
 				FirstName: "first",
 				LastName:  "last",
+				Phone:     "123456789",
 			}),
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   mustMarshal(ErrPasswordTooShort),
@@ -120,6 +127,18 @@ func TestRegisterHandler(t *testing.T) {
 			body: mustMarshal(&UserInfo{
 				Email:     "valid2@test.com",
 				Password:  "",
+				FirstName: "first",
+				LastName:  "last",
+				Phone:     "123456789",
+			}),
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			uri:    registerURL,
+			method: http.MethodPost,
+			body: mustMarshal(&UserInfo{
+				Email:     "valid@test.com",
+				Password:  "password",
 				FirstName: "first",
 				LastName:  "last",
 			}),
@@ -162,6 +181,7 @@ func TestVerifyAccountHandler(t *testing.T) {
 		Password:  testPass,
 		FirstName: testFirstName,
 		LastName:  testLastName,
+		Phone:     testPhone,
 	})
 	req, err := http.NewRequest(http.MethodPost, testURL(usersEndpoint), bytes.NewBuffer(jsonUser))
 	c.Assert(err, qt.IsNil)
@@ -251,6 +271,7 @@ func TestRecoverAndResetPassword(t *testing.T) {
 		Password:  testPass,
 		FirstName: testFirstName,
 		LastName:  testLastName,
+		Phone:     testPhone,
 	})
 	req, err := http.NewRequest(http.MethodPost, testURL(usersEndpoint), bytes.NewBuffer(jsonUser))
 	c.Assert(err, qt.IsNil)

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -125,17 +125,6 @@ func TestRegisterHandler(t *testing.T) {
 			}),
 			expectedStatus: http.StatusBadRequest,
 		},
-		{
-			uri:    registerURL,
-			method: http.MethodPost,
-			body: mustMarshal(&UserInfo{
-				Email:     "valid@test.com",
-				Password:  "password",
-				FirstName: "first",
-				LastName:  "last",
-			}),
-			expectedStatus: http.StatusBadRequest,
-		},
 	}
 
 	for _, testCase := range testCases {

--- a/db/const.go
+++ b/db/const.go
@@ -38,8 +38,14 @@ func IsOrganizationTypeValid(ot string) bool {
 }
 
 // ValidRoles is a map that contains the valid user roles
-var ValidRoles = map[UserRole]bool{
+var validRoles = map[UserRole]bool{
 	AdminRole:   true,
 	ManagerRole: true,
 	ViewerRole:  true,
+}
+
+// IsValidUserRole function checks if the user role is valid
+func IsValidUserRole(role UserRole) bool {
+	_, valid := validRoles[role]
+	return valid
 }

--- a/db/const.go
+++ b/db/const.go
@@ -36,3 +36,10 @@ func IsOrganizationTypeValid(ot string) bool {
 	_, valid := validOrganizationTypes[OrganizationType(ot)]
 	return valid
 }
+
+// ValidRoles is a map that contains the valid user roles
+var ValidRoles = map[UserRole]bool{
+	AdminRole:   true,
+	ManagerRole: true,
+	ViewerRole:  true,
+}

--- a/db/helpers.go
+++ b/db/helpers.go
@@ -61,12 +61,16 @@ func (ms *MongoStorage) initCollections(database string) error {
 	if ms.users, err = getCollection("users"); err != nil {
 		return err
 	}
+	// verifications collection
+	if ms.verifications, err = getCollection("verifications"); err != nil {
+		return err
+	}
 	// organizations collection
 	if ms.organizations, err = getCollection("organizations"); err != nil {
 		return err
 	}
-	// verifications collection
-	if ms.verifications, err = getCollection("verifications"); err != nil {
+	// organizationInvites collection
+	if ms.organizationInvites, err = getCollection("organizationInvites"); err != nil {
 		return err
 	}
 	return nil
@@ -110,15 +114,15 @@ func (ms *MongoStorage) createIndexes() error {
 		Keys:    bson.D{{Key: "email", Value: 1}}, // 1 for ascending order
 		Options: options.Index().SetUnique(true),
 	}
-	if _, err := ms.users.Indexes().CreateOne(ctx, userEmailIndex); err != nil {
-		return fmt.Errorf("failed to create index on addresses for users: %w", err)
-	}
 	// create an index for the 'phone' field on users
 	userPhoneIndex := mongo.IndexModel{
 		Keys:    bson.D{{Key: "phone", Value: 1}}, // 1 for ascending order
 		Options: options.Index().SetSparse(true),
 	}
-	if _, err := ms.users.Indexes().CreateOne(ctx, userPhoneIndex); err != nil {
+	if _, err := ms.users.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		userEmailIndex,
+		userPhoneIndex,
+	}); err != nil {
 		return fmt.Errorf("failed to create index on phone for users: %w", err)
 	}
 	// create an index for the 'name' field on organizations (must be unique)
@@ -139,6 +143,31 @@ func (ms *MongoStorage) createIndexes() error {
 	}
 	if _, err := ms.verifications.Indexes().CreateOne(ctx, verificationCodeIndex); err != nil {
 		return fmt.Errorf("failed to create index on code for verifications: %w", err)
+	}
+	// create an index for the 'invitationCode' field on organization invites (must be unique)
+	organizationInviteIndex := mongo.IndexModel{
+		Keys:    bson.D{{Key: "invitationCode", Value: 1}}, // 1 for ascending order
+		Options: options.Index().SetUnique(true),
+	}
+	// create a ttl index for the 'expiration' field on organization invites
+	organizationInviteExpirationIndex := mongo.IndexModel{
+		Keys:    bson.D{{Key: "expiration", Value: 1}}, // 1 for ascending order
+		Options: options.Index().SetExpireAfterSeconds(0),
+	}
+	// create an index to ensure that the tuple ('organizationAddress', 'newUserEmail') is unique
+	organizationInviteUniqueIndex := mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "organizationAddress", Value: 1}, // 1 for ascending order
+			{Key: "newUserEmail", Value: 1},        // 1 for ascending order
+		},
+		Options: options.Index().SetUnique(true),
+	}
+	if _, err := ms.organizationInvites.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		organizationInviteIndex,
+		organizationInviteExpirationIndex,
+		organizationInviteUniqueIndex,
+	}); err != nil {
+		return fmt.Errorf("failed to create index on invitationCode for organization invites: %w", err)
 	}
 	return nil
 }

--- a/db/helpers.go
+++ b/db/helpers.go
@@ -114,15 +114,7 @@ func (ms *MongoStorage) createIndexes() error {
 		Keys:    bson.D{{Key: "email", Value: 1}}, // 1 for ascending order
 		Options: options.Index().SetUnique(true),
 	}
-	// create an index for the 'phone' field on users
-	userPhoneIndex := mongo.IndexModel{
-		Keys:    bson.D{{Key: "phone", Value: 1}}, // 1 for ascending order
-		Options: options.Index().SetSparse(true),
-	}
-	if _, err := ms.users.Indexes().CreateMany(ctx, []mongo.IndexModel{
-		userEmailIndex,
-		userPhoneIndex,
-	}); err != nil {
+	if _, err := ms.users.Indexes().CreateOne(ctx, userEmailIndex); err != nil {
 		return fmt.Errorf("failed to create index on phone for users: %w", err)
 	}
 	// create an index for the 'name' field on organizations (must be unique)

--- a/db/mongo.go
+++ b/db/mongo.go
@@ -104,6 +104,14 @@ func (ms *MongoStorage) Reset() error {
 	if err := ms.organizations.Drop(ctx); err != nil {
 		return err
 	}
+	// drop organizationInvites collection
+	if err := ms.organizationInvites.Drop(ctx); err != nil {
+		return err
+	}
+	// drop verifications collection
+	if err := ms.verifications.Drop(ctx); err != nil {
+		return err
+	}
 	// init the collections
 	if err := ms.initCollections(ms.database); err != nil {
 		return err

--- a/db/mongo_types.go
+++ b/db/mongo_types.go
@@ -12,7 +12,13 @@ type OrganizationCollection struct {
 	Organizations []Organization `json:"organizations" bson:"organizations"`
 }
 
+type OrganizationInvitesCollection struct {
+	OrganizationInvites []OrganizationInvite `json:"organizationInvites" bson:"organizationInvites"`
+}
+
 type Collection struct {
 	UserCollection
+	UserVerifications
 	OrganizationCollection
+	OrganizationInvitesCollection
 }

--- a/db/organization_invites.go
+++ b/db/organization_invites.go
@@ -1,0 +1,52 @@
+package db
+
+import (
+	"context"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// CreateInvitation creates a new invitation for a user to join an organization.
+func (ms *MongoStorage) CreateInvitation(invite *OrganizationInvite) error {
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := ms.organizationInvites.InsertOne(ctx, invite)
+	return err
+}
+
+// Invitation returns the invitation for the given code.
+func (ms *MongoStorage) Invitation(invitationCode string) (*OrganizationInvite, error) {
+	ms.keysLock.RLock()
+	defer ms.keysLock.RUnlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result := ms.organizationInvites.FindOne(ctx, bson.M{"invitationCode": invitationCode})
+	invite := &OrganizationInvite{}
+	if err := result.Decode(invite); err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return invite, nil
+}
+
+// DeclineInvitation removes the invitation from the database.
+func (ms *MongoStorage) DeclineInvitation(invitationCode string) error {
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := ms.organizationInvites.DeleteOne(ctx, bson.M{"invitationCode": invitationCode})
+	return err
+}

--- a/db/organization_invites_test.go
+++ b/db/organization_invites_test.go
@@ -35,7 +35,6 @@ func TestCreateInvitation(t *testing.T) {
 	// non existing user
 	c.Assert(db.SetOrganization(&Organization{
 		Address: orgAddress,
-		Name:    "Organization",
 	}), qt.IsNil)
 	c.Assert(db.CreateInvitation(testInvite), qt.ErrorIs, ErrNotFound)
 	// non organization member
@@ -86,7 +85,6 @@ func TestInvitation(t *testing.T) {
 	c.Assert(err, qt.ErrorIs, ErrNotFound)
 	c.Assert(db.SetOrganization(&Organization{
 		Address: orgAddress,
-		Name:    "Organization",
 	}), qt.IsNil)
 	_, err = db.SetUser(&User{
 		Email:     testUserEmail,
@@ -130,7 +128,6 @@ func TestDeleteInvitation(t *testing.T) {
 	// create valid invitation
 	c.Assert(db.SetOrganization(&Organization{
 		Address: orgAddress,
-		Name:    "Organization",
 	}), qt.IsNil)
 	_, err := db.SetUser(&User{
 		Email:     testUserEmail,

--- a/db/organization_invites_test.go
+++ b/db/organization_invites_test.go
@@ -1,0 +1,159 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+var (
+	invitationCode = "abc123"
+	orgAddress     = "0x1234567890"
+	currentUserID  = uint64(1)
+	newMemberEmail = "inviteme@email.com"
+	expires        = time.Now().Add(time.Hour)
+)
+
+func TestCreateInvitation(t *testing.T) {
+	c := qt.New(t)
+	defer func() {
+		if err := db.Reset(); err != nil {
+			t.Error(err)
+		}
+	}()
+	// non existing organization
+	testInvite := &OrganizationInvite{
+		InvitationCode:      invitationCode,
+		OrganizationAddress: orgAddress,
+		CurrentUserID:       currentUserID,
+		NewUserEmail:        newMemberEmail,
+		Role:                AdminRole,
+		Expiration:          expires,
+	}
+	c.Assert(db.CreateInvitation(testInvite), qt.ErrorIs, ErrNotFound)
+	// non existing user
+	c.Assert(db.SetOrganization(&Organization{
+		Address: orgAddress,
+		Name:    "Organization",
+	}), qt.IsNil)
+	c.Assert(db.CreateInvitation(testInvite), qt.ErrorIs, ErrNotFound)
+	// non organization member
+	_, err := db.SetUser(&User{
+		Email:     testUserEmail,
+		Password:  testUserPass,
+		FirstName: testUserFirstName,
+		LastName:  testUserLastName,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.CreateInvitation(testInvite).Error(), qt.Equals, "user is not part of the organization")
+	// expiration date in the past
+	_, err = db.SetUser(&User{
+		ID: currentUserID,
+		Organizations: []OrganizationMember{
+			{Address: orgAddress, Role: AdminRole},
+		},
+	})
+	c.Assert(err, qt.IsNil)
+	testInvite.Expiration = time.Now().Add(-time.Hour)
+	c.Assert(db.CreateInvitation(testInvite).Error(), qt.Equals, "expiration date must be in the future")
+	// invalid role
+	testInvite.Expiration = expires
+	testInvite.Role = "invalid"
+	c.Assert(db.CreateInvitation(testInvite).Error(), qt.Equals, "invalid role")
+	// invitation expires
+	testInvite.Role = AdminRole
+	testInvite.Expiration = time.Now().Add(time.Second)
+	c.Assert(db.CreateInvitation(testInvite), qt.IsNil)
+	// TTL index could take up to 1 minute
+	time.Sleep(time.Second * 75)
+	_, err = db.Invitation(invitationCode)
+	c.Assert(err, qt.ErrorIs, ErrNotFound)
+	// success
+	testInvite.Expiration = expires
+	c.Assert(db.CreateInvitation(testInvite), qt.IsNil)
+}
+
+func TestInvitation(t *testing.T) {
+	c := qt.New(t)
+	defer func() {
+		if err := db.Reset(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	_, err := db.Invitation(invitationCode)
+	c.Assert(err, qt.ErrorIs, ErrNotFound)
+	c.Assert(db.SetOrganization(&Organization{
+		Address: orgAddress,
+		Name:    "Organization",
+	}), qt.IsNil)
+	_, err = db.SetUser(&User{
+		Email:     testUserEmail,
+		Password:  testUserPass,
+		FirstName: testUserFirstName,
+		LastName:  testUserLastName,
+		Organizations: []OrganizationMember{
+			{Address: orgAddress, Role: AdminRole},
+		},
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.CreateInvitation(&OrganizationInvite{
+		InvitationCode:      invitationCode,
+		OrganizationAddress: orgAddress,
+		CurrentUserID:       currentUserID,
+		NewUserEmail:        newMemberEmail,
+		Role:                AdminRole,
+		Expiration:          expires,
+	}), qt.IsNil)
+	invitation, err := db.Invitation(invitationCode)
+	c.Assert(err, qt.IsNil)
+	c.Assert(invitation.InvitationCode, qt.Equals, invitationCode)
+	c.Assert(invitation.OrganizationAddress, qt.Equals, orgAddress)
+	c.Assert(invitation.CurrentUserID, qt.Equals, currentUserID)
+	c.Assert(invitation.NewUserEmail, qt.Equals, newMemberEmail)
+	c.Assert(invitation.Role, qt.Equals, AdminRole)
+	// truncate expiration to seconds to avoid rounding issues, also set to UTC
+	c.Assert(invitation.Expiration.Truncate(time.Second).UTC(), qt.Equals, expires.Truncate(time.Second).UTC())
+}
+
+func TestDeleteInvitation(t *testing.T) {
+	c := qt.New(t)
+	defer func() {
+		if err := db.Reset(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// non existing invitation does not return an error on delete attempt
+	c.Assert(db.DeleteInvitation(invitationCode), qt.IsNil)
+	// create valid invitation
+	c.Assert(db.SetOrganization(&Organization{
+		Address: orgAddress,
+		Name:    "Organization",
+	}), qt.IsNil)
+	_, err := db.SetUser(&User{
+		Email:     testUserEmail,
+		Password:  testUserPass,
+		FirstName: testUserFirstName,
+		LastName:  testUserLastName,
+		Organizations: []OrganizationMember{
+			{Address: orgAddress, Role: AdminRole},
+		},
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.CreateInvitation(&OrganizationInvite{
+		InvitationCode:      invitationCode,
+		OrganizationAddress: orgAddress,
+		CurrentUserID:       currentUserID,
+		NewUserEmail:        newMemberEmail,
+		Role:                AdminRole,
+		Expiration:          expires,
+	}), qt.IsNil)
+	_, err = db.Invitation(invitationCode)
+	c.Assert(err, qt.IsNil)
+	// delete the invitation
+	c.Assert(db.DeleteInvitation(invitationCode), qt.IsNil)
+	_, err = db.Invitation(invitationCode)
+	c.Assert(err, qt.ErrorIs, ErrNotFound)
+}

--- a/db/organizations_test.go
+++ b/db/organizations_test.go
@@ -7,12 +7,13 @@ import (
 )
 
 func TestOrganization(t *testing.T) {
+	c := qt.New(t)
 	defer func() {
 		if err := db.Reset(); err != nil {
 			t.Error(err)
 		}
 	}()
-	c := qt.New(t)
+
 	// test not found organization
 	address := "childOrgToGet"
 	org, _, err := db.Organization(address, false)
@@ -44,12 +45,13 @@ func TestOrganization(t *testing.T) {
 }
 
 func TestSetOrganization(t *testing.T) {
+	c := qt.New(t)
 	defer func() {
 		if err := db.Reset(); err != nil {
 			t.Error(err)
 		}
 	}()
-	c := qt.New(t)
+
 	// create a new organization
 	address := "orgToSet"
 	orgName := "Organization"
@@ -88,8 +90,10 @@ func TestSetOrganization(t *testing.T) {
 	}), qt.IsNotNil)
 	// register the creator and retry to create the organization
 	_, err = db.SetUser(&User{
-		Email:    testUserEmail,
-		Password: testUserPass,
+		Email:     testUserEmail,
+		Password:  testUserPass,
+		FirstName: testUserFirstName,
+		LastName:  testUserLastName,
 	})
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.SetOrganization(&Organization{
@@ -100,12 +104,13 @@ func TestSetOrganization(t *testing.T) {
 }
 
 func TestDeleteOrganization(t *testing.T) {
+	c := qt.New(t)
 	defer func() {
 		if err := db.Reset(); err != nil {
 			t.Error(err)
 		}
 	}()
-	c := qt.New(t)
+
 	// create a new organization and delete it
 	address := "orgToDelete"
 	name := "Organization to delete"
@@ -127,18 +132,21 @@ func TestDeleteOrganization(t *testing.T) {
 }
 
 func TestReplaceCreatorEmail(t *testing.T) {
+	c := qt.New(t)
 	defer func() {
 		if err := db.Reset(); err != nil {
 			t.Error(err)
 		}
 	}()
-	c := qt.New(t)
+
 	// create a new organization with a creator
 	address := "orgToReplaceCreator"
 	name := "Organization to replace creator"
 	_, err := db.SetUser(&User{
-		Email:    testUserEmail,
-		Password: testUserPass,
+		Email:     testUserEmail,
+		Password:  testUserPass,
+		FirstName: testUserFirstName,
+		LastName:  testUserLastName,
 	})
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.SetOrganization(&Organization{
@@ -164,18 +172,21 @@ func TestReplaceCreatorEmail(t *testing.T) {
 }
 
 func TestOrganizationsMembers(t *testing.T) {
+	c := qt.New(t)
 	defer func() {
 		if err := db.Reset(); err != nil {
 			t.Error(err)
 		}
 	}()
-	c := qt.New(t)
+
 	// create a new organization with a creator
 	address := "orgToReplaceCreator"
 	name := "Organization to replace creator"
 	_, err := db.SetUser(&User{
-		Email:    testUserEmail,
-		Password: testUserPass,
+		Email:     testUserEmail,
+		Password:  testUserPass,
+		FirstName: testUserFirstName,
+		LastName:  testUserLastName,
 	})
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.SetOrganization(&Organization{

--- a/db/types.go
+++ b/db/types.go
@@ -62,3 +62,12 @@ type Organization struct {
 	TokensRemaining uint64           `json:"tokensRemaining" bson:"tokensRemaining"`
 	Parent          string           `json:"parent" bson:"parent"`
 }
+
+type OrganizationInvite struct {
+	InvitationCode      string    `json:"invitationCode" bson:"invitationCode"`
+	OrganizationAddress string    `json:"organizationAddress" bson:"organizationAddress"`
+	CurrentUserID       uint64    `json:"currentUserID" bson:"currentUserID"`
+	NewUserEmail        string    `json:"newUserEmail" bson:"newUserEmail"`
+	Role                UserRole  `json:"role" bson:"role"`
+	Expiration          time.Time `json:"expiration" bson:"expiration"`
+}

--- a/db/types.go
+++ b/db/types.go
@@ -5,7 +5,6 @@ import "time"
 type User struct {
 	ID            uint64               `json:"id" bson:"_id"`
 	Email         string               `json:"email" bson:"email"`
-	Phone         string               `json:"phone" bson:"phone"`
 	Password      string               `json:"password" bson:"password"`
 	FirstName     string               `json:"firstName" bson:"firstName"`
 	LastName      string               `json:"lastName" bson:"lastName"`

--- a/db/users_test.go
+++ b/db/users_test.go
@@ -14,12 +14,13 @@ const (
 )
 
 func TestUserByEmail(t *testing.T) {
+	c := qt.New(t)
 	defer func() {
 		if err := db.Reset(); err != nil {
 			t.Error(err)
 		}
 	}()
-	c := qt.New(t)
+
 	// test not found user
 	user, err := db.UserByEmail(testUserEmail)
 	c.Assert(user, qt.IsNil)
@@ -44,12 +45,13 @@ func TestUserByEmail(t *testing.T) {
 }
 
 func TestUser(t *testing.T) {
+	c := qt.New(t)
 	defer func() {
 		if err := db.Reset(); err != nil {
 			t.Error(err)
 		}
 	}()
-	c := qt.New(t)
+
 	// test not found user
 	id := uint64(100)
 	user, err := db.User(id)
@@ -79,12 +81,13 @@ func TestUser(t *testing.T) {
 }
 
 func TestSetUser(t *testing.T) {
+	c := qt.New(t)
 	defer func() {
 		if err := db.Reset(); err != nil {
 			t.Error(err)
 		}
 	}()
-	c := qt.New(t)
+
 	// trying to create a new user with invalid email
 	user := &User{
 		Email:     "invalid-email",
@@ -121,12 +124,13 @@ func TestSetUser(t *testing.T) {
 }
 
 func TestDelUser(t *testing.T) {
+	c := qt.New(t)
 	defer func() {
 		if err := db.Reset(); err != nil {
 			t.Error(err)
 		}
 	}()
-	c := qt.New(t)
+
 	// create a new user
 	user := &User{
 		Email:     testUserEmail,
@@ -159,12 +163,13 @@ func TestDelUser(t *testing.T) {
 }
 
 func TestIsMemberOf(t *testing.T) {
+	c := qt.New(t)
 	defer func() {
 		if err := db.Reset(); err != nil {
 			t.Error(err)
 		}
 	}()
-	c := qt.New(t)
+
 	// create a new user with some organizations
 	user := &User{
 		Email:     testUserEmail,
@@ -200,12 +205,12 @@ func TestIsMemberOf(t *testing.T) {
 }
 
 func TestVerifyUser(t *testing.T) {
+	c := qt.New(t)
 	defer func() {
 		if err := db.Reset(); err != nil {
 			t.Error(err)
 		}
 	}()
-	c := qt.New(t)
 
 	nonExistingUserID := uint64(100)
 	c.Assert(db.VerifyUserAccount(&User{ID: nonExistingUserID}), qt.Equals, ErrNotFound)

--- a/db/validations.go
+++ b/db/validations.go
@@ -3,7 +3,8 @@ package db
 import "go.mongodb.org/mongo-driver/bson"
 
 var collectionsValidators = map[string]bson.M{
-	"users": usersCollectionValidator,
+	"users":               usersCollectionValidator,
+	"organizationInvites": organizationInvitesCollectionValidator,
 }
 
 var usersCollectionValidator = bson.M{
@@ -25,6 +26,40 @@ var usersCollectionValidator = bson.M{
 				"bsonType":    "string",
 				"description": "must be a string and is required",
 				"minLength":   8,
+			},
+		},
+	},
+}
+
+var organizationInvitesCollectionValidator = bson.M{
+	"$jsonSchema": bson.M{
+		"bsonType": "object",
+		"required": []string{"invitationCode", "organizationAddress", "currentUserID", "newUserEmail", "role", "expiration"},
+		"properties": bson.M{
+			"invitationCode": bson.M{
+				"bsonType":    "string",
+				"description": "must be a string and is required",
+				"minimum":     6,
+				"pattern":     `^[\w]{6,}$`,
+			},
+			"organizationAddress": bson.M{
+				"bsonType":    "string",
+				"description": "must be a string and is required",
+			},
+			"currentUserID": bson.M{
+				"bsonType":    "long",
+				"description": "must be an integer and is required",
+				"minimum":     1,
+				"pattern":     `^[1-9]+$`,
+			},
+			"newUserEmail": bson.M{
+				"bsonType":    "string",
+				"description": "must be an email and is required",
+				"pattern":     `^[\w.\-]+@([\w\-]+\.)+[\w]{2,}$`,
+			},
+			"expiration": bson.M{
+				"bsonType":    "date",
+				"description": "must be a date and is required",
 			},
 		},
 	},

--- a/db/verifications_test.go
+++ b/db/verifications_test.go
@@ -8,12 +8,12 @@ import (
 )
 
 func TestUserVerificationCode(t *testing.T) {
+	c := qt.New(t)
 	defer func() {
 		if err := db.Reset(); err != nil {
 			t.Error(err)
 		}
 	}()
-	c := qt.New(t)
 
 	userID, err := db.SetUser(&User{
 		Email:     testUserEmail,
@@ -39,12 +39,12 @@ func TestUserVerificationCode(t *testing.T) {
 }
 
 func TestSetVerificationCode(t *testing.T) {
+	c := qt.New(t)
 	defer func() {
 		if err := db.Reset(); err != nil {
 			t.Error(err)
 		}
 	}()
-	c := qt.New(t)
 
 	nonExistingUserID := uint64(100)
 	err := db.SetVerificationCode(&User{ID: nonExistingUserID}, "testCode", CodeTypeAccountVerification, time.Now())


### PR DESCRIPTION
New endpoint to invite new organization members:
 * The endpoint must include the required user information and the role of that user in the organization.
 * The organization must exists before invite new members.
 * Only admins can invite new members.
 * If the new member user already exists, the endpoint just requires the email address of the user.
 * If the new member does not exists yet, the endpoint requires also the first name, the last name and the phone of the new user. The new account will be created with a random password and a code to reset it will be sent to the user (via email or sms).