### PR TITLE
chore(docker-compose): enable file watch

### DIFF
--- a/dev.dockerfile
+++ b/dev.dockerfile
@@ -1,0 +1,30 @@
+# Dev image for local development with `go run`
+FROM golang:1.24
+
+WORKDIR /src
+
+# Enable CGO and set caches
+ENV CGO_ENABLED=1 \
+    GOCACHE=/go-cache \
+    GOPATH=/go
+
+# Native dependencies required by rapidsnark/wasmer, TLS, etc.
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+      libc6-dev libomp-dev openmpi-common libgomp1 ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/*
+
+# Pre-warm module cache to speed up first run
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go-cache go mod download
+
+# Optional: copy the code so the container can run without compose-watch.
+# When using `docker compose watch`, your code will be synced over this path.
+COPY . .
+
+# Ensure the dynamic linker can find Wasmer's shared library used by wasmer-go
+ENV WASMER_PATH=/go/pkg/mod/github.com/wasmerio/wasmer-go@v1.0.4/wasmer/packaged/lib/linux-amd64
+ENV LD_LIBRARY_PATH=${WASMER_PATH}
+
+# Default command for dev: run the service directly
+CMD ["go", "run", "./cmd/service/main.go"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - VOCDONI_MONGOURL=mongodb://root:vocdoni@mongo:27017/saasdb
     build:
       context: ./
+      dockerfile: dev.dockerfile
+
     ports:
       - ${VOCDONI_PORT}:${VOCDONI_PORT}
     sysctls:
@@ -17,6 +19,13 @@ services:
     depends_on:
       - mongo
 
+    develop:
+      watch:
+        - action: sync+restart
+          path: .
+          target: /src
+          ignore:
+            - .git
   mongo:
     image: mongo
     restart: ${RESTART:-unless-stopped}
@@ -26,7 +35,6 @@ services:
       - MONGO_INITDB_ROOT_USERNAME=root
       - MONGO_INITDB_ROOT_PASSWORD=vocdoni
       - MONGO_INITDB_DATABASE=saasdb
-
     volumes:
       - mongodb:/data/mongodb
 
@@ -42,6 +50,3 @@ services:
 
 volumes:
   mongodb: {}
-
-
-


### PR DESCRIPTION
When running `docker compose up` (non detached ofc) you'll see you can enable watch via pressing `w`.
