### PR TITLE
api(test): dedup code with new funcs requestAndParse, requestAndAssertCode, etc

### DIFF
--- a/api/csp_voting_test.go
+++ b/api/csp_voting_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/csp/handlers"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/internal"
@@ -47,9 +48,8 @@ func TestCSPVoting(t *testing.T) {
 		token := testCreateUser(t, "superpassword123")
 
 		// Verify the token works
-		resp, code := testRequest(t, http.MethodGet, token, nil, usersMeEndpoint)
-		c.Assert(code, qt.Equals, http.StatusOK)
-		t.Logf("User info: %s", resp)
+		user := requestAndParse[apicommon.UserInfo](t, http.MethodGet, token, nil, usersMeEndpoint)
+		t.Logf("User: %+v\n", user)
 
 		// Create a new vocdoni client
 		vocdoniClient := testNewVocdoniClient(t)
@@ -96,8 +96,7 @@ func TestCSPVoting(t *testing.T) {
 			signRemoteSignerAndSendVocdoniTx(t, &tx, token, vocdoniClient, orgAddress)
 
 			// Verify the organization was created
-			resp, code = testRequest(t, http.MethodGet, token, nil, "organizations", orgAddress.String())
-			c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+			requestAndAssertCode(http.StatusOK, t, http.MethodGet, token, nil, "organizations", orgAddress.String())
 		})
 
 		// Create a process for the organization

--- a/api/organization_meta_test.go
+++ b/api/organization_meta_test.go
@@ -16,17 +16,15 @@ func TestOrganizationMeta(t *testing.T) {
 	adminToken := testCreateUser(t, "adminpassword123")
 
 	// Verify the token works
-	resp, code := testRequest(t, http.MethodGet, adminToken, nil, usersMeEndpoint)
-	c.Assert(code, qt.Equals, http.StatusOK)
-	t.Logf("Admin user: %s\n", resp)
+	user := requestAndParse[apicommon.UserInfo](t, http.MethodGet, adminToken, nil, usersMeEndpoint)
+	t.Logf("Admin user: %+v\n", user)
 
 	// Create an organization
 	orgAddress := testCreateOrganization(t, adminToken)
 	t.Logf("Created organization with address: %s\n", orgAddress)
 
 	// Get the organization to verify it exists
-	resp, code = testRequest(t, http.MethodGet, adminToken, nil, "organizations", orgAddress.String())
-	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+	requestAndAssertCode(http.StatusOK, t, http.MethodGet, adminToken, nil, "organizations", orgAddress.String())
 
 	// Test 1: Add organization meta
 	// Test 1.1: Test with valid data
@@ -39,12 +37,11 @@ func TestOrganizationMeta(t *testing.T) {
 			"public":   true,
 		},
 	}
-	resp, code = testRequest(t, http.MethodPost, adminToken, metaInfo, "organizations", orgAddress.String(), "meta")
+	resp, code := testRequest(t, http.MethodPost, adminToken, metaInfo, "organizations", orgAddress.String(), "meta")
 	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 
 	// Test 1.2: Test with no authentication
-	_, code = testRequest(t, http.MethodPost, "", metaInfo, "organizations", orgAddress.String(), "meta")
-	c.Assert(code, qt.Equals, http.StatusUnauthorized)
+	requestAndAssertCode(http.StatusUnauthorized, t, http.MethodPost, "", metaInfo, "organizations", orgAddress.String(), "meta")
 
 	// Test 1.3: Test with invalid organization address
 	_, code = testRequest(t, http.MethodPost, adminToken, metaInfo, "organizations", "invalid-address", "meta")
