### PR TITLE
refactor(csp): Added MaxVoteOverwritesPerProcess constant to define the limit of vote changes

### DIFF
--- a/csp/handlers/handlers.go
+++ b/csp/handlers/handlers.go
@@ -332,16 +332,16 @@ func (c *CSPHandlers) ConsumedAddressHandler(w http.ResponseWriter, r *http.Requ
 		errors.ErrUnauthorized.WithErr(err).Write(w)
 		return
 	}
-	// check if the process has been consumed and return error if not
-	if !cspProcess.Consumed {
+	// check if the address has voted at least one time and return error if not
+	if !cspProcess.Used {
 		errors.ErrUserNoVoted.Write(w)
 		return
 	}
 	// return the address used to sign the process and the nullifier
 	apicommon.HTTPWriteJSON(w, &ConsumedAddressResponse{
-		Address:   cspProcess.ConsumedAddress,
-		Nullifier: state.GenerateNullifier(common.BytesToAddress(cspProcess.ConsumedAddress), *processID),
-		At:        cspProcess.ConsumedAt,
+		Address:   cspProcess.UsedAddress,
+		Nullifier: state.GenerateNullifier(common.BytesToAddress(cspProcess.UsedAddress), *processID),
+		At:        cspProcess.UsedAt,
 	})
 }
 

--- a/csp/handlers/types.go
+++ b/csp/handlers/types.go
@@ -50,16 +50,16 @@ type SignRequest struct {
 }
 
 // ConsumedAddressRequest defines the payload for the request to get the
-// if a token was consumed and which address was used. It includes the
+// if a token was used and which address was used. It includes the
 // authToken to query the information.
 type ConsumedAddressRequest struct {
 	AuthToken internal.HexBytes `json:"authToken" swaggertype:"string" format:"hex" example:"deadbeef"`
 }
 
 // ConsumedAddressResponse defines the payload for the response to the
-// request to get the if a token was consumed and which address was used.
+// request to get the if a token was used and which address was used.
 // It includes the address, the nullifier, and the timestamp of the
-// consumption.
+// usage.
 type ConsumedAddressResponse struct {
 	Address   internal.HexBytes `json:"authToken" swaggertype:"string" format:"hex" example:"deadbeef"`
 	Nullifier internal.HexBytes `json:"nullifier" swaggertype:"string" format:"hex" example:"deadbeef"`

--- a/csp/sign_test.go
+++ b/csp/sign_test.go
@@ -113,7 +113,9 @@ func TestPrepareSaltedKeySigner(t *testing.T) {
 		// verify the token
 		c.Assert(csp.Storage.VerifyCSPAuth(testToken), qt.IsNil)
 		// consume the process
-		c.Assert(csp.Storage.ConsumeCSPProcess(testToken, testPID, testAddress), qt.IsNil)
+		for i := 0; i <= 10; i++ {
+			c.Assert(csp.Storage.ConsumeCSPProcess(testToken, testPID, testAddress), qt.IsNil)
+		}
 		_, _, _, err := csp.prepareSaltedKeySigner(testToken, testAddress, testPID)
 		c.Assert(err, qt.ErrorIs, ErrProcessAlreadyConsumed)
 	})
@@ -212,10 +214,11 @@ func TestFinishSaltedKeySigner(t *testing.T) {
 
 		status, err := csp.Storage.CSPProcess(testToken, testPID)
 		c.Assert(err, qt.IsNil)
-		c.Assert(status.Consumed, qt.IsTrue)
-		c.Assert(status.ConsumedToken, qt.DeepEquals, testToken)
-		c.Assert(status.ConsumedAddress, qt.DeepEquals, testAddress)
-		c.Assert(status.ConsumedAt.IsZero(), qt.IsFalse)
-		c.Assert(status.ConsumedAt.After(time.Now().Add(-time.Second)), qt.IsTrue)
+		c.Assert(status.Used, qt.IsTrue)
+		c.Assert(status.UsedToken, qt.DeepEquals, testToken)
+		c.Assert(status.UsedAddress, qt.DeepEquals, testAddress)
+		c.Assert(status.UsedAt.IsZero(), qt.IsFalse)
+		c.Assert(status.UsedAt.After(time.Now().Add(-time.Second)), qt.IsTrue)
+		c.Assert(status.TimesVoted, qt.Equals, 1)
 	})
 }

