### PR TITLE
api: more granular permissions (Organization vs Process)

### DIFF
--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -106,8 +106,11 @@ type OrganizationRole struct {
 	// Human-readable name of the role
 	Name string `json:"name"`
 
-	// Whether this role has write permissions
-	WritePermission bool `json:"writePermission"`
+	// Whether this role has organization write permission
+	OrganizationWritePermission bool `json:"organizationWritePermission"`
+
+	// Whether this role has process write permission
+	ProcessWritePermission bool `json:"processWritePermission"`
 }
 
 // OrganizationRoleList represents a list of organization roles.

--- a/api/auth.go
+++ b/api/auth.go
@@ -123,9 +123,9 @@ func (*API) writableOrganizationAddressesHandler(w http.ResponseWriter, r *http.
 	}
 	// get the addresses of the organizations where the user has write access
 	for _, org := range user.Organizations {
-		// check if the user has write access to the organization based on the
+		// check if the user has organization write permission to the organization based on the
 		// role of the user in the organization
-		if db.HasWriteAccess(org.Role) {
+		if db.HasOrganizationWritePermission(org.Role) {
 			userAddresses.Addresses = append(userAddresses.Addresses, org.Address)
 		}
 	}

--- a/api/organization_users.go
+++ b/api/organization_users.go
@@ -529,9 +529,10 @@ func (*API) organizationRolesHandler(w http.ResponseWriter, _ *http.Request) {
 	availableRoles := []*apicommon.OrganizationRole{}
 	for role, name := range db.UserRolesNames {
 		availableRoles = append(availableRoles, &apicommon.OrganizationRole{
-			Role:            string(role),
-			Name:            name,
-			WritePermission: db.HasWriteAccess(role),
+			Role:                        string(role),
+			Name:                        name,
+			OrganizationWritePermission: db.HasOrganizationWritePermission(role),
+			ProcessWritePermission:      db.HasProcessWritePermission(role),
 		})
 	}
 	apicommon.HTTPWriteJSON(w, &apicommon.OrganizationRoleList{Roles: availableRoles})

--- a/db/const.go
+++ b/db/const.go
@@ -22,8 +22,15 @@ const (
 	CodeTypeOrgInviteUpdate CodeType = "organization_invite_update"
 )
 
-// writableRoles is a map that contains if the role is writable or not
-var writableRoles = map[UserRole]bool{
+// organizationWritePermissions is a map that contains if the role has organization write permission
+var organizationWritePermissions = map[UserRole]bool{
+	AdminRole:   true,
+	ManagerRole: false,
+	ViewerRole:  false,
+}
+
+// processWritePermissions is a map that contains if the role has process write permission
+var processWritePermissions = map[UserRole]bool{
 	AdminRole:   true,
 	ManagerRole: true,
 	ViewerRole:  false,
@@ -36,9 +43,14 @@ var UserRolesNames = map[UserRole]string{
 	ViewerRole:  "Viewer",
 }
 
-// HasWriteAccess function checks if the user role has write access
-func HasWriteAccess(role UserRole) bool {
-	return writableRoles[role]
+// HasOrganizationWritePermission function checks if the user role has organization write permission
+func HasOrganizationWritePermission(role UserRole) bool {
+	return organizationWritePermissions[role]
+}
+
+// HasProcessWritePermission function checks if the user role has process write permission
+func HasProcessWritePermission(role UserRole) bool {
+	return processWritePermissions[role]
 }
 
 // validOrganizationTypes is a map that contains the valid organization types

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -482,12 +482,15 @@ definitions:
       name:
         description: Human-readable name of the role
         type: string
+      organizationWritePermission:
+        description: Whether this role has organization write permission
+        type: boolean
+      processWritePermission:
+        description: Whether this role has process write permission
+        type: boolean
       role:
         description: Role identifier
         type: string
-      writePermission:
-        description: Whether this role has write permissions
-        type: boolean
     type: object
   apicommon.OrganizationRoleList:
     properties:


### PR DESCRIPTION
## Naming Consistency Improvements:

- Used consistent "Permission" terminology instead of mixing "Access" and "Permission"
- Used singular "Process" instead of plural "Processes" for consistency with "Organization"
- Clear, descriptive variable and function names throughout

## API Response Example:

```json
{
  "roles": [
    {
      "role": "admin",
      "name": "Admin",
      "organizationWritePermission": true,
      "processWritePermission": true
    },
    {
      "role": "manager", 
      "name": "Manager",
      "organizationWritePermission": false,
      "processWritePermission": true
    },
    {
      "role": "viewer",
      "name": "Viewer", 
      "organizationWritePermission": false,
      "processWritePermission": false
    }
  ]
}
```
