### PR TITLE
feat: implement flexible 2FA authentication with email OR phone support

### DIFF
--- a/csp/handlers/handlers.go
+++ b/csp/handlers/handlers.go
@@ -509,11 +509,13 @@ func (c *CSPHandlers) authFirstStep(
 		Phone:        phone,
 	}
 
-	// Get participant information using the already retrieved census
-	loginHash := db.HashAuthTwoFaFields(*inputMember, census.AuthFields, census.TwoFaFields)
-
 	// Check the participant is in the census
-	censuParticipant, err := c.mainDB.CensusParticipantByLoginHash(censusID, loginHash)
+	censusParticipant, err := c.mainDB.CensusParticipantByLoginHashOrEmailorPhone(
+		censusID,
+		census.AuthFields,
+		census.TwoFaFields,
+		*inputMember,
+	)
 	if err != nil {
 		if err == db.ErrNotFound {
 			return nil, errors.ErrUnauthorized.Withf("participant not found in the census")
@@ -522,7 +524,7 @@ func (c *CSPHandlers) authFirstStep(
 	}
 
 	// Fetch the corresponding org member using the participant ID (which is the ObjectID hex string)
-	orgMember, err := c.mainDB.OrgMember(census.OrgAddress, censuParticipant.ParticipantID)
+	orgMember, err := c.mainDB.OrgMember(census.OrgAddress, censusParticipant.ParticipantID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get org member: %w", err)
 	}

--- a/db/helpers.go
+++ b/db/helpers.go
@@ -278,6 +278,24 @@ func (ms *MongoStorage) createIndexes() error {
 	}); err != nil {
 		return fmt.Errorf("failed to create index on censusId and loginHash for censusParticipants: %w", err)
 	}
+	// index for the censusId and loginhashPhone
+	if _, err := ms.censusParticipants.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "censusId", Value: 1},       // 1 for ascending order
+			{Key: "loginHashPhone", Value: 1}, // 1 for ascending order
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to create index on censusId and loginHashPhone for censusParticipants: %w", err)
+	}
+	// index for the censusId and loginhashEmail
+	if _, err := ms.censusParticipants.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "censusId", Value: 1},       // 1 for ascending order
+			{Key: "loginHashEmail", Value: 1}, // 1 for ascending order
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to create index on censusId and loginHashEmail for censusParticipants: %w", err)
+	}
 
 	// unique index over userID and processID
 	if _, err := ms.cspTokensStatus.Indexes().CreateOne(ctx, mongo.IndexModel{

--- a/db/types.go
+++ b/db/types.go
@@ -322,12 +322,16 @@ type OrganizationMemberGroup struct {
 
 // Relates an OrgMember to a Census
 // The censusID is the hex format in string of the objectID
+//
+//nolint:lll
 type CensusParticipant struct {
-	ParticipantID string    `json:"participantID" bson:"participantID"`
-	CensusID      string    `json:"censusId" bson:"censusId"`
-	LoginHash     []byte    `json:"loginHash" bson:"loginHash" swaggertype:"string" format:"base64" example:"aGVsbG8gd29ybGQ="`
-	CreatedAt     time.Time `json:"createdAt" bson:"createdAt"`
-	UpdatedAt     time.Time `json:"updatedAt" bson:"updatedAt"`
+	ParticipantID  string    `json:"participantID" bson:"participantID"`
+	CensusID       string    `json:"censusId" bson:"censusId"`
+	LoginHash      []byte    `json:"loginHash" bson:"loginHash" swaggertype:"string" format:"base64" example:"aGVsbG8gd29ybGQ="`
+	LoginHashPhone []byte    `json:"loginHashPhone" bson:"loginHashPhone" swaggertype:"string" format:"base64" example:"aGVsbG8gd29ybGQ="`
+	LoginHashEmail []byte    `json:"loginHashEmail" bson:"loginHashEmail" swaggertype:"string" format:"base64" example:"aGVsbG8gd29ybGQ="`
+	CreatedAt      time.Time `json:"createdAt" bson:"createdAt"`
+	UpdatedAt      time.Time `json:"updatedAt" bson:"updatedAt"`
 }
 
 // Represents a published census as a census is represented in the vochain


### PR DESCRIPTION
Database Schema Enhancements:
- Add `LoginHashPhone` and `LoginHashEmail` fields to `CensusParticipant` struct
- Create MongoDB indexes for efficient lookups on `loginHashPhone` and `loginHashEmail`
- Store separate hashes for email-only and phone-only authentication scenarios

Authentication Logic Improvements:

- Implement `CensusParticipantByLoginHashOrEmailorPhone()` method for flexible participant lookup
- Allow authentication with either email OR phone when both are configured as 2FA methods
- Maintain backward compatibility with existing single-method 2FA configurations

Technical Implementation:

- Modified bulk census participant operations to generate separate hashes when both 2FA methods are available
- Updated authentication handler to use new flexible lookup method
- Fallback logic ensures users can authenticate with available contact method