--- a/db/const.go
+++ b/db/const.go
@@ -23,6 +23,8 @@ const (
 
 	// max census size allowed for user test purposes
 	TestMaxCensusSize = 10
+	// max vote overwrites per process
+	MaxVoteOverwritesPerProcess = 10
 )
 
 // organizationWritePermissions is a map that contains if the role has organization write permission


### PR DESCRIPTION
Closes https://github.com/vocdoni/saas-backend/issues/243

* Changed terminology from "consumed" to "used" for voting
Replace "consumed" terminology with "used" across handlers, types, and database models to better represent the voting process. This change allows voters to modify their votes up to 10 times per process, adding support for vote overwrites rather than one-time-only voting.
* This pull request updates the CSP (Cryptographic Service Provider) voting process to support multiple votes (up to a maximum), replaces the "consumed" terminology with "used" for clarity, and enforces stricter validation on address reuse. The changes also update related data models, handlers, and tests to reflect this new logic.

**Voting process enhancements:**

* Introduced a `TimesVoted` field in the `CSPProcess` struct to track the number of votes per process, and replaced `Consumed` fields with `Used` fields for improved clarity (`db/csp.go`, `db/csp_test.go`, `csp/handlers/types.go`). [[1]](diffhunk://#diff-4f8d80701a83a9feae44b3cd998d2a9dc8ce04fdd98932a39be6aba820063815L30-R34) [[2]](diffhunk://#diff-704cf1ff9c36d98e7f0f59baffe7306fa6fa897ccaee05142fd72272c2887be4L122-R152) [[3]](diffhunk://#diff-3f6ff3740ebe9ab0e1390f739bb3f351372206a8169e8064654981df326bda22L53-R62)
* Enforced a maximum number of votes per process (`MaxVoteOverwritesPerProcess = 10`), returning an error if this limit is exceeded (`db/const.go`, `db/csp.go`). [[1]](diffhunk://#diff-e26fe96fb16861a2c8eb67b58f6bf5b3af0f4a1dfd6bb9a2c2b08b3cd4447aeaR23-R24) [[2]](diffhunk://#diff-4f8d80701a83a9feae44b3cd998d2a9dc8ce04fdd98932a39be6aba820063815L161-R169) [[3]](diffhunk://#diff-4f8d80701a83a9feae44b3cd998d2a9dc8ce04fdd98932a39be6aba820063815L198-R219)

**Validation improvements:**

* Added a check to ensure that all votes for a process must use the same address; attempts to vote with a different address now return an error (`db/csp.go`, `db/csp_test.go`). [[1]](diffhunk://#diff-4f8d80701a83a9feae44b3cd998d2a9dc8ce04fdd98932a39be6aba820063815L198-R219) [[2]](diffhunk://#diff-704cf1ff9c36d98e7f0f59baffe7306fa6fa897ccaee05142fd72272c2887be4L122-R152)

**API and handler updates:**

* Updated the `ConsumedAddressHandler` and related request/response types to use the new "used" terminology and logic, ensuring responses reflect the new fields (`csp/handlers/handlers.go`, `csp/handlers/types.go`). [[1]](diffhunk://#diff-159e215050988e1a4ff8f24fb514a2d55f5909ff7b415086c8b3214211a48331L335-R344) [[2]](diffhunk://#diff-3f6ff3740ebe9ab0e1390f739bb3f351372206a8169e8064654981df326bda22L53-R62)

**Test updates:**

* Revised and expanded tests to cover the new voting logic, address validation, and error handling for exceeding the vote limit (`db/csp_test.go`, `csp/sign_test.go`). [[1]](diffhunk://#diff-704cf1ff9c36d98e7f0f59baffe7306fa6fa897ccaee05142fd72272c2887be4L122-R152) [[2]](diffhunk://#diff-9639df898ec1dbdf725cf9f18779bdc17e6fb7a27d709382537391416d55429fR116-R118) [[3]](diffhunk://#diff-9639df898ec1dbdf725cf9f18779bdc17e6fb7a27d709382537391416d55429fL215-R221)