### PR TITLE
feature: improve and extend auth middleware

### DIFF
--- a/api/middlewares.go
+++ b/api/middlewares.go
@@ -43,6 +43,11 @@ func (a *API) authenticator(next http.Handler) http.Handler {
 			ErrGenericInternalServerError.Withf("could not retrieve user from database: %v", err).Write(w)
 			return
 		}
+		// check if the user is already verified
+		if !user.Verified {
+			ErrUserNoVerified.With("user account not verified").Write(w)
+			return
+		}
 		// add the user to the context
 		ctx := context.WithValue(r.Context(), userMetadataKey, *user)
 		// token is authenticated, pass it through with the new context with the

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -238,11 +238,6 @@ func (a *API) inviteOrganizationMemberHandler(w http.ResponseWriter, r *http.Req
 		ErrUnauthorized.Withf("user is not admin of organization").Write(w)
 		return
 	}
-	// check if the user is already verified
-	if !user.Verified {
-		ErrUserNoVerified.With("user account not verified").Write(w)
-		return
-	}
 	// get new admin info from the request body
 	invite := &OrganizationInvite{}
 	if err := json.NewDecoder(r.Body).Decode(invite); err != nil {
@@ -412,11 +407,6 @@ func (a *API) pendingOrganizationMembersHandler(w http.ResponseWriter, r *http.R
 	}
 	if !user.HasRoleFor(org.Address, db.AdminRole) {
 		ErrUnauthorized.Withf("user is not admin of organization").Write(w)
-		return
-	}
-	// check if the user is already verified
-	if !user.Verified {
-		ErrUserNoVerified.With("user account not verified").Write(w)
 		return
 	}
 	// get the pending invitations


### PR DESCRIPTION
After code review, there is no need to implement a helper or make the verification endpoint public, because it already is. Simply extend the current auth middleware to enforce that user accounts have been verified in order to perform any operation that requires it. 

It closes #25 