### PR TITLE
partially revert "db: Minor fixes to avoid prevent exception in case a `setBulkCensusParticipant` is intended without members"

### DIFF
--- a/db/org_members.go
+++ b/db/org_members.go
@@ -568,6 +568,13 @@ func (ms *MongoStorage) orgMembersByIDs(
 		"orgAddress": orgAddress,
 	}
 
+	// Count total documents
+	totalCount, err := ms.orgMembers.CountDocuments(ctx, filter)
+	if err != nil {
+		return 0, nil, err
+	}
+	totalPages := int(math.Ceil(float64(totalCount) / float64(pageSize)))
+
 	// Calculate skip value based on page and pageSize
 	skip := (page - 1) * pageSize
 
@@ -580,7 +587,6 @@ func (ms *MongoStorage) orgMembersByIDs(
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to find org members: %w", err)
 	}
-	totalPages := int(math.Ceil(float64(cursor.RemainingBatchLength()) / float64(pageSize)))
 	defer func() {
 		if err := cursor.Close(ctx); err != nil {
 			log.Warnw("error closing cursor", "error", err)


### PR DESCRIPTION
if pageSize=1, cursor.RemainingBatchLength() returns 1 because of the		SetLimit(pageSize)

we can't avoid calculating totalCount using CountDocuments