### PR TITLE
api: limit creation of process drafts

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/vocdoni/saas-backend/csp"
 	"github.com/vocdoni/saas-backend/csp/handlers"
 	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/errors"
 	"github.com/vocdoni/saas-backend/internal"
 	"github.com/vocdoni/saas-backend/migrations"
 	"github.com/vocdoni/saas-backend/notifications/smtp"
@@ -83,7 +84,7 @@ var (
 			MaxCensus:    50,
 			MaxDuration:  7,
 			CustomURL:    false,
-			Drafts:       false,
+			MaxDrafts:    0,
 			CustomPlan:   false,
 		},
 		VotingTypes: db.VotingTypes{
@@ -123,7 +124,7 @@ var (
 			MaxCensus:    10000,
 			MaxDuration:  90,
 			CustomURL:    false,
-			Drafts:       true,
+			MaxDrafts:    5,
 			CustomPlan:   false,
 		},
 		VotingTypes: db.VotingTypes{
@@ -163,7 +164,7 @@ var (
 			MaxCensus:    20000,
 			MaxDuration:  180,
 			CustomURL:    false,
-			Drafts:       false,
+			MaxDrafts:    10,
 		},
 		VotingTypes: db.VotingTypes{
 			Single:     true,
@@ -768,4 +769,12 @@ func requestAndParseWithAssertCode[T any](expectedCode int, t *testing.T, method
 func requestAndAssertCode(expectedCode int, t *testing.T, method, jwt string, jsonBody any, urlPath ...string) {
 	resp, code := testRequest(t, method, jwt, jsonBody, urlPath...)
 	qt.Assert(t, code, qt.Equals, expectedCode, qt.Commentf("response: %s", resp))
+}
+
+// requestAndAssertError makes a request and asserts the expected response matches error.
+// It takes the expected status code as the first parameter, followed by the same parameters as testRequest.
+func requestAndAssertError(expectedError errors.Error, t *testing.T, method, jwt string, jsonBody any, urlPath ...string) {
+	errResp := requestAndParseWithAssertCode[errors.Error](expectedError.HTTPstatus,
+		t, method, jwt, jsonBody, urlPath...)
+	qt.Assert(t, errResp.Code, qt.Equals, expectedError.Code)
 }

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -533,8 +533,8 @@ type SubscriptionPlanLimits struct {
 	// Whether custom URLs are allowed
 	CustomURL bool `json:"customURL"`
 
-	// Whether draft processes allowed
-	Drafts bool `json:"drafts"`
+	// How many draft processes are allowed
+	MaxDrafts int `json:"drafts"`
 
 	// Whether this is a custom plan
 	CustomPlan bool `json:"customPlan"`

--- a/db/types.go
+++ b/db/types.go
@@ -87,7 +87,7 @@ type PlanLimits struct {
 	// Max process duration in days
 	MaxDuration int  `json:"maxDaysDuration" bson:"maxDuration"`
 	CustomURL   bool `json:"customURL" bson:"customURL"`
-	Drafts      bool `json:"drafts" bson:"drafts"`
+	MaxDrafts   int  `json:"drafts" bson:"drafts"`
 	CustomPlan  bool `json:"customPlan" bson:"customPlan"`
 }
 

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -780,8 +780,8 @@ definitions:
         description: Whether custom URLs are allowed
         type: boolean
       drafts:
-        description: Whether draft processes allowed
-        type: boolean
+        description: How many draft processes are allowed
+        type: integer
       maxCensus:
         description: Maximum number of census allowed
         type: integer
@@ -1097,7 +1097,7 @@ definitions:
       customURL:
         type: boolean
       drafts:
-        type: boolean
+        type: integer
       maxCensus:
         type: integer
       maxDaysDuration:

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -73,6 +73,7 @@ var (
 	// Subscription errors (400)
 	ErrOrganizationSubscriptionInactive = Error{Code: 40021, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("organization subscription is not active")}
 	ErrNoDefaultPlan                    = Error{Code: 40022, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("no default plan available")}
+	ErrMaxDraftsReached                 = Error{Code: 40031, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("max drafts reached")}
 
 	// Server errors (500) - These should be used sparingly and only for true internal errors
 	ErrMarshalingServerJSONFailed  = Error{Code: 50001, HTTPstatus: http.StatusInternalServerError, Err: fmt.Errorf("server error: failed to process response"), LogLevel: "error"}

--- a/subscriptions/subscriptions_test.go
+++ b/subscriptions/subscriptions_test.go
@@ -204,3 +204,7 @@ func (m *mockMongoStorage) OrganizationWithParent(address common.Address) (
 	}
 	return org, nil, nil
 }
+
+func (*mockMongoStorage) CountProcesses(_ common.Address, _ db.DraftFilter) (int64, error) {
+	return 0, nil
+}


### PR DESCRIPTION
    api: limit creation of process drafts
    
    * extend TestDraftProcess to check limits enforcement
    
    * cleanup leftovers introduced in "api: support creating a draft process"
