### PR TITLE
db: check MatchedCount on methods that do UpdateOne

### DIFF
--- a/api/csp_voting_test.go
+++ b/api/csp_voting_test.go
@@ -64,7 +64,7 @@ func TestCSPVoting(t *testing.T) {
 		c.Assert(len(plans), qt.Not(qt.Equals), 0)
 
 		err = testDB.SetOrganizationSubscription(orgAddress.String(), &db.OrganizationSubscription{
-			PlanID:          plans[0].ID,
+			PlanID:          plans[1].ID,
 			StartDate:       time.Now(),
 			RenewalDate:     time.Now().Add(time.Hour * 24),
 			LastPaymentDate: time.Now(),

--- a/api/organization_users.go
+++ b/api/organization_users.go
@@ -175,9 +175,8 @@ func (a *API) inviteOrganizationUserHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	// update the org users counter
-	org.Counters.Users++
-	if err := a.db.SetOrganization(org); err != nil {
-		errors.ErrGenericInternalServerError.Withf("could not update organization: %v", err).Write(w)
+	if err := a.db.IncrementOrganizationUsersCounter(org.Address); err != nil {
+		errors.ErrGenericInternalServerError.Withf("could not update organization users counter: %v", err).Write(w)
 		return
 	}
 	apicommon.HTTPWriteOK(w)
@@ -451,9 +450,8 @@ func (a *API) deletePendingUserInvitationHandler(w http.ResponseWriter, r *http.
 	}
 
 	// update the org users counter
-	org.Counters.Users--
-	if err := a.db.SetOrganization(org); err != nil {
-		errors.ErrGenericInternalServerError.Withf("could not update organization: %v", err).Write(w)
+	if err := a.db.DecrementOrganizationUsersCounter(org.Address); err != nil {
+		errors.ErrGenericInternalServerError.Withf("could not update organization users counter: %v", err).Write(w)
 		return
 	}
 	apicommon.HTTPWriteOK(w)
@@ -660,9 +658,8 @@ func (a *API) removeOrganizationUserHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	// update the org users counter
-	org.Counters.Users--
-	if err := a.db.SetOrganization(org); err != nil {
-		errors.ErrGenericInternalServerError.Withf("could not update organization: %v", err).Write(w)
+	if err := a.db.DecrementOrganizationUsersCounter(org.Address); err != nil {
+		errors.ErrGenericInternalServerError.Withf("could not update organization users counter: %v", err).Write(w)
 		return
 	}
 	apicommon.HTTPWriteOK(w)

--- a/api/organization_users_test.go
+++ b/api/organization_users_test.go
@@ -334,8 +334,6 @@ func TestOrganizationUsers(t *testing.T) {
 		c.Assert(code, qt.Equals, http.StatusUnauthorized)
 
 		// Test 6: Try to update a non-existent user
-		// Note: The current implementation returns 200 OK even for non-existent users
-		// because the MongoDB UpdateOne operation doesn't return an error if no documents match
 		_, code = testRequest(
 			t,
 			http.MethodPut,
@@ -346,7 +344,7 @@ func TestOrganizationUsers(t *testing.T) {
 			"users",
 			"999999",
 		)
-		c.Assert(code, qt.Equals, http.StatusOK)
+		c.Assert(code, qt.Equals, http.StatusBadRequest)
 	})
 
 	t.Run("RemoveOrganizationUser", func(t *testing.T) {
@@ -485,8 +483,6 @@ func TestOrganizationUsers(t *testing.T) {
 		c.Assert(code, qt.Equals, http.StatusUnauthorized)
 
 		// Test 4: Try to remove a non-existent user
-		// Note: The current implementation returns 200 OK even for non-existent users
-		// because the MongoDB UpdateOne operation doesn't return an error if no documents match
 		_, code = testRequest(
 			t,
 			http.MethodDelete,
@@ -497,7 +493,7 @@ func TestOrganizationUsers(t *testing.T) {
 			"users",
 			"999999",
 		)
-		c.Assert(code, qt.Equals, http.StatusOK)
+		c.Assert(code, qt.Equals, http.StatusBadRequest)
 
 		// Test 5: Try to remove yourself (which should fail)
 		// Get the admin's user ID

--- a/api/organization_users_test.go
+++ b/api/organization_users_test.go
@@ -208,8 +208,9 @@ func TestOrganizationUsers(t *testing.T) {
 		var pendingInvites apicommon.OrganizationInviteList
 		err = parseJSON(resp, &pendingInvites)
 		c.Assert(err, qt.IsNil)
-		c.Assert(len(pendingInvites.Invites), qt.Equals, nInvites,
-			qt.Commentf("expected %d pending invitations, got %d", nInvites, len(pendingInvites.Invites)))
+		expectedInvitesCount := min(nInvites, orgPlan.Organization.Users)
+		c.Assert(len(pendingInvites.Invites), qt.Equals, expectedInvitesCount,
+			qt.Commentf("expected %d pending invitations, got %d", expectedInvitesCount, len(pendingInvites.Invites)))
 	})
 
 	t.Run("UpdateOrganizationUserRole", func(t *testing.T) {

--- a/api/organization_users_test.go
+++ b/api/organization_users_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -110,6 +111,106 @@ func TestOrganizationUsers(t *testing.T) {
 	}
 	c.Assert(userID, qt.Not(qt.Equals), uint64(0), qt.Commentf("User not found in organization"))
 	c.Assert(initialRole, qt.Equals, string(db.ViewerRole))
+
+	// Test for race condition in inviteOrganizationUserHandler
+	t.Run("RaceConditionInviteUsers", func(t *testing.T) {
+		// Create a new organization for this test
+		newOrgAddress := testCreateOrganization(t, adminToken)
+		t.Logf("Created organization with address: %s\n", newOrgAddress.String())
+
+		// Subscribe the organization to a plan
+		plans, err := testDB.Plans()
+		c.Assert(err, qt.IsNil)
+		c.Assert(len(plans), qt.Not(qt.Equals), 0)
+		orgPlan := plans[1]
+
+		err = testDB.SetOrganizationSubscription(newOrgAddress.String(), &db.OrganizationSubscription{
+			PlanID:          orgPlan.ID,
+			StartDate:       time.Now(),
+			RenewalDate:     time.Now().Add(time.Hour * 24),
+			LastPaymentDate: time.Now(),
+			Active:          true,
+			MaxCensusSize:   1000,
+		})
+		c.Assert(err, qt.IsNil)
+		// Get the initial organization to check the users counter
+		resp, code := testRequest(t, http.MethodGet, adminToken, nil, "organizations", newOrgAddress.String())
+		c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+
+		var initialOrg apicommon.OrganizationInfo
+		err = parseJSON(resp, &initialOrg)
+		c.Assert(err, qt.IsNil)
+
+		initialUserCount := initialOrg.Counters.Users
+		t.Logf("Initial users counter: %d", initialUserCount)
+
+		nInvites := 15
+		t.Logf("Will invite %d users", nInvites)
+		var wg sync.WaitGroup
+		wg.Add(nInvites)
+
+		// Send invites concurrently to trigger the race condition
+		for range nInvites {
+			go func() {
+				defer wg.Done()
+				resp, code := testRequest(
+					t,
+					http.MethodPost,
+					adminToken,
+					&apicommon.OrganizationInvite{
+						Email: fmt.Sprintf("user-%s@example.com", uuid.New().String()),
+						Role:  string(db.ViewerRole),
+					},
+					"organizations",
+					newOrgAddress.String(),
+					"users",
+				)
+				c.Logf("response (%d): %s", code, resp)
+			}()
+		}
+		// Wait for all invites to complete
+		wg.Wait()
+
+		// Wait a bit more to ensure all DB operations complete
+		time.Sleep(500 * time.Millisecond)
+
+		// Get the organization again to check the users counter
+		resp, code = testRequest(t, http.MethodGet, adminToken, nil, "organizations", newOrgAddress.String())
+		c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+
+		var finalOrg apicommon.OrganizationInfo
+		err = parseJSON(resp, &finalOrg)
+		c.Assert(err, qt.IsNil)
+
+		// After our fix, we expect the counter to be correctly incremented by nInvites,
+		// but not exceed max allowed users of the subscribed plan
+		expectedCount := min(initialUserCount+nInvites, orgPlan.Organization.Users)
+		t.Logf("Final users counter: %d (expected %d)",
+			finalOrg.Counters.Users, expectedCount)
+
+		c.Assert(finalOrg.Counters.Users, qt.Equals, expectedCount,
+			qt.Commentf("race condition detected: expected users counter to be %d, got %d",
+				expectedCount, finalOrg.Counters.Users))
+
+		// Verify all invitations were actually created by checking pending invitations
+		resp, code = testRequest(
+			t,
+			http.MethodGet,
+			adminToken,
+			nil,
+			"organizations",
+			newOrgAddress.String(),
+			"users",
+			"pending",
+		)
+		c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+
+		var pendingInvites apicommon.OrganizationInviteList
+		err = parseJSON(resp, &pendingInvites)
+		c.Assert(err, qt.IsNil)
+		c.Assert(len(pendingInvites.Invites), qt.Equals, nInvites,
+			qt.Commentf("expected %d pending invitations, got %d", nInvites, len(pendingInvites.Invites)))
+	})
 
 	t.Run("UpdateOrganizationUserRole", func(t *testing.T) {
 		// Test 1: Update the user's role from Viewer to Manager

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -136,9 +136,8 @@ func (a *API) createOrganizationHandler(w http.ResponseWriter, r *http.Request) 
 
 	// update the parent organization counter
 	if orgInfo.Parent != nil {
-		dbParentOrg.Counters.SubOrgs++
-		if err := a.db.SetOrganization(dbParentOrg); err != nil {
-			errors.ErrGenericInternalServerError.Withf("could not update parent organization: %v", err).Write(w)
+		if err := a.db.IncrementOrganizationSubOrgsCounter(dbParentOrg.Address); err != nil {
+			errors.ErrGenericInternalServerError.Withf("could not update parent organization suborgs counter: %v", err).Write(w)
 			return
 		}
 	}

--- a/db/organizations.go
+++ b/db/organizations.go
@@ -188,9 +188,10 @@ func (ms *MongoStorage) UpdateOrganizationUserRole(address string, userID uint64
 		},
 	}
 
-	_, err := ms.users.UpdateOne(ctx, filter, update)
-	if err != nil {
+	if result, err := ms.users.UpdateOne(ctx, filter, update); err != nil {
 		return err
+	} else if result.MatchedCount == 0 {
+		return fmt.Errorf("either user has no role in organization, or organization doesn't exist (user %d, org %s)", userID, address)
 	}
 	return nil
 }
@@ -214,9 +215,10 @@ func (ms *MongoStorage) RemoveOrganizationUser(address string, userID uint64) er
 			},
 		},
 	}
-	_, err := ms.users.UpdateOne(ctx, filter, update)
-	if err != nil {
+	if result, err := ms.users.UpdateOne(ctx, filter, update); err != nil {
 		return err
+	} else if result.MatchedCount == 0 {
+		return fmt.Errorf("either user has no role in organization, or organization doesn't exist (user %d, org %s)", userID, address)
 	}
 	return nil
 }
@@ -236,8 +238,10 @@ func (ms *MongoStorage) SetOrganizationSubscription(address string, orgSubscript
 	filter := bson.M{"_id": bson.M{"$regex": address, "$options": "i"}}
 	updateDoc := bson.M{"$set": bson.M{"subscription": orgSubscription}}
 	// update the organization in the database
-	if _, err := ms.organizations.UpdateOne(ctx, filter, updateDoc); err != nil {
+	if result, err := ms.organizations.UpdateOne(ctx, filter, updateDoc); err != nil {
 		return err
+	} else if result.MatchedCount == 0 {
+		return fmt.Errorf("no organization found with address: %s", address)
 	}
 	return nil
 }
@@ -254,8 +258,10 @@ func (ms *MongoStorage) AddOrganizationMeta(address string, meta map[string]any)
 	filter := bson.M{"_id": bson.M{"$regex": address, "$options": "i"}}
 	updateDoc := bson.M{"$set": bson.M{"meta": meta}}
 	// update the organization in the database
-	if _, err := ms.organizations.UpdateOne(ctx, filter, updateDoc); err != nil {
+	if result, err := ms.organizations.UpdateOne(ctx, filter, updateDoc); err != nil {
 		return err
+	} else if result.MatchedCount == 0 {
+		return fmt.Errorf("no organization found with address: %s", address)
 	}
 	return nil
 }

--- a/db/organizations.go
+++ b/db/organizations.go
@@ -16,7 +16,7 @@ func (ms *MongoStorage) fetchOrganizationFromDB(ctx context.Context, address str
 	// find the organization in the database by its address (case insensitive)
 	filter := bson.M{"_id": bson.M{"$regex": address, "$options": "i"}}
 	result := ms.organizations.FindOne(ctx, filter)
-	org := &Organization{Subscription: OrganizationSubscription{}}
+	org := &Organization{}
 	if err := result.Decode(org); err != nil {
 		// if the organization doesn't exist return a specific error
 		if err == mongo.ErrNoDocuments {
@@ -233,7 +233,7 @@ func (ms *MongoStorage) SetOrganizationSubscription(address string, orgSubscript
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 	// prepare the document to be updated in the database
-	filter := bson.M{"_id": address}
+	filter := bson.M{"_id": bson.M{"$regex": address, "$options": "i"}}
 	updateDoc := bson.M{"$set": bson.M{"subscription": orgSubscription}}
 	// update the organization in the database
 	if _, err := ms.organizations.UpdateOne(ctx, filter, updateDoc); err != nil {
@@ -251,7 +251,7 @@ func (ms *MongoStorage) AddOrganizationMeta(address string, meta map[string]any)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 	// prepare the document to be updated in the database
-	filter := bson.M{"_id": address}
+	filter := bson.M{"_id": bson.M{"$regex": address, "$options": "i"}}
 	updateDoc := bson.M{"$set": bson.M{"meta": meta}}
 	// update the organization in the database
 	if _, err := ms.organizations.UpdateOne(ctx, filter, updateDoc); err != nil {
@@ -277,7 +277,7 @@ func (ms *MongoStorage) UpdateOrganizationMeta(address string, metaUpdates map[s
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
-	filter := bson.M{"_id": address}
+	filter := bson.M{"_id": bson.M{"$regex": address, "$options": "i"}}
 	update := bson.M{"$set": updateFields}
 
 	result, err := ms.organizations.UpdateOne(ctx, filter, update)
@@ -309,7 +309,7 @@ func (ms *MongoStorage) DeleteOrganizationMetaKeys(address string, keysToDelete 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
-	filter := bson.M{"_id": address}
+	filter := bson.M{"_id": bson.M{"$regex": address, "$options": "i"}}
 	update := bson.M{"$unset": unsetFields}
 
 	result, err := ms.organizations.UpdateOne(ctx, filter, update)

--- a/db/organizations.go
+++ b/db/organizations.go
@@ -331,7 +331,7 @@ func (ms *MongoStorage) IncrementOrganizationUsersCounter(address string) error 
 
 	org, err := ms.Organization(address)
 	if err != nil {
-		return fmt.Errorf("could not get organization: %v", err)
+		return fmt.Errorf("could not get organization: %w", err)
 	}
 
 	// Check if the organization has a subscription
@@ -341,7 +341,7 @@ func (ms *MongoStorage) IncrementOrganizationUsersCounter(address string) error 
 
 	plan, err := ms.Plan(org.Subscription.PlanID)
 	if err != nil {
-		return fmt.Errorf("could not get organization plan: %v", err)
+		return fmt.Errorf("could not get organization plan: %w", err)
 	}
 
 	if org.Counters.Users >= plan.Organization.Users {

--- a/db/organizations.go
+++ b/db/organizations.go
@@ -323,3 +323,153 @@ func (ms *MongoStorage) DeleteOrganizationMetaKeys(address string, keysToDelete 
 
 	return nil
 }
+
+// IncrementOrganizationUsersCounter atomically increments the users counter for the organization with the given address.
+func (ms *MongoStorage) IncrementOrganizationUsersCounter(address string) error {
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+
+	org, err := ms.Organization(address)
+	if err != nil {
+		return fmt.Errorf("could not get organization: %v", err)
+	}
+
+	// Check if the organization has a subscription
+	if org.Subscription.PlanID == 0 {
+		return fmt.Errorf("organization has no subscription plan")
+	}
+
+	plan, err := ms.Plan(org.Subscription.PlanID)
+	if err != nil {
+		return fmt.Errorf("could not get organization plan: %v", err)
+	}
+
+	if org.Counters.Users >= plan.Organization.Users {
+		return fmt.Errorf("max users reached (%d >= %d)", org.Counters.Users, plan.Organization.Users)
+	}
+
+	// Create a context with a timeout
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	// Prepare the filter to find the organization
+	filter := bson.M{"_id": address}
+
+	// Use the $inc operator to atomically increment the users counter
+	update := bson.M{"$inc": bson.M{"counters.users": 1}}
+
+	// Update the organization in the database
+	result, err := ms.organizations.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return fmt.Errorf("failed to increment users counter: %w", err)
+	}
+
+	if result.MatchedCount == 0 {
+		return fmt.Errorf("no organization found with address: %s", address)
+	}
+
+	return nil
+}
+
+// DecrementOrganizationUsersCounter atomically decrements the users counter for the organization with the given address.
+func (ms *MongoStorage) DecrementOrganizationUsersCounter(address string) error {
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+
+	// Create a context with a timeout
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	// Prepare the filter to find the organization
+	filter := bson.M{"_id": address}
+
+	// Use the $inc operator with a negative value to atomically decrement the users counter
+	update := bson.M{"$inc": bson.M{"counters.users": -1}}
+
+	// Update the organization in the database
+	result, err := ms.organizations.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return fmt.Errorf("failed to decrement users counter: %w", err)
+	}
+
+	if result.MatchedCount == 0 {
+		return fmt.Errorf("no organization found with address: %s", address)
+	}
+
+	return nil
+}
+
+// IncrementOrganizationSubOrgsCounter atomically increments the suborgs counter for the organization with the given address.
+func (ms *MongoStorage) IncrementOrganizationSubOrgsCounter(address string) error {
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+
+	org, err := ms.Organization(address)
+	if err != nil {
+		return fmt.Errorf("could not get organization: %v", err)
+	}
+
+	// Check if the organization has a subscription
+	if org.Subscription.PlanID == 0 {
+		return fmt.Errorf("organization has no subscription plan")
+	}
+
+	plan, err := ms.Plan(org.Subscription.PlanID)
+	if err != nil {
+		return fmt.Errorf("could not get organization plan: %v", err)
+	}
+
+	if org.Counters.SubOrgs >= plan.Organization.SubOrgs {
+		return fmt.Errorf("max suborgs reached (%d >= %d)", org.Counters.SubOrgs, plan.Organization.SubOrgs)
+	}
+
+	// Create a context with a timeout
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	// Prepare the filter to find the organization
+	filter := bson.M{"_id": address}
+
+	// Use the $inc operator to atomically increment the suborgs counter
+	update := bson.M{"$inc": bson.M{"counters.subOrgs": 1}}
+
+	// Update the organization in the database
+	result, err := ms.organizations.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return fmt.Errorf("failed to increment suborgs counter: %w", err)
+	}
+
+	if result.MatchedCount == 0 {
+		return fmt.Errorf("no organization found with address: %s", address)
+	}
+
+	return nil
+}
+
+// DecrementOrganizationSubOrgsCounter atomically decrements the suborgs counter for the organization with the given address.
+func (ms *MongoStorage) DecrementOrganizationSubOrgsCounter(address string) error {
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+
+	// Create a context with a timeout
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	// Prepare the filter to find the organization
+	filter := bson.M{"_id": address}
+
+	// Use the $inc operator with a negative value to atomically decrement the suborgs counter
+	update := bson.M{"$inc": bson.M{"counters.subOrgs": -1}}
+
+	// Update the organization in the database
+	result, err := ms.organizations.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return fmt.Errorf("failed to decrement suborgs counter: %w", err)
+	}
+
+	if result.MatchedCount == 0 {
+		return fmt.Errorf("no organization found with address: %s", address)
+	}
+
+	return nil
+}

--- a/db/organizations_test.go
+++ b/db/organizations_test.go
@@ -250,14 +250,12 @@ func TestOrganizations(t *testing.T) {
 		// Test updating a non-existent user
 		nonExistentUserID := uint64(9999)
 		err = testDB.UpdateOrganizationUserRole(orgAddress, nonExistentUserID, AdminRole)
-		// The function doesn't return an error for non-existent users, it just doesn't update anything
-		c.Assert(err, qt.IsNil)
+		c.Assert(err, qt.ErrorMatches, ".*user has no role in organization.*")
 
 		// Test updating a user for a non-existent organization
 		nonExistentOrgAddress := "nonExistentOrg"
 		err = testDB.UpdateOrganizationUserRole(nonExistentOrgAddress, userID, AdminRole)
-		// The function doesn't return an error for non-existent organizations, it just doesn't update anything
-		c.Assert(err, qt.IsNil)
+		c.Assert(err, qt.ErrorMatches, ".*organization doesn't exist.*")
 
 		// Verify the user's role hasn't changed after the non-existent org update
 		user, err = testDB.User(userID)
@@ -309,7 +307,7 @@ func TestOrganizations(t *testing.T) {
 		nonExistentUserID := uint64(9999)
 		err = testDB.RemoveOrganizationUser(orgAddress, nonExistentUserID)
 		// The function doesn't return an error for non-existent users, it just doesn't remove anything
-		c.Assert(err, qt.IsNil)
+		c.Assert(err, qt.ErrorMatches, ".*user has no role in organization.*")
 
 		// Create another user and add them to multiple organizations
 		secondUserEmail := "seconduser@example.com"

--- a/subscriptions/subscriptions.go
+++ b/subscriptions/subscriptions.go
@@ -157,28 +157,11 @@ func (p *Subscriptions) HasDBPermission(userEmail, orgAddress string, permission
 	if err != nil {
 		return false, fmt.Errorf("could not get user: %v", err)
 	}
-	org, err := p.db.Organization(orgAddress)
-	if err != nil {
-		return false, fmt.Errorf("could not get organization: %v", err)
-	}
-
-	// Check if the organization has a subscription
-	if org.Subscription.PlanID == 0 {
-		return false, fmt.Errorf("organization has no subscription plan")
-	}
-
-	plan, err := p.db.Plan(org.Subscription.PlanID)
-	if err != nil {
-		return false, fmt.Errorf("could not get organization plan: %v", err)
-	}
 	switch permission {
 	case InviteUser:
 		// check if the user has permission to invite users
 		if !user.HasRoleFor(orgAddress, db.AdminRole) {
 			return false, fmt.Errorf("user does not have admin role")
-		}
-		if org.Counters.Users >= plan.Organization.Users {
-			return false, fmt.Errorf("max users reached")
 		}
 		return true, nil
 	case DeleteUser:
@@ -191,9 +174,6 @@ func (p *Subscriptions) HasDBPermission(userEmail, orgAddress string, permission
 		// check if the user has permission to create sub organizations
 		if !user.HasRoleFor(orgAddress, db.AdminRole) {
 			return false, fmt.Errorf("user does not have admin role")
-		}
-		if org.Counters.SubOrgs >= plan.Organization.SubOrgs {
-			return false, fmt.Errorf("max sub organizations reached")
 		}
 		return true, nil
 	}


### PR DESCRIPTION
until now, they succeeded even when nothing was updated, leading to
hard to understand bugs.

* UpdateOrganizationUserRole
* RemoveOrganizationUser
* SetOrganizationSubscription
* AddOrganizationMeta
