### PR TITLE
api: return errors on addMembers job

### DIFF
--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -854,6 +854,9 @@ type AddMembersResponse struct {
 	// Number of members added
 	Count uint32 `json:"count"`
 
+	// Errors encountered during job
+	Errors []error `json:"errors"`
+
 	// Job ID for tracking the addition process
 	JobID internal.HexBytes `json:"jobID" swaggertype:"string" format:"hex" example:"deadbeef"`
 }

--- a/api/org_members_test.go
+++ b/api/org_members_test.go
@@ -311,7 +311,7 @@ func TestOrganizationMembers(t *testing.T) {
 
 	// Test 5: Check the job progress
 	var (
-		jobStatus   *db.BulkOrgMembersStatus
+		jobStatus   *db.BulkOrgMembersJob
 		maxAttempts = 30
 		attempts    = 0
 		completed   = false
@@ -335,8 +335,8 @@ func TestOrganizationMembers(t *testing.T) {
 		err = json.Unmarshal(resp, &jobStatus)
 		c.Assert(err, qt.IsNil)
 
-		t.Logf("Job progress: %d%%, Added: %d, Total: %d\n",
-			jobStatus.Progress, jobStatus.Added, jobStatus.Total)
+		t.Logf("Job progress: %d%%, Added: %d, Total: %d, Errors: %d\n",
+			jobStatus.Progress, jobStatus.Added, jobStatus.Total, len(jobStatus.Errors))
 
 		if jobStatus.Progress == 100 {
 			completed = true
@@ -351,6 +351,7 @@ func TestOrganizationMembers(t *testing.T) {
 	c.Assert(jobStatus.Added, qt.Equals, 2) // We added 2 members
 	c.Assert(jobStatus.Total, qt.Equals, 2)
 	c.Assert(jobStatus.Progress, qt.Equals, 100)
+	c.Assert(jobStatus.Errors, qt.HasLen, 0)
 
 	// Test 6: Get organization members with pagination
 	// Test 6.1: Test with page=1 and pageSize=2

--- a/db/org_members_test.go
+++ b/db/org_members_test.go
@@ -192,7 +192,7 @@ func TestOrgMembers(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		// Wait for the operation to complete and get the final status
-		var lastStatus *BulkOrgMembersStatus
+		var lastStatus *BulkOrgMembersJob
 		for status := range progressChan {
 			lastStatus = status
 		}
@@ -201,6 +201,7 @@ func TestOrgMembers(t *testing.T) {
 		c.Assert(lastStatus, qt.Not(qt.IsNil))
 		c.Assert(lastStatus.Progress, qt.Equals, 100)
 		c.Assert(lastStatus.Added, qt.Equals, 2)
+		c.Assert(lastStatus.Errors, qt.HasLen, 0)
 
 		// Verify both members were created with hashed fields
 		member1, err := testDB.OrgMemberByMemberNumber(testOrgAddress, testMemberNumber)
@@ -232,6 +233,7 @@ func TestOrgMembers(t *testing.T) {
 		c.Assert(lastStatus, qt.Not(qt.IsNil))
 		c.Assert(lastStatus.Progress, qt.Equals, 100)
 		c.Assert(lastStatus.Added, qt.Equals, 2) // Both documents should be updated
+		c.Assert(lastStatus.Errors, qt.HasLen, 0)
 
 		// Verify updates for both members
 		updatedMember1, err := testDB.OrgMemberByMemberNumber(testOrgAddress, testMemberNumber)

--- a/db/users_test.go
+++ b/db/users_test.go
@@ -170,7 +170,6 @@ func TestUsers(t *testing.T) {
 			success, err = testDB.UserHasAnyRoleInOrg(user.Email, org.Address)
 			c.Assert(err, qt.IsNil)
 			c.Assert(success, qt.IsTrue)
-
 		}
 		// test the user role in a non-existent organizations
 		success, err := testDB.UserHasRoleInOrg(user.Email, "notFoundOrg", AdminRole)

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -31,6 +31,10 @@ definitions:
       count:
         description: Number of members added
         type: integer
+      errors:
+        description: Errors encountered during job
+        items: {}
+        type: array
       jobID:
         description: Job ID for tracking the addition process
         example: deadbeef
@@ -782,10 +786,13 @@ definitions:
       total:
         type: integer
     type: object
-  db.BulkOrgMembersStatus:
+  db.BulkOrgMembersJob:
     properties:
       added:
         type: integer
+      errors:
+        items: {}
+        type: array
       progress:
         type: integer
       total:
@@ -957,6 +964,8 @@ definitions:
       code:
         description: Error code
         type: integer
+      data:
+        description: Optional data to include in the error response
       err:
         description: Original error
       httpstatus:
@@ -23044,7 +23053,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/db.BulkOrgMembersStatus'
+            $ref: '#/definitions/db.BulkOrgMembersJob'
         "400":
           description: Invalid job ID
           schema:


### PR DESCRIPTION
    api: return errors on addMembers job
    
    * db: merge processOrgMemberBatch into createOrgMemberBulkOperations
    * db: refactor startOrgMemberProgressReporter for simplicity
    * db: rename BulkOrgMembersStatus -> BulkOrgMembersJob
    * db: add Errors field to BulkOrgMembersJob
