### PR TITLE
api: support creating (and listing) draft processes

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -239,6 +239,9 @@ func (a *API) initRouter() http.Handler {
 		// get organization censuses
 		log.Infow("new route", "method", "GET", "path", organizationCensusesEndpoint)
 		r.Get(organizationCensusesEndpoint, a.organizationCensusesHandler)
+		// get organization draft processes
+		log.Infow("new route", "method", "GET", "path", organizationListProcessDraftsEndpoint)
+		r.Get(organizationListProcessDraftsEndpoint, a.organizationListProcessDraftsHandler)
 		// pending organization invitations
 		log.Infow("new route", "method", "GET", "path", organizationPendingUsersEndpoint)
 		r.Get(organizationPendingUsersEndpoint, a.pendingOrganizationUsersHandler)
@@ -336,6 +339,8 @@ func (a *API) initRouter() http.Handler {
 		// PROCESS ROUTES
 		log.Infow("new route", "method", "POST", "path", processCreateEndpoint)
 		r.Post(processCreateEndpoint, a.createProcessHandler)
+		log.Infow("new route", "method", "PUT", "path", processEndpoint)
+		r.Put(processEndpoint, a.updateProcessHandler)
 		// PROCESS BUNDLE ROUTES (private)
 		log.Infow("new route", "method", "POST", "path", processBundleEndpoint)
 		r.Post(processBundleEndpoint, a.createProcessBundleHandler)

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -255,6 +255,15 @@ type ListOrganizationMemberGroupResponse struct {
 	Members []OrgMember `json:"members"`
 }
 
+// ListOrganizationProcesses represents the response for listing the processes of an organization.
+// swagger:model ListOrganizationProcesses
+type ListOrganizationProcesses struct {
+	// Pagination fields
+	Pagination *Pagination `json:"pagination"`
+	// List of organization processes
+	Processes []db.Process `json:"processes"`
+}
+
 // ValidateMemberGroupRequest validates the request for creating or updating an organization member group.
 // Validates that either AuthFields or TwoFaFields are provided and checks for duplicates or empty fields.
 // swagger:model ValidateMemberGroupRequest
@@ -959,6 +968,20 @@ type CreateProcessRequest struct {
 	// Organization address
 	OrgAddress common.Address `json:"orgAddress"`
 
+	// Vochain ID/Address of the process
+	Address internal.HexBytes `json:"address" swaggertype:"string" format:"hex" example:"deadbeef"`
+
+	// Census ID
+	CensusID internal.HexBytes `json:"censusId" swaggertype:"string" format:"hex" example:"deadbeef"`
+
+	// Additional metadata for the process
+	// Can be any key-value pairs
+	Metadata map[string]any `json:"metadata"`
+}
+
+// UpdateProcessRequest defines the payload for updating an existing voting process.
+// swagger:model UpdateProcessRequest
+type UpdateProcessRequest struct {
 	// Vochain ID/Address of the process
 	Address internal.HexBytes `json:"address" swaggertype:"string" format:"hex" example:"deadbeef"`
 

--- a/api/process.go
+++ b/api/process.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-chi/chi/v5"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
@@ -35,11 +36,6 @@ func (a *API) createProcessHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if processInfo.CensusID == nil {
-		errors.ErrMalformedBody.Withf("missing census ID").Write(w)
-		return
-	}
-
 	// get the user from the request context
 	user, ok := apicommon.UserFromContext(r.Context())
 	if !ok {
@@ -47,29 +43,46 @@ func (a *API) createProcessHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	census, err := a.db.Census(processInfo.CensusID.String())
-	if err != nil {
-		if err == db.ErrNotFound {
-			errors.ErrMalformedURLParam.Withf("census not found").Write(w)
+	// if it's a draft process
+	if processInfo.Address.Equals(nil) && processInfo.OrgAddress == (common.Address{}) {
+		errors.ErrMalformedBody.Withf("draft processes must provide an org address").Write(w)
+		return
+	}
+
+	// Create or update the process
+	process := &db.Process{
+		Metadata: processInfo.Metadata,
+	}
+
+	var orgAddress common.Address
+	if processInfo.CensusID != nil {
+		var err error
+		census, err := a.db.Census(processInfo.CensusID.String())
+		if err != nil {
+			if err == db.ErrNotFound {
+				errors.ErrMalformedURLParam.Withf("invalid census provided").Write(w)
+				return
+			}
+			errors.ErrGenericInternalServerError.WithErr(err).Write(w)
 			return
 		}
-		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		process.Census = *census
+		orgAddress = census.OrgAddress
+	} else if processInfo.OrgAddress != (common.Address{}) {
+		orgAddress = processInfo.OrgAddress
+	} else {
+		errors.ErrMalformedBody.Withf("either census ID or organization address must be provided").Write(w)
 		return
 	}
 
 	// check the user has the necessary permissions
-	if !user.HasRoleFor(census.OrgAddress, db.ManagerRole) && !user.HasRoleFor(census.OrgAddress, db.AdminRole) {
+	if !user.HasRoleFor(orgAddress, db.ManagerRole) && !user.HasRoleFor(orgAddress, db.AdminRole) {
 		errors.ErrUnauthorized.Withf("user is not admin of organization").Write(w)
 		return
 	}
 
-	// finally create the process
-	process := &db.Process{
-		Census:     *census,
-		Metadata:   processInfo.Metadata,
-		OrgAddress: census.OrgAddress,
-	}
-	if len(processInfo.Address) > 0 {
+	process.OrgAddress = orgAddress
+	if !processInfo.Address.Equals(nil) {
 		process.Address = processInfo.Address
 	}
 
@@ -80,6 +93,102 @@ func (a *API) createProcessHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	apicommon.HTTPWriteJSON(w, processID)
+}
+
+// updateProcessHandler godoc
+//
+//	@Summary		Update an existing voting process
+//	@Description	Update an existing voting process. Requires Manager/Admin role.
+//	@Tags			process
+//	@Accept			json
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			processId	path		string							true	"Process ID"
+//	@Param			request		body		apicommon.CreateProcessRequest	true	"Process update information"
+//	@Success		200			{string}	string							"OK"
+//	@Failure		400			{object}	errors.Error					"Invalid input data"
+//	@Failure		401			{object}	errors.Error					"Unauthorized"
+//	@Failure		404			{object}	errors.Error					"Process not found"
+//	@Failure		500			{object}	errors.Error					"Internal server error"
+//	@Router			/process/{processId} [put]
+func (a *API) updateProcessHandler(w http.ResponseWriter, r *http.Request) {
+	processID := chi.URLParam(r, "processId")
+	if processID == "" {
+		errors.ErrMalformedURLParam.Withf("missing process ID").Write(w)
+		return
+	}
+	parsedID, err := primitive.ObjectIDFromHex(processID)
+	if err != nil {
+		errors.ErrMalformedURLParam.Withf("invalid process ID").Write(w)
+		return
+	}
+
+	// parse the process info from the request body
+	processInfo := &apicommon.UpdateProcessRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&processInfo); err != nil {
+		errors.ErrMalformedBody.Write(w)
+		return
+	}
+
+	// get the user from the request context
+	user, ok := apicommon.UserFromContext(r.Context())
+	if !ok {
+		errors.ErrUnauthorized.Write(w)
+		return
+	}
+
+	existingProcess, err := a.db.Process(parsedID)
+	if err != nil {
+		if err == db.ErrNotFound {
+			errors.ErrMalformedURLParam.Withf("process not found").Write(w)
+			return
+		}
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+
+	// check if it's a draft process and can be overwritten
+	if !existingProcess.Address.Equals(nil) {
+		errors.ErrDuplicateConflict.Withf("process already exists and is not in draft mode").Write(w)
+		return
+	}
+
+	// check the user has the necessary permissions
+	if !user.HasRoleFor(existingProcess.OrgAddress, db.ManagerRole) &&
+		!user.HasRoleFor(existingProcess.OrgAddress, db.AdminRole) {
+		errors.ErrUnauthorized.Withf("user is not admin or manager of the organization that owns this process").Write(w)
+		return
+	}
+
+	var census *db.Census
+	if !processInfo.CensusID.Equals(nil) {
+		census, err = a.db.Census(processInfo.CensusID.String())
+		if err != nil {
+			if err == db.ErrNotFound {
+				errors.ErrMalformedURLParam.Withf("census not found").Write(w)
+				return
+			}
+			errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+			return
+		}
+		existingProcess.Census = *census
+	}
+
+	if len(processInfo.Metadata) > 0 {
+		existingProcess.Metadata = processInfo.Metadata
+	}
+
+	if !processInfo.Address.Equals(nil) {
+		existingProcess.Address = processInfo.Address
+	}
+
+	_, err = a.db.SetProcess(existingProcess)
+	if err != nil {
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+
+	apicommon.HTTPWriteOK(w)
 }
 
 // processInfoHandler godoc
@@ -118,4 +227,58 @@ func (a *API) processInfoHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	apicommon.HTTPWriteJSON(w, process)
+}
+
+// organizationListProcessDraftsHandler godoc
+//
+//	@Summary		Get paginated list of process drafts
+//	@Description	Returns a list of voting process drafts.
+//	@Tags			process
+//	@Accept			json
+//	@Produce		json
+//	@Success		200	{object}	apicommon.ListOrganizationProcesses
+//	@Failure		404	{object}	errors.Error	"Process not found"
+//	@Failure		500	{object}	errors.Error	"Internal server error"
+//	@Router			/organizations/{address}/processes/drafts [get]
+func (a *API) organizationListProcessDraftsHandler(w http.ResponseWriter, r *http.Request) {
+	// get the organization info from the request context
+	org, _, ok := a.organizationFromRequest(r)
+	if !ok {
+		errors.ErrNoOrganizationProvided.Write(w)
+		return
+	}
+	// get the user from the request context
+	user, ok := apicommon.UserFromContext(r.Context())
+	if !ok {
+		errors.ErrUnauthorized.Write(w)
+		return
+	}
+	// check the user has the necessary permissions
+	if !user.HasRoleFor(org.Address, db.ManagerRole) && !user.HasRoleFor(org.Address, db.AdminRole) {
+		errors.ErrUnauthorized.Withf("user is not admin of organization").Write(w)
+		return
+	}
+
+	params, err := parsePaginationParams(r.URL.Query().Get(ParamPage), r.URL.Query().Get(ParamLimit))
+	if err != nil {
+		errors.ErrMalformedURLParam.WithErr(err).Write(w)
+		return
+	}
+
+	// retrieve the orgMembers with pagination
+	totalItems, processes, err := a.db.ListProcesses(org.Address, params.Page, params.Limit, db.DraftOnly)
+	if err != nil {
+		errors.ErrGenericInternalServerError.Withf("could not get processes: %v", err).Write(w)
+		return
+	}
+	pagination, err := calculatePagination(params.Page, params.Limit, totalItems)
+	if err != nil {
+		errors.ErrMalformedURLParam.WithErr(err).Write(w)
+		return
+	}
+
+	apicommon.HTTPWriteJSON(w, &apicommon.ListOrganizationProcesses{
+		Pagination: pagination,
+		Processes:  processes,
+	})
 }

--- a/api/process_test.go
+++ b/api/process_test.go
@@ -4,18 +4,20 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/errors"
 	"github.com/vocdoni/saas-backend/internal"
 	"go.vocdoni.io/dvote/util"
 )
 
-func TestProcess(t *testing.T) {
+func testCreateOrgAndCensus(
+	t *testing.T,
+	adminToken string,
+) (common.Address, string, apicommon.PublishedCensusResponse) {
 	c := qt.New(t)
-
-	// Create a user with admin permissions
-	adminToken := testCreateUser(t, "adminpassword123")
 
 	// Verify the token works
 	user := requestAndParse[apicommon.UserInfo](t, http.MethodGet, adminToken, nil, usersMeEndpoint)
@@ -79,6 +81,18 @@ func TestProcess(t *testing.T) {
 	c.Assert(publishedCensus.URI, qt.Not(qt.Equals), "")
 	c.Assert(publishedCensus.Root, qt.Not(qt.Equals), "")
 
+	return orgAddress, censusID, publishedCensus
+}
+
+func TestProcess(t *testing.T) {
+	c := qt.New(t)
+
+	// Create a user with admin permissions
+	adminToken := testCreateUser(t, "adminpassword123")
+
+	// Create org and census
+	orgAddress, censusID, _ := testCreateOrgAndCensus(t, adminToken)
+
 	// Test 1: Create a process
 	// Generate a random process ID
 	processID := internal.HexBytes(util.RandomBytes(32))
@@ -86,15 +100,16 @@ func TestProcess(t *testing.T) {
 
 	// Test 1.1: Test with valid data
 	censusIDBytes := internal.HexBytes{}
-	err = censusIDBytes.ParseString(censusID)
+	err := censusIDBytes.ParseString(censusID)
 	c.Assert(err, qt.IsNil)
 
 	processInfo := &apicommon.CreateProcessRequest{
-		CensusID: censusIDBytes,
-		Metadata: map[string]any{"title": "Test Process", "description": "This is a test process"},
+		OrgAddress: orgAddress,
+		CensusID:   censusIDBytes,
+		Metadata:   map[string]any{"title": "Test Process", "description": "This is a test process"},
 	}
 
-	resp, code = testRequest(t, http.MethodPost, adminToken, processInfo, "process")
+	resp, code := testRequest(t, http.MethodPost, adminToken, processInfo, "process")
 	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 
 	// Test 1.2: Test create with no authentication
@@ -130,4 +145,114 @@ func TestProcess(t *testing.T) {
 	c.Assert(retrievedProcess.ID.Hex(), qt.Equals, pid)
 	c.Assert(retrievedProcess.Metadata["title"], qt.Equals, "Test Process")
 	c.Assert(retrievedProcess.Metadata["description"], qt.Equals, "This is a test process")
+}
+
+// TestDraftProcess tests the draft process functionality
+func TestDraftProcess(t *testing.T) {
+	c := qt.New(t)
+
+	// Create a user with admin permissions
+	adminToken := testCreateUser(t, "adminpassword123")
+
+	// Create org and census
+	orgAddress, censusID, _ := testCreateOrgAndCensus(t, adminToken)
+
+	// Genereate a mock Vochain Address
+	randomAddress := common.HexToAddress(internal.RandomHex(1000000))
+
+	censusIDBytes := internal.HexBytes{}
+	err := censusIDBytes.ParseString(censusID)
+	c.Assert(err, qt.IsNil)
+
+	// Step 1: Create a process with draft=true
+	initialMetadata := map[string]any{
+		"title":       "Draft Process",
+		"description": "This is a draft process",
+	}
+	draftProcessInfo := &apicommon.CreateProcessRequest{
+		OrgAddress: orgAddress,
+		CensusID:   censusIDBytes,
+		Metadata:   initialMetadata,
+	}
+
+	pid := requestAndParseWithAssertCode[string](
+		http.StatusOK,
+		t,
+		http.MethodPost,
+		adminToken,
+		draftProcessInfo,
+		"process",
+	)
+	t.Log("Successfully created draft process")
+
+	// Verify the process was created and is in draft mode
+	resp, code := testRequest(t, http.MethodGet, adminToken, nil, "process", pid)
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+
+	var createdProcess db.Process
+	err = parseJSON(resp, &createdProcess)
+	c.Assert(err, qt.IsNil)
+	c.Assert(createdProcess.Address, qt.IsNil, qt.Commentf("Process should be a draft (have no vochain address)"))
+	t.Log("Verified process is a draft")
+
+	// Verify the list of draft processes contains 1 item
+	{
+		processDraftsResp := requestAndParse[apicommon.ListOrganizationProcesses](t,
+			http.MethodGet, adminToken, nil, "organizations", orgAddress.String(), "processes", "drafts")
+		c.Assert(processDraftsResp.Processes, qt.HasLen, 1)
+	}
+
+	// Step 2: Update the process with new metadata and draft=false
+	updatedMetadata := map[string]any{
+		"title":       "Updated Process",
+		"description": "This is no longer a draft process",
+	}
+	updatedProcessInfo := &apicommon.UpdateProcessRequest{
+		CensusID: censusIDBytes,
+		Metadata: updatedMetadata,
+		Address:  randomAddress[:], // No longer a draft
+	}
+
+	resp, code = testRequest(t, http.MethodPut, adminToken, updatedProcessInfo, "process", pid)
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+	t.Log("Successfully updated process and set draft=false")
+
+	// Verify the process was updated and is no longer in draft mode
+	resp, code = testRequest(t, http.MethodGet, adminToken, nil, "process", pid)
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+
+	var updatedProcess db.Process
+	err = parseJSON(resp, &updatedProcess)
+	c.Assert(err, qt.IsNil)
+	c.Assert(updatedProcess.Address, qt.IsNotNil, qt.Commentf("Process should no longer be a draft"))
+	c.Assert(updatedProcess.Metadata, qt.DeepEquals, updatedMetadata, qt.Commentf("Process metadata should be updated"))
+	t.Log("Verified process is no longer in draft mode and metadata was updated")
+
+	// Verify the list of draft processes is now empty
+	{
+		processDraftsResp := requestAndParse[apicommon.ListOrganizationProcesses](t,
+			http.MethodGet, adminToken, nil, "organizations", orgAddress.String(), "processes", "drafts")
+		c.Assert(processDraftsResp.Processes, qt.HasLen, 0)
+		c.Assert(processDraftsResp.Pagination.TotalItems, qt.Equals, int64(0))
+	}
+
+	// Step 3: Try to update the process again, which should fail since it's no longer in draft mode
+
+	// Genereate another mock Vochain Address
+	finalRandomAddress := common.HexToAddress(internal.RandomHex(1000000))
+
+	finalMetadata := map[string]any{
+		"title":       "Final Process",
+		"description": "This update should fail",
+	}
+	finalProcessInfo := &apicommon.CreateProcessRequest{
+		CensusID: censusIDBytes,
+		Metadata: finalMetadata,         // Try to update metadata (should fail)
+		Address:  finalRandomAddress[:], // Try to update address (should fail)
+	}
+
+	errResp := requestAndParseWithAssertCode[errors.Error](http.StatusConflict,
+		t, http.MethodPut, adminToken, finalProcessInfo, "process", pid)
+	c.Assert(errResp.Code, qt.Equals, errors.ErrDuplicateConflict.Code)
+	t.Log("Successfully verified that updating a non-draft process fails")
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -68,6 +68,9 @@ const (
 	organizationSubscriptionEndpoint = "/organizations/{address}/subscription"
 	// GET /organizations/{address}/censuses to get the organization censuses
 	organizationCensusesEndpoint = "/organizations/{address}/censuses"
+	// GET /organizations/{address}/processes/drafts to get the organization draft processes
+	organizationListProcessDraftsEndpoint = "/organizations/{address}/processes/drafts"
+
 	// GET /organizations/{address}/members to get the organization members
 	organizationMembersEndpoint = "/organizations/{address}/members"
 	// POST /organizations/{address}/members to add new members

--- a/db/const.go
+++ b/db/const.go
@@ -103,3 +103,12 @@ func IsValidUserRole(role UserRole) bool {
 	_, valid := validRoles[role]
 	return valid
 }
+
+// DraftFilter is used to filter processes by draft status
+type DraftFilter int
+
+const (
+	AllProcesses DraftFilter = iota
+	DraftOnly
+	PublishedOnly
+)

--- a/db/types.go
+++ b/db/types.go
@@ -364,7 +364,7 @@ type PublishedCensus struct {
 //
 //nolint:lll
 type Process struct {
-	ID         primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	ID         primitive.ObjectID `json:"id" bson:"_id"`
 	Address    internal.HexBytes  `json:"address" bson:"address"  swaggertype:"string" format:"hex" example:"deadbeef"`
 	OrgAddress common.Address     `json:"orgAdress" bson:"orgAddress"`
 	Census     Census             `json:"census" bson:"census"`

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -243,6 +243,18 @@ definitions:
         - $ref: '#/definitions/apicommon.Pagination'
         description: Pagination fields
     type: object
+  apicommon.ListOrganizationProcesses:
+    properties:
+      pagination:
+        allOf:
+        - $ref: '#/definitions/apicommon.Pagination'
+        description: Pagination fields
+      processes:
+        description: List of organization processes
+        items:
+          $ref: '#/definitions/db.Process'
+        type: array
+    type: object
   apicommon.LoginResponse:
     properties:
       expirity:
@@ -2388,6 +2400,29 @@ paths:
       summary: Check the progress of adding members
       tags:
       - organizations
+  /organizations/{address}/processes/drafts:
+    get:
+      consumes:
+      - application/json
+      description: Returns a list of voting process drafts.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apicommon.ListOrganizationProcesses'
+        "404":
+          description: Process not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+      summary: Get paginated list of process drafts
+      tags:
+      - process
   /organizations/{address}/subscription:
     get:
       consumes:
@@ -3177,6 +3212,50 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
       summary: Get process information
+      tags:
+      - process
+    put:
+      consumes:
+      - application/json
+      description: Update an existing voting process. Requires Manager/Admin role.
+      parameters:
+      - description: Process ID
+        in: path
+        name: processId
+        required: true
+        type: string
+      - description: Process update information
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/apicommon.CreateProcessRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: string
+        "400":
+          description: Invalid input data
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "404":
+          description: Process not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+      security:
+      - BearerAuth: []
+      summary: Update an existing voting process
       tags:
       - process
   /process/{processId}/sign-info:

--- a/internal/hexbytes.go
+++ b/internal/hexbytes.go
@@ -132,5 +132,10 @@ func (hb HexBytes) Address() common.Address {
 }
 
 func (hb HexBytes) Equals(b HexBytes) bool {
-	return hb.String() == b.String()
+	return hb.Cmp(b) == 0
+}
+
+// Cmp compares two HexBytes
+func (hb HexBytes) Cmp(other HexBytes) int {
+	return bytes.Compare(hb, other)
 }


### PR DESCRIPTION
* [x] Rebase on top of current `main`
* [x] Add a new endpoint to list drafts (paginated) @altergui 
* [x] Rebase on top of #301 
* [x] remove the dependency on publishedCensusRoot
* [x] Take into acocunt that there are cases that the census can be null when storing a draft process
* [x] Add a PUT /proces/:id endpoint
