### PR TITLE
api: initial refactor (still missing)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -76,6 +76,11 @@ func New(conf *APIConfig) *API {
 	if conf == nil {
 		return nil
 	}
+	// Set the ServerURL for the ObjectStorageClient
+	if conf.ObjectStorage != nil {
+		conf.ObjectStorage.ServerURL = conf.ServerURL
+	}
+
 	return &API{
 		db:              conf.DB,
 		auth:            jwtauth.New("HS256", []byte(conf.Secret), nil),
@@ -186,7 +191,7 @@ func (a *API) initRouter() http.Handler {
 		r.Get(subscriptionsPortal, a.createSubscriptionPortalSessionHandler)
 		// upload an image to the object storage
 		log.Infow("new route", "method", "POST", "path", objectStorageUploadTypedEndpoint)
-		r.Post(objectStorageUploadTypedEndpoint, a.uploadImageWithFormHandler)
+		r.Post(objectStorageUploadTypedEndpoint, a.objectStorage.UploadImageWithFormHandler)
 		// CENSUS ROUTES
 		// create census
 		log.Infow("new route", "method", "POST", "path", censusEndpoint)
@@ -261,7 +266,7 @@ func (a *API) initRouter() http.Handler {
 		r.Post(subscriptionsWebhook, a.handleWebhook)
 		// upload an image to the object storage
 		log.Infow("new route", "method", "GET", "path", objectStorageDownloadTypedEndpoint)
-		r.Get(objectStorageDownloadTypedEndpoint, a.downloadImageInlineHandler)
+		r.Get(objectStorageDownloadTypedEndpoint, a.objectStorage.DownloadImageInlineHandler)
 		// get census info
 		log.Infow("new route", "method", "GET", "path", censusIDEndpoint)
 		r.Get(censusIDEndpoint, a.censusInfoHandler)

--- a/api/apicommon/const.go
+++ b/api/apicommon/const.go
@@ -1,0 +1,22 @@
+package apicommon
+
+import "time"
+
+// MetadataKey is a type to define the key for the metadata stored in the
+// context.
+type MetadataKey string
+
+// userMetadataKey is the key used to store the user in the context.
+const UserMetadataKey MetadataKey = "user"
+
+// VerificationCodeExpiration is the duration of the verification code
+// before it is invalidated
+var VerificationCodeExpiration = 3 * time.Minute
+
+const (
+	// VerificationCodeLength is the length of the verification code in bytes
+	VerificationCodeLength = 3
+	// InvitationExpiration is the duration of the invitation code before it is
+	// invalidated
+	InvitationExpiration = 5 * 24 * time.Hour // 5 days
+)

--- a/api/apicommon/helpers.go
+++ b/api/apicommon/helpers.go
@@ -1,0 +1,41 @@
+package apicommon
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/vocdoni/saas-backend/db"
+	"go.vocdoni.io/dvote/log"
+)
+
+// UserFromContext retrieves the user from the context provided, expected to be
+// the context of a request handled by the authenticator middleware.
+func UserFromContext(ctx context.Context) (*db.User, bool) {
+	rawUser, ok := ctx.Value(UserMetadataKey).(db.User)
+	if ok {
+		return &rawUser, ok
+	}
+	return nil, false
+}
+
+// HttpWriteJSON helper function allows to write a JSON response.
+func HttpWriteJSON(w http.ResponseWriter, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	if _, err := w.Write([]byte("\n")); err != nil {
+		log.Warnw("failed to write on response", "error", err)
+	}
+}
+
+// HttpWriteOK helper function allows to write an OK response.
+func HttpWriteOK(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write([]byte("\n")); err != nil {
+		log.Warnw("failed to write on response", "error", err)
+	}
+}

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -1,4 +1,4 @@
-package api
+package apicommon
 
 import (
 	"time"
@@ -153,18 +153,18 @@ type MessageSignature struct {
 	Signature internal.HexBytes `json:"signature,omitempty"`
 }
 
-// organizationFromDB converts a db.Organization to an OrganizationInfo, if the parent
+// OrganizationFromDB converts a db.Organization to an OrganizationInfo, if the parent
 // organization is provided it will be included in the response.
-func organizationFromDB(dbOrg, parent *db.Organization) *OrganizationInfo {
+func OrganizationFromDB(dbOrg, parent *db.Organization) *OrganizationInfo {
 	if dbOrg == nil {
 		return nil
 	}
 	var parentOrg *OrganizationInfo
 	if parent != nil {
-		parentOrg = organizationFromDB(parent, nil)
+		parentOrg = OrganizationFromDB(parent, nil)
 	}
-	details := subscriptionDetailsFromDB(&dbOrg.Subscription)
-	usage := subscriptionUsageFromDB(&dbOrg.Counters)
+	details := SubscriptionDetailsFromDB(&dbOrg.Subscription)
+	usage := SubscriptionUsageFromDB(&dbOrg.Counters)
 	return &OrganizationInfo{
 		Address:        dbOrg.Address,
 		Website:        dbOrg.Website,
@@ -206,7 +206,7 @@ type SubscriptionPlan struct {
 	CensusSizeTiers []SubscriptionPlanTier  `json:"censusSizeTiers"`
 }
 
-func subscriptionPlanFromDB(plan *db.Plan) SubscriptionPlan {
+func SubscriptionPlanFromDB(plan *db.Plan) SubscriptionPlan {
 	if plan == nil {
 		return SubscriptionPlan{}
 	}
@@ -286,7 +286,7 @@ type SubscriptionDetails struct {
 	Email           string    `json:"email"`
 }
 
-func subscriptionDetailsFromDB(details *db.OrganizationSubscription) SubscriptionDetails {
+func SubscriptionDetailsFromDB(details *db.OrganizationSubscription) SubscriptionDetails {
 	if details == nil {
 		return SubscriptionDetails{}
 	}
@@ -311,7 +311,7 @@ type SubscriptionUsage struct {
 	Processes  int `json:"processes"`
 }
 
-func subscriptionUsageFromDB(usage *db.OrganizationCounters) SubscriptionUsage {
+func SubscriptionUsageFromDB(usage *db.OrganizationCounters) SubscriptionUsage {
 	if usage == nil {
 		return SubscriptionUsage{}
 	}
@@ -350,7 +350,7 @@ type OrganizationCensus struct {
 	OrgAddress string        `json:"orgAddress"`
 }
 
-func organizationCensusFromDB(census *db.Census) OrganizationCensus {
+func OrganizationCensusFromDB(census *db.Census) OrganizationCensus {
 	if census == nil {
 		return OrganizationCensus{}
 	}
@@ -379,10 +379,10 @@ type AddParticipantsRequest struct {
 	Participants []OrgParticipant `json:"participants"`
 }
 
-func (r *AddParticipantsRequest) dbOrgParticipants(orgAddress string) []db.OrgParticipant {
+func (r *AddParticipantsRequest) DbOrgParticipants(orgAddress string) []db.OrgParticipant {
 	participants := make([]db.OrgParticipant, 0, len(r.Participants))
 	for _, p := range r.Participants {
-		participants = append(participants, p.toDB(orgAddress))
+		participants = append(participants, p.ToDb(orgAddress))
 	}
 	return participants
 }
@@ -398,7 +398,7 @@ type OrgParticipant struct {
 	Other         map[string]any `json:"other"`
 }
 
-func (p *OrgParticipant) toDB(orgAddress string) db.OrgParticipant {
+func (p *OrgParticipant) ToDb(orgAddress string) db.OrgParticipant {
 	return db.OrgParticipant{
 		OrgAddress:    orgAddress,
 		ParticipantNo: p.ParticipantNo,
@@ -461,4 +461,16 @@ type SignRequest struct {
 	Address    string            `json:"address,omitempty"`
 	Payload    string            `json:"payload,omitempty"`
 	ElectionId internal.HexBytes `json:"electionId,omitempty"`
+}
+
+// CreateProcessBundleRequest defines the payload for creating a new process bundle
+type CreateProcessBundleRequest struct {
+	CensusID  string   `json:"censusID"`
+	Processes []string `json:"processes"`
+}
+
+// CreateProcessBundleResponse defines the response for a successful process bundle creation
+type CreateProcessBundleResponse struct {
+	URI  string            `json:"uri"`
+	Root internal.HexBytes `json:"root"`
 }

--- a/api/auth.go
+++ b/api/auth.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
 	"github.com/vocdoni/saas-backend/internal"
@@ -12,7 +13,7 @@ import (
 // refresh handles the refresh request. It returns a new JWT token.
 func (a *API) refreshTokenHandler(w http.ResponseWriter, r *http.Request) {
 	// get the user from the request context
-	user, ok := userFromContext(r.Context())
+	user, ok := apicommon.UserFromContext(r.Context())
 	if !ok {
 		errors.ErrUnauthorized.Write(w)
 		return
@@ -24,13 +25,13 @@ func (a *API) refreshTokenHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// send the token back to the user
-	httpWriteJSON(w, res)
+	apicommon.HttpWriteJSON(w, res)
 }
 
 // login handles the login request. It returns a JWT token if the login is successful.
 func (a *API) authLoginHandler(w http.ResponseWriter, r *http.Request) {
 	// het the user info from the request body
-	loginInfo := &UserInfo{}
+	loginInfo := &apicommon.UserInfo{}
 	if err := json.NewDecoder(r.Body).Decode(loginInfo); err != nil {
 		errors.ErrMalformedBody.Write(w)
 		return
@@ -62,14 +63,14 @@ func (a *API) authLoginHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// send the token back to the user
-	httpWriteJSON(w, res)
+	apicommon.HttpWriteJSON(w, res)
 }
 
 // writableOrganizationAddressesHandler returns the list of addresses of the
 // organizations where the user has write access.
 func (a *API) writableOrganizationAddressesHandler(w http.ResponseWriter, r *http.Request) {
 	// get the user from the request context
-	user, ok := userFromContext(r.Context())
+	user, ok := apicommon.UserFromContext(r.Context())
 	if !ok {
 		errors.ErrUnauthorized.Write(w)
 		return
@@ -80,7 +81,7 @@ func (a *API) writableOrganizationAddressesHandler(w http.ResponseWriter, r *htt
 		return
 	}
 	// get the user organizations information from the database if any
-	userAddresses := &OrganizationAddresses{
+	userAddresses := &apicommon.OrganizationAddresses{
 		Addresses: []string{},
 	}
 	// get the addresses of the organizations where the user has write access
@@ -92,5 +93,5 @@ func (a *API) writableOrganizationAddressesHandler(w http.ResponseWriter, r *htt
 		}
 	}
 	// write the response back to the user
-	httpWriteJSON(w, userAddresses)
+	apicommon.HttpWriteJSON(w, userAddresses)
 }

--- a/api/census_test.go
+++ b/api/census_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/internal"
 )
@@ -32,7 +33,7 @@ func TestCensus(t *testing.T) {
 
 	// Test 1: Create a census
 	// Test 1.1: Test with valid data
-	censusInfo := &OrganizationCensus{
+	censusInfo := &apicommon.OrganizationCensus{
 		Type:       db.CensusTypeSMSorMail,
 		OrgAddress: orgAddress.String(),
 	}
@@ -40,7 +41,7 @@ func TestCensus(t *testing.T) {
 	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 
 	// Parse the response to get the census ID
-	var createdCensus OrganizationCensus
+	var createdCensus apicommon.OrganizationCensus
 	err := parseJSON(resp, &createdCensus)
 	c.Assert(err, qt.IsNil)
 	c.Assert(createdCensus.ID, qt.Not(qt.Equals), "")
@@ -55,7 +56,7 @@ func TestCensus(t *testing.T) {
 	c.Assert(code, qt.Equals, http.StatusUnauthorized)
 
 	// Test 1.3: Test with invalid organization address
-	invalidCensusInfo := &OrganizationCensus{
+	invalidCensusInfo := &apicommon.OrganizationCensus{
 		Type:       db.CensusTypeSMSorMail,
 		OrgAddress: "invalid-address",
 	}
@@ -67,7 +68,7 @@ func TestCensus(t *testing.T) {
 	resp, code = testRequest(t, http.MethodGet, adminToken, nil, censusEndpoint, censusID)
 	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 
-	var retrievedCensus OrganizationCensus
+	var retrievedCensus apicommon.OrganizationCensus
 	err = parseJSON(resp, &retrievedCensus)
 	c.Assert(err, qt.IsNil)
 	c.Assert(retrievedCensus.ID, qt.Equals, censusID)
@@ -80,8 +81,8 @@ func TestCensus(t *testing.T) {
 
 	// Test 3: Add participants to census
 	// Test 3.1: Test with valid data
-	participants := &AddParticipantsRequest{
-		Participants: []OrgParticipant{
+	participants := &apicommon.AddParticipantsRequest{
+		Participants: []apicommon.OrgParticipant{
 			{
 				ParticipantNo: "P001",
 				Name:          "John Doe",
@@ -111,7 +112,7 @@ func TestCensus(t *testing.T) {
 	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 
 	// Verify the response contains the number of participants added
-	var addedResponse AddParticipantsResponse
+	var addedResponse apicommon.AddParticipantsResponse
 	err = parseJSON(resp, &addedResponse)
 	c.Assert(err, qt.IsNil)
 	c.Assert(addedResponse.ParticipantsNo, qt.Equals, uint32(2))
@@ -125,15 +126,15 @@ func TestCensus(t *testing.T) {
 	c.Assert(code, qt.Not(qt.Equals), http.StatusOK)
 
 	// Test 3.4: Test with empty participants list
-	emptyParticipants := &AddParticipantsRequest{
-		Participants: []OrgParticipant{},
+	emptyParticipants := &apicommon.AddParticipantsRequest{
+		Participants: []apicommon.OrgParticipant{},
 	}
 	_, code = testRequest(t, http.MethodPost, adminToken, emptyParticipants, censusEndpoint, censusID)
 	c.Assert(code, qt.Equals, http.StatusOK)
 
 	// Test 3.5: Test with async=true flag
-	asyncParticipants := &AddParticipantsRequest{
-		Participants: []OrgParticipant{
+	asyncParticipants := &apicommon.AddParticipantsRequest{
+		Participants: []apicommon.OrgParticipant{
 			{
 				ParticipantNo: "P003",
 				Name:          "Bob Johnson",
@@ -164,7 +165,7 @@ func TestCensus(t *testing.T) {
 	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 
 	// Verify the response contains a job ID
-	var asyncResponse AddParticipantsResponse
+	var asyncResponse apicommon.AddParticipantsResponse
 	err = parseJSON(resp, &asyncResponse)
 	c.Assert(err, qt.IsNil)
 	c.Assert(asyncResponse.JobID, qt.Not(qt.IsNil))
@@ -213,7 +214,7 @@ func TestCensus(t *testing.T) {
 	resp, code = testRequest(t, http.MethodPost, adminToken, nil, censusEndpoint, censusID, "publish")
 	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 
-	var publishedCensus PublishedCensusResponse
+	var publishedCensus apicommon.PublishedCensusResponse
 	err = parseJSON(resp, &publishedCensus)
 	c.Assert(err, qt.IsNil)
 	c.Assert(publishedCensus.URI, qt.Not(qt.Equals), "")

--- a/api/const.go
+++ b/api/const.go
@@ -1,17 +1,1 @@
 package api
-
-import (
-	"time"
-)
-
-// VerificationCodeExpiration is the duration of the verification code
-// before it is invalidated
-var VerificationCodeExpiration = 3 * time.Minute
-
-const (
-	// VerificationCodeLength is the length of the verification code in bytes
-	VerificationCodeLength = 3
-	// InvitationExpiration is the duration of the invitation code before it is
-	// invalidated
-	InvitationExpiration = 5 * 24 * time.Hour // 5 days
-)

--- a/api/middlewares.go
+++ b/api/middlewares.go
@@ -6,16 +6,10 @@ import (
 
 	"github.com/go-chi/jwtauth/v5"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
 )
-
-// MetadataKey is a type to define the key for the metadata stored in the
-// context.
-type MetadataKey string
-
-// userMetadataKey is the key used to store the user in the context.
-const userMetadataKey MetadataKey = "user"
 
 // authenticator is a middleware that authenticates the user and returns a JWT
 // token. If successful, the decodes the user identifier (its email) from the
@@ -50,19 +44,9 @@ func (a *API) authenticator(next http.Handler) http.Handler {
 			return
 		}
 		// add the user to the context
-		ctx := context.WithValue(r.Context(), userMetadataKey, *user)
+		ctx := context.WithValue(r.Context(), apicommon.UserMetadataKey, *user)
 		// token is authenticated, pass it through with the new context with the
 		// user information
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
-}
-
-// userFromContext retrieves the user from the context provided, expected to be
-// the context of a request handled by the authenticator middleware.
-func userFromContext(ctx context.Context) (*db.User, bool) {
-	rawUser, ok := ctx.Value(userMetadataKey).(db.User)
-	if ok {
-		return &rawUser, ok
-	}
-	return nil, false
 }

--- a/api/plans.go
+++ b/api/plans.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/errors"
 )
 
@@ -18,7 +19,7 @@ func (a *API) getPlansHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// send the plans back to the user
-	httpWriteJSON(w, plans)
+	apicommon.HttpWriteJSON(w, plans)
 }
 
 func (a *API) planInfoHandler(w http.ResponseWriter, r *http.Request) {
@@ -41,5 +42,5 @@ func (a *API) planInfoHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// send the plan back to the user
-	httpWriteJSON(w, plan)
+	apicommon.HttpWriteJSON(w, plan)
 }

--- a/api/process.go
+++ b/api/process.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
 	"github.com/vocdoni/saas-backend/internal"
@@ -19,7 +20,7 @@ func (a *API) createProcessHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	processInfo := &CreateProcessRequest{}
+	processInfo := &apicommon.CreateProcessRequest{}
 	if err := json.NewDecoder(r.Body).Decode(&processInfo); err != nil {
 		errors.ErrMalformedBody.Write(w)
 		return
@@ -31,7 +32,7 @@ func (a *API) createProcessHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// get the user from the request context
-	user, ok := userFromContext(r.Context())
+	user, ok := apicommon.UserFromContext(r.Context())
 	if !ok {
 		errors.ErrUnauthorized.Write(w)
 		return
@@ -76,7 +77,7 @@ func (a *API) createProcessHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpWriteOK(w)
+	apicommon.HttpWriteOK(w)
 }
 
 // processInfoHandler retrieves voting process information by ID.
@@ -98,5 +99,5 @@ func (a *API) processInfoHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpWriteJSON(w, process)
+	apicommon.HttpWriteJSON(w, process)
 }

--- a/api/process_test.go
+++ b/api/process_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/internal"
 	"go.vocdoni.io/dvote/util"
@@ -30,7 +31,7 @@ func TestProcess(t *testing.T) {
 	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 
 	// Create a census
-	censusInfo := &OrganizationCensus{
+	censusInfo := &apicommon.OrganizationCensus{
 		Type:       db.CensusTypeSMSorMail,
 		OrgAddress: orgAddress.String(),
 	}
@@ -38,7 +39,7 @@ func TestProcess(t *testing.T) {
 	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 
 	// Parse the response to get the census ID
-	var createdCensus OrganizationCensus
+	var createdCensus apicommon.OrganizationCensus
 	err := parseJSON(resp, &createdCensus)
 	c.Assert(err, qt.IsNil)
 	c.Assert(createdCensus.ID, qt.Not(qt.Equals), "")
@@ -46,8 +47,8 @@ func TestProcess(t *testing.T) {
 	t.Logf("Created census with ID: %s\n", censusID)
 
 	// Add participants to the census
-	participants := &AddParticipantsRequest{
-		Participants: []OrgParticipant{
+	participants := &apicommon.AddParticipantsRequest{
+		Participants: []apicommon.OrgParticipant{
 			{
 				ParticipantNo: "P001",
 				Name:          "John Doe",
@@ -80,7 +81,7 @@ func TestProcess(t *testing.T) {
 	resp, code = testRequest(t, http.MethodPost, adminToken, nil, censusEndpoint, censusID, "publish")
 	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 
-	var publishedCensus PublishedCensusResponse
+	var publishedCensus apicommon.PublishedCensusResponse
 	err = parseJSON(resp, &publishedCensus)
 	c.Assert(err, qt.IsNil)
 	c.Assert(publishedCensus.URI, qt.Not(qt.Equals), "")
@@ -99,7 +100,7 @@ func TestProcess(t *testing.T) {
 	err = censusIDBytes.ParseString(censusID)
 	c.Assert(err, qt.IsNil)
 
-	processInfo := &CreateProcessRequest{
+	processInfo := &apicommon.CreateProcessRequest{
 		PublishedCensusRoot: censusRoot,
 		PublishedCensusURI:  publishedCensus.URI,
 		CensusID:            censusIDBytes,
@@ -118,7 +119,7 @@ func TestProcess(t *testing.T) {
 	c.Assert(code, qt.Not(qt.Equals), http.StatusOK)
 
 	// Test 1.4: Test with missing census root/ID
-	invalidProcessInfo := &CreateProcessRequest{
+	invalidProcessInfo := &apicommon.CreateProcessRequest{
 		PublishedCensusURI: publishedCensus.URI,
 		Metadata:           []byte(`{"title":"Test Process","description":"This is a test process"}`),
 	}

--- a/api/stripe.go
+++ b/api/stripe.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/stripe/stripe-go/v81"
+	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
 	stripeService "github.com/vocdoni/saas-backend/stripe"
@@ -156,12 +157,12 @@ func (a *API) handleWebhook(w http.ResponseWriter, r *http.Request) {
 // createSubscriptionCheckoutHandler handles requests to create a new Stripe checkout session
 // for subscription purchases.
 func (a *API) createSubscriptionCheckoutHandler(w http.ResponseWriter, r *http.Request) {
-	user, ok := userFromContext(r.Context())
+	user, ok := apicommon.UserFromContext(r.Context())
 	if !ok {
 		errors.ErrUnauthorized.Write(w)
 		return
 	}
-	checkout := &SubscriptionCheckout{}
+	checkout := &apicommon.SubscriptionCheckout{}
 	if err := json.NewDecoder(r.Body).Decode(checkout); err != nil {
 		errors.ErrMalformedBody.Write(w)
 		return
@@ -207,7 +208,7 @@ func (a *API) createSubscriptionCheckoutHandler(w http.ResponseWriter, r *http.R
 		ClientSecret: session.ClientSecret,
 		SessionID:    session.ID,
 	}
-	httpWriteJSON(w, data)
+	apicommon.HttpWriteJSON(w, data)
 }
 
 // checkoutSessionHandler retrieves the status of a Stripe checkout session.
@@ -223,7 +224,7 @@ func (a *API) checkoutSessionHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpWriteJSON(w, status)
+	apicommon.HttpWriteJSON(w, status)
 }
 
 // getSubscriptionOrgInfo is a helper function that retrieves the subscription information from
@@ -253,7 +254,7 @@ func (a *API) getSubscriptionOrgInfo(event *stripe.Event) (*stripeService.Stripe
 // based on the organization creator email..
 // It requires the user to be authenticated and to have admin role for the organization.
 func (a *API) createSubscriptionPortalSessionHandler(w http.ResponseWriter, r *http.Request) {
-	user, ok := userFromContext(r.Context())
+	user, ok := apicommon.UserFromContext(r.Context())
 	if !ok {
 		errors.ErrUnauthorized.Write(w)
 		return
@@ -279,5 +280,5 @@ func (a *API) createSubscriptionPortalSessionHandler(w http.ResponseWriter, r *h
 	}{
 		PortalURL: session.URL,
 	}
-	httpWriteJSON(w, data)
+	apicommon.HttpWriteJSON(w, data)
 }

--- a/api/transaction.go
+++ b/api/transaction.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/vocdoni/saas-backend/account"
+	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
 	"go.vocdoni.io/proto/build/go/models"
@@ -13,13 +14,13 @@ import (
 
 func (a *API) signTxHandler(w http.ResponseWriter, r *http.Request) {
 	// get the user from the request context
-	user, ok := userFromContext(r.Context())
+	user, ok := apicommon.UserFromContext(r.Context())
 	if !ok {
 		errors.ErrUnauthorized.Write(w)
 		return
 	}
 	// read the request body
-	signReq := &TransactionData{}
+	signReq := &apicommon.TransactionData{}
 	if err := json.NewDecoder(r.Body).Decode(signReq); err != nil {
 		errors.ErrMalformedBody.Withf("could not decode request body: %v", err).Write(w)
 		return
@@ -98,7 +99,7 @@ func (a *API) signTxHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// return the signed tx payload
-	httpWriteJSON(w, &TransactionData{
+	apicommon.HttpWriteJSON(w, &apicommon.TransactionData{
 		TxPayload: stx,
 	})
 }
@@ -106,13 +107,13 @@ func (a *API) signTxHandler(w http.ResponseWriter, r *http.Request) {
 // signMessageHandler signs a message with the user's private key. Only certain messages are allowed to be signed.
 func (a *API) signMessageHandler(w http.ResponseWriter, r *http.Request) {
 	// get the user from the request context
-	user, ok := userFromContext(r.Context())
+	user, ok := apicommon.UserFromContext(r.Context())
 	if !ok {
 		errors.ErrUnauthorized.Write(w)
 		return
 	}
 	// read the message from the request body
-	signReq := &MessageSignature{}
+	signReq := &apicommon.MessageSignature{}
 	if err := json.NewDecoder(r.Body).Decode(signReq); err != nil {
 		errors.ErrMalformedBody.Withf("could not decode request body: %v", err).Write(w)
 		return
@@ -151,7 +152,7 @@ func (a *API) signMessageHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// return the signature
-	httpWriteJSON(w, &MessageSignature{
+	apicommon.HttpWriteJSON(w, &apicommon.MessageSignature{
 		Signature: signature,
 	})
 }

--- a/cmd/census-workflow/main.go
+++ b/cmd/census-workflow/main.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/vocdoni/saas-backend/api"
+	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/internal"
 )
@@ -87,10 +87,10 @@ func (c *Client) makeRequest(method, path string, body interface{}, target inter
 	return nil
 }
 
-func generateParticipants(n int) []api.OrgParticipant {
-	participants := make([]api.OrgParticipant, n)
-	for i := range n {
-		participants[i] = api.OrgParticipant{
+func generateParticipants(n int) []apicommon.OrgParticipant {
+	participants := make([]apicommon.OrgParticipant, n)
+	for i := 0; i < n; i++ {
+		participants[i] = apicommon.OrgParticipant{
 			Email:         fmt.Sprintf("user%d@example.com", i+1),
 			Phone:         fmt.Sprintf("+%010d", rand.Int63n(10000000000)),
 			ParticipantNo: fmt.Sprintf("participant_%d", i+1),
@@ -137,7 +137,7 @@ func main() {
 
 	// 1. Login
 	fmt.Println("1. Logging in...")
-	var loginResp api.LoginResponse
+	var loginResp apicommon.LoginResponse
 	err := client.makeRequest("POST", "/auth/login", LoginRequest{
 		Email:    config.Email,
 		Password: config.Password,
@@ -152,7 +152,7 @@ func main() {
 	// 2. Create census
 	fmt.Println("\n2. Creating census...")
 	var censusID string
-	err = client.makeRequest("POST", "/census", api.OrganizationCensus{
+	err = client.makeRequest("POST", "/census", apicommon.OrganizationCensus{
 		Type:       db.CensusTypeSMSorMail,
 		OrgAddress: config.OrgAddress,
 	}, &censusID)
@@ -175,7 +175,7 @@ func main() {
 	// 4. Add participants
 	fmt.Println("\n4. Adding participants...")
 	participants := generateParticipants(10)
-	err = client.makeRequest("POST", fmt.Sprintf("/census/%s", censusID), api.AddParticipantsRequest{
+	err = client.makeRequest("POST", fmt.Sprintf("/census/%s", censusID), apicommon.AddParticipantsRequest{
 		Participants: participants,
 	}, nil)
 	if err != nil {
@@ -199,7 +199,7 @@ func main() {
 	processID := fmt.Sprintf("test_process_%d", time.Now().Unix())
 	metadata := generateMetadata()
 	root := new(internal.HexBytes).SetString(publishedCensus.Root)
-	err = client.makeRequest("POST", fmt.Sprintf("/process/%s", processID), api.CreateProcessRequest{
+	err = client.makeRequest("POST", fmt.Sprintf("/process/%s", processID), apicommon.CreateProcessRequest{
 		PublishedCensusRoot: *root,
 		Metadata:            metadata,
 	}, nil)

--- a/objectstorage/objectstorage.go
+++ b/objectstorage/objectstorage.go
@@ -35,12 +35,14 @@ var DefaultSupportedFileTypes = map[ObjectFileType]bool{
 type ObjectStorageConfig struct {
 	DB             *db.MongoStorage
 	SupportedTypes []ObjectFileType
+	ServerURL      string
 }
 
 type ObjectStorageClient struct {
 	db             *db.MongoStorage
 	supportedTypes map[ObjectFileType]bool
 	cache          *lru.Cache[string, db.Object]
+	ServerURL      string
 }
 
 // New initializes a new ObjectStorageClient with the provided API credentials and configuration.
@@ -61,6 +63,7 @@ func New(conf *ObjectStorageConfig) (*ObjectStorageClient, error) {
 		db:             conf.DB,
 		supportedTypes: supportedTypes,
 		cache:          cache,
+		ServerURL:      conf.ServerURL,
 	}, nil
 }
 


### PR DESCRIPTION
The idea is to move most of the handlers to its own packages. To this end we need to create an apicommon package to avoid ciclic dependency issues.

The common package is created and the first handler (objectstorage) moved.