@@ -302,7 +299,7 @@ func TestOrganizationMeta(t *testing.T) {
 
 	// Verify the token works
 	resp, code = testRequest(t, http.MethodGet, managerToken, nil, usersMeEndpoint)
-	c.Assert(code, qt.Equals, http.StatusOK)
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 	t.Logf("Manager user: %s\n", resp)
 
 	// Test 6.1: Test that the manager can't access the organization meta initially

--- a/api/organization_users_test.go
+++ b/api/organization_users_test.go
@@ -23,7 +23,7 @@ func TestOrganizationUsers(t *testing.T) {
 
 	// Verify the token works
 	resp, code := testRequest(t, http.MethodGet, adminToken, nil, usersMeEndpoint)
-	c.Assert(code, qt.Equals, http.StatusOK)
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 	t.Logf("Admin user: %s\n", resp)
 
 	// Create an organization
@@ -39,7 +39,7 @@ func TestOrganizationUsers(t *testing.T) {
 
 	// Get the second user's info
 	resp, code = testRequest(t, http.MethodGet, userToken, nil, usersMeEndpoint)
-	c.Assert(code, qt.Equals, http.StatusOK)
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 
 	var userInfo apicommon.UserInfo
 	err := parseJSON(resp, &userInfo)
@@ -336,7 +336,7 @@ func TestOrganizationUsers(t *testing.T) {
 		// Test 6: Try to update a non-existent user
 		// Note: The current implementation returns 200 OK even for non-existent users
 		// because the MongoDB UpdateOne operation doesn't return an error if no documents match
-		_, code = testRequest(
+		resp, code = testRequest(
 			t,
 			http.MethodPut,
 			adminToken,
@@ -346,7 +346,7 @@ func TestOrganizationUsers(t *testing.T) {
 			"users",
 			"999999",
 		)
-		c.Assert(code, qt.Equals, http.StatusOK)
+		c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 	})
 
 	t.Run("RemoveOrganizationUser", func(t *testing.T) {
@@ -357,7 +357,7 @@ func TestOrganizationUsers(t *testing.T) {
 		// Create a user to be removed
 		userToRemoveToken := testCreateUser(t, "removepassword123")
 		resp, code = testRequest(t, http.MethodGet, userToRemoveToken, nil, usersMeEndpoint)
-		c.Assert(code, qt.Equals, http.StatusOK)
+		c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 
 		var userToRemoveInfo apicommon.UserInfo
 		err := parseJSON(resp, &userToRemoveInfo)
@@ -487,7 +487,7 @@ func TestOrganizationUsers(t *testing.T) {
 		// Test 4: Try to remove a non-existent user
 		// Note: The current implementation returns 200 OK even for non-existent users
 		// because the MongoDB UpdateOne operation doesn't return an error if no documents match
-		_, code = testRequest(
+		resp, code = testRequest(
 			t,
 			http.MethodDelete,
 			adminToken,
@@ -497,7 +497,7 @@ func TestOrganizationUsers(t *testing.T) {
 			"users",
 			"999999",
 		)
-		c.Assert(code, qt.Equals, http.StatusOK)
+		c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 
 		// Test 5: Try to remove yourself (which should fail)
 		// Get the admin's user ID
@@ -508,7 +508,7 @@ func TestOrganizationUsers(t *testing.T) {
 			nil,
 			usersMeEndpoint,
 		)
-		c.Assert(code, qt.Equals, http.StatusOK)
+		c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 
 		var adminInfo apicommon.UserInfo
 		err = parseJSON(resp, &adminInfo)
@@ -687,7 +687,7 @@ func TestOrganizationUsers(t *testing.T) {
 			"users",
 			"pending",
 		)
-		c.Assert(code, qt.Equals, http.StatusOK)
+		c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 
 		var anotherPendingInvites apicommon.OrganizationInviteList
 		err = parseJSON(resp, &anotherPendingInvites)
@@ -712,7 +712,7 @@ func TestOrganizationUsers(t *testing.T) {
 		c.Assert(code, qt.Not(qt.Equals), http.StatusOK)
 
 		// Clean up: Delete the invitations
-		_, code = testRequest(
+		resp, code = testRequest(
 			t,
 			http.MethodDelete,
 			adminToken,
@@ -723,9 +723,9 @@ func TestOrganizationUsers(t *testing.T) {
 			"pending",
 			invitationID,
 		)
-		c.Assert(code, qt.Equals, http.StatusOK)
+		c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 
-		_, code = testRequest(
+		resp, code = testRequest(
 			t,
 			http.MethodDelete,
 			adminToken,
@@ -736,7 +736,7 @@ func TestOrganizationUsers(t *testing.T) {
 			"pending",
 			anotherInvitationID,
 		)
-		c.Assert(code, qt.Equals, http.StatusOK)
+		c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 	})
 
 	t.Run("DeletePendingInvitation", func(t *testing.T) {
@@ -893,7 +893,7 @@ func TestOrganizationUsers(t *testing.T) {
 			"users",
 			"pending",
 		)
-		c.Assert(code, qt.Equals, http.StatusOK)
+		c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 
 		var anotherPendingInvites apicommon.OrganizationInviteList
 		err = parseJSON(resp, &anotherPendingInvites)
@@ -918,7 +918,7 @@ func TestOrganizationUsers(t *testing.T) {
 		c.Assert(code, qt.Not(qt.Equals), http.StatusOK)
 
 		// Clean up: Delete the invitation from the correct organization
-		_, code = testRequest(
+		resp, code = testRequest(
 			t,
 			http.MethodDelete,
 			adminToken,
@@ -929,7 +929,7 @@ func TestOrganizationUsers(t *testing.T) {
 			"pending",
 			anotherInvitationID,
 		)
-		c.Assert(code, qt.Equals, http.StatusOK)
+		c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 	})
 
 	t.Run("MaxUsersReached", func(t *testing.T) {

--- a/api/stripe_test.go
+++ b/api/stripe_test.go
@@ -28,14 +28,10 @@ func TestStripeAPI(t *testing.T) {
 				Locale:    "en",
 			}
 
-			resp, status := testRequest(t, http.MethodPost, token, checkoutReq, "subscriptions", "checkout")
-			c.Assert(status, qt.Equals, http.StatusBadRequest, qt.Commentf("response: %s", resp))
-
+			errorResp := requestAndParseWithAssertCode[apiError](http.StatusBadRequest, t, http.MethodPost, token, checkoutReq,
+				"subscriptions", "checkout")
 			// Verify the error message indicates missing required fields
-			var errorResp map[string]any
-			err := json.Unmarshal(resp, &errorResp)
-			c.Assert(err, qt.IsNil)
-			c.Assert(errorResp["error"], qt.Contains, "Missing required fields")
+			c.Assert(errorResp.Error, qt.Contains, "Missing required fields")
 		})
 
 		t.Run("ValidAddress", func(t *testing.T) {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -27,13 +27,13 @@ func (e Error) MarshalJSON() ([]byte, error) {
 	// since it wouldn't be marshaled otherwise. (json.Marshal doesn't call Err.Error())
 	return json.Marshal(
 		struct {
-			Err  string `json:"error"`
-			Code int    `json:"code"`
-			Data any    `json:"data,omitempty"`
+			Error string `json:"error"`
+			Code  int    `json:"code"`
+			Data  any    `json:"data,omitempty"`
 		}{
-			Err:  e.Err.Error(),
-			Code: e.Code,
-			Data: e.Data,
+			Error: e.Err.Error(),
+			Code:  e.Code,
+			Data:  e.Data,
 		})
 }
 


### PR DESCRIPTION
this greatly simplifies the code, and always having `qt.Commentf(resp)` makes debugging regressions much easier