### PR TITLE
Refactor Process model: separate database ID from blockchain address

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -334,8 +334,8 @@ func (a *API) initRouter() http.Handler {
 		log.Infow("new route", "method", "GET", "path", censusParticipantsEndpoint)
 		r.Get(censusParticipantsEndpoint, a.censusParticipantsHandler)
 		// PROCESS ROUTES
-		log.Infow("new route", "method", "POST", "path", processEndpoint)
-		r.Post(processEndpoint, a.createProcessHandler)
+		log.Infow("new route", "method", "POST", "path", processCreateEndpoint)
+		r.Post(processCreateEndpoint, a.createProcessHandler)
 		// PROCESS BUNDLE ROUTES (private)
 		log.Infow("new route", "method", "POST", "path", processBundleEndpoint)
 		r.Post(processBundleEndpoint, a.createProcessBundleHandler)

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -956,18 +956,18 @@ type AddMembersJobResponse struct {
 // CreateProcessRequest defines the payload for creating a new voting process.
 // swagger:model CreateProcessRequest
 type CreateProcessRequest struct {
-	// Merkle root of the published census
-	PublishedCensusRoot internal.HexBytes `json:"censusRoot" swaggertype:"string" format:"hex" example:"deadbeef"`
+	// Organization address
+	OrgAddress common.Address `json:"orgAddress"`
 
-	// URI of the published census
-	PublishedCensusURI string `json:"censusUri"`
+	// Vochain ID/Address of the process
+	Address internal.HexBytes `json:"address" swaggertype:"string" format:"hex" example:"deadbeef"`
 
 	// Census ID
 	CensusID internal.HexBytes `json:"censusId" swaggertype:"string" format:"hex" example:"deadbeef"`
 
 	// Additional metadata for the process
 	// Can be any key-value pairs
-	Metadata []byte `json:"metadata,omitempty" swaggertype:"string" format:"base64" example:"aGVsbG8gd29ybGQ="`
+	Metadata map[string]any `json:"metadata"`
 }
 
 // InitiateAuthRequest defines the payload for participant authentication.
@@ -1043,7 +1043,7 @@ type CreateProcessBundleRequest struct {
 	// Census ID
 	CensusID string `json:"censusId"`
 
-	// List of process IDs to include in the bundle
+	// List of process Addresses to include in the bundle
 	Processes []string `json:"processes"`
 }
 

--- a/api/process.go
+++ b/api/process.go
@@ -8,7 +8,7 @@ import (
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
-	"github.com/vocdoni/saas-backend/internal"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 // createProcessHandler godoc
@@ -19,30 +19,24 @@ import (
 //	@Accept			json
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			processId	path		string							true	"Process ID"
-//	@Param			request		body		apicommon.CreateProcessRequest	true	"Process creation information"
-//	@Success		200			{string}	string							"OK"
-//	@Failure		400			{object}	errors.Error					"Invalid input data"
-//	@Failure		401			{object}	errors.Error					"Unauthorized"
-//	@Failure		404			{object}	errors.Error					"Published census not found"
-//	@Failure		409			{object}	errors.Error					"Process already exists"
-//	@Failure		500			{object}	errors.Error					"Internal server error"
-//	@Router			/process/{processId} [post]
+//	@Param			request	body		apicommon.CreateProcessRequest	true	"Process creation information"
+//	@Success		200		{object}	primitive.ObjectID				"Process ID"
+//	@Failure		400		{object}	errors.Error					"Invalid input data"
+//	@Failure		401		{object}	errors.Error					"Unauthorized"
+//	@Failure		404		{object}	errors.Error					"Published census not found"
+//	@Failure		409		{object}	errors.Error					"Process already exists"
+//	@Failure		500		{object}	errors.Error					"Internal server error"
+//	@Router			/process [post]
 func (a *API) createProcessHandler(w http.ResponseWriter, r *http.Request) {
-	processID := internal.HexBytes{}
-	if err := processID.ParseString(chi.URLParam(r, "processId")); err != nil {
-		errors.ErrMalformedURLParam.Withf("missing process ID").Write(w)
-		return
-	}
-
+	// parse the process info from the request body
 	processInfo := &apicommon.CreateProcessRequest{}
 	if err := json.NewDecoder(r.Body).Decode(&processInfo); err != nil {
 		errors.ErrMalformedBody.Write(w)
 		return
 	}
 
-	if processInfo.PublishedCensusRoot == nil || processInfo.CensusID == nil {
-		errors.ErrMalformedBody.Withf("missing published census root or ID").Write(w)
+	if processInfo.CensusID == nil {
+		errors.ErrMalformedBody.Withf("missing census ID").Write(w)
 		return
 	}
 
@@ -63,38 +57,29 @@ func (a *API) createProcessHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if processInfo.PublishedCensusRoot.String() != census.Published.Root.String() ||
-		processInfo.PublishedCensusURI != census.Published.URI {
-		errors.ErrMalformedBody.Withf("published census root or URI does not match census").Write(w)
-		return
-	}
-
 	// check the user has the necessary permissions
 	if !user.HasRoleFor(census.OrgAddress, db.ManagerRole) && !user.HasRoleFor(census.OrgAddress, db.AdminRole) {
 		errors.ErrUnauthorized.Withf("user is not admin of organization").Write(w)
 		return
 	}
 
-	// check that the process does not exist
-	if _, err := a.db.Process(processID); err == nil {
-		errors.ErrDuplicateConflict.Withf("process already exists").Write(w)
-		return
-	}
-
 	// finally create the process
 	process := &db.Process{
-		ID:         processID,
 		Census:     *census,
 		Metadata:   processInfo.Metadata,
 		OrgAddress: census.OrgAddress,
 	}
+	if len(processInfo.Address) > 0 {
+		process.Address = processInfo.Address
+	}
 
-	if err := a.db.SetProcess(process); err != nil {
+	processID, err := a.db.SetProcess(process)
+	if err != nil {
 		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
 		return
 	}
 
-	apicommon.HTTPWriteOK(w)
+	apicommon.HTTPWriteJSON(w, processID)
 }
 
 // processInfoHandler godoc
@@ -116,8 +101,13 @@ func (a *API) processInfoHandler(w http.ResponseWriter, r *http.Request) {
 		errors.ErrMalformedURLParam.Withf("missing process ID").Write(w)
 		return
 	}
+	parsedID, err := primitive.ObjectIDFromHex(processID)
+	if err != nil {
+		errors.ErrMalformedURLParam.Withf("invalid process ID").Write(w)
+		return
+	}
 
-	process, err := a.db.Process([]byte(processID))
+	process, err := a.db.Process(parsedID)
 	if err != nil {
 		if err == db.ErrNotFound {
 			errors.ErrMalformedURLParam.Withf("process not found").Write(w)

--- a/api/routes.go
+++ b/api/routes.go
@@ -128,6 +128,7 @@ const (
 
 	// process routes
 	// POST /process/{processId} to create a new process
+	processCreateEndpoint = "/process"
 	// GET /process/{processId} to get process information
 	processEndpoint = "/process/{processId}"
 	// POST /process/{processId}/auth to check if the voter is authorized

--- a/db/process.go
+++ b/db/process.go
@@ -7,44 +7,52 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 // CreateProcess creates a new process for an organization
-func (ms *MongoStorage) SetProcess(process *Process) error {
-	if len(process.ID) == 0 || process.OrgAddress.Cmp(common.Address{}) == 0 || len(process.Census.ID) == 0 {
-		return ErrInvalidData
+func (ms *MongoStorage) SetProcess(process *Process) (primitive.ObjectID, error) {
+	if process.OrgAddress.Cmp(common.Address{}) == 0 {
+		return primitive.NilObjectID, ErrInvalidData
 	}
-
-	// check that the org exists
-	if _, err := ms.Organization(process.OrgAddress); err != nil {
-		return fmt.Errorf("failed to get organization %s: %w", process.OrgAddress, err)
-	}
-	// check that the census exists
-	census, err := ms.Census(process.Census.ID.Hex())
-	if err != nil {
-		return fmt.Errorf("failed to get census: %w", err)
-	}
-	if len(census.Published.Root) == 0 || len(census.Published.URI) == 0 {
-		return fmt.Errorf("census %s does not have a published root or URI", census.ID.Hex())
-	}
-
-	// TODO create the census if not found?
 
 	ms.keysLock.Lock()
 	defer ms.keysLock.Unlock()
+
+	// check that the org exists
+	if _, err := ms.Organization(process.OrgAddress); err != nil {
+		return primitive.NilObjectID, fmt.Errorf("failed to get organization %s: %w", process.OrgAddress, err)
+	}
+	// check that the census exists
+	if !process.Census.ID.IsZero() {
+		census, err := ms.Census(process.Census.ID.Hex())
+		if err != nil {
+			return primitive.NilObjectID, fmt.Errorf("failed to get census: %w", err)
+		}
+		if len(census.Published.Root) == 0 || len(census.Published.URI) == 0 {
+			return primitive.NilObjectID, fmt.Errorf("census %s does not have a published root or URI", census.ID.Hex())
+		}
+	}
+
+	if process.ID.IsZero() {
+		// if the process doesn't exist, create its id
+		process.ID = primitive.NewObjectID()
+	}
+
 	// create a context with a timeout
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
-	if _, err := ms.processes.InsertOne(ctx, process); err != nil {
-		return fmt.Errorf("failed to create process: %w", err)
+	_, err := ms.processes.InsertOne(ctx, process)
+	if err != nil {
+		return primitive.NilObjectID, fmt.Errorf("failed to create process: %w", err)
 	}
 
-	return nil
+	return process.ID, nil
 }
 
 // DeleteProcess removes a process
-func (ms *MongoStorage) DelProcess(processID internal.HexBytes) error {
-	if len(processID) == 0 {
+func (ms *MongoStorage) DelProcess(processID primitive.ObjectID) error {
+	if processID == primitive.NilObjectID {
 		return ErrInvalidData
 	}
 	ms.keysLock.Lock()
@@ -60,8 +68,8 @@ func (ms *MongoStorage) DelProcess(processID internal.HexBytes) error {
 }
 
 // Process retrieves a process from the DB based on its ID
-func (ms *MongoStorage) Process(processID internal.HexBytes) (*Process, error) {
-	if len(processID) == 0 {
+func (ms *MongoStorage) Process(processID primitive.ObjectID) (*Process, error) {
+	if processID == primitive.NilObjectID {
 		return nil, ErrInvalidData
 	}
 
@@ -71,6 +79,24 @@ func (ms *MongoStorage) Process(processID internal.HexBytes) (*Process, error) {
 
 	process := &Process{}
 	if err := ms.processes.FindOne(ctx, bson.M{"_id": processID}).Decode(process); err != nil {
+		return nil, fmt.Errorf("failed to get process: %w", err)
+	}
+
+	return process, nil
+}
+
+// Process retrieves a process from the DB based on its address
+func (ms *MongoStorage) ProcessByAddress(address internal.HexBytes) (*Process, error) {
+	if len(address) == 0 {
+		return nil, ErrInvalidData
+	}
+
+	// create a context with a timeout
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	process := &Process{}
+	if err := ms.processes.FindOne(ctx, bson.M{"address": address}).Decode(process); err != nil {
 		return nil, fmt.Errorf("failed to get process: %w", err)
 	}
 

--- a/db/types.go
+++ b/db/types.go
@@ -364,10 +364,11 @@ type PublishedCensus struct {
 //
 //nolint:lll
 type Process struct {
-	ID         internal.HexBytes `json:"id" bson:"_id"  swaggertype:"string" format:"hex" example:"deadbeef"`
-	OrgAddress common.Address    `json:"orgAdress" bson:"orgAddress"`
-	Census     Census            `json:"census" bson:"census"`
-	Metadata   []byte            `json:"metadata,omitempty"  bson:"metadata"  swaggertype:"string" format:"base64" example:"aGVsbG8gd29ybGQ="`
+	ID         primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	Address    internal.HexBytes  `json:"address" bson:"address"  swaggertype:"string" format:"hex" example:"deadbeef"`
+	OrgAddress common.Address     `json:"orgAdress" bson:"orgAddress"`
+	Census     Census             `json:"census" bson:"census"`
+	Metadata   map[string]any     `json:"metadata"  bson:"metadata"`
 }
 
 // ProcessesBundle represents a group of voting processes that share a common census.
@@ -378,7 +379,7 @@ type ProcessesBundle struct {
 	ID         primitive.ObjectID  `json:"id" bson:"_id"`                                                                         // Unique identifier for the bundle
 	Census     Census              `json:"census" bson:"census"`                                                                  // The census associated with this bundle
 	OrgAddress common.Address      `json:"orgAddress" bson:"orgAddress"`                                                          // The organization that owns this bundle
-	Processes  []internal.HexBytes `json:"processes" bson:"processes" swaggertype:"array,string" format:"hex" example:"deadbeef"` // Array of process IDs included in this bundle
+	Processes  []internal.HexBytes `json:"processes" bson:"processes" swaggertype:"array,string" format:"hex" example:"deadbeef"` // Array of process addresses included in this bundle
 }
 
 // HashedPhone represents a hashed phone number for database storage

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -131,7 +131,7 @@ definitions:
         description: Census ID
         type: string
       processes:
-        description: List of process IDs to include in the bundle
+        description: List of process Addresses to include in the bundle
         items:
           type: string
         type: array
@@ -149,26 +149,27 @@ definitions:
     type: object
   apicommon.CreateProcessRequest:
     properties:
+      address:
+        description: Vochain ID/Address of the process
+        example: deadbeef
+        format: hex
+        type: string
       censusId:
         description: Census ID
         example: deadbeef
         format: hex
         type: string
-      censusRoot:
-        description: Merkle root of the published census
-        example: deadbeef
-        format: hex
-        type: string
-      censusUri:
-        description: URI of the published census
-        type: string
       metadata:
+        additionalProperties: {}
         description: |-
           Additional metadata for the process
           Can be any key-value pairs
-        example: aGVsbG8gd29ybGQ=
-        format: base64
-        type: string
+        type: object
+      orgAddress:
+        description: Organization address
+        items:
+          type: integer
+        type: array
     type: object
   apicommon.DeleteMembersRequest:
     properties:
@@ -1099,16 +1100,17 @@ definitions:
     type: object
   db.Process:
     properties:
-      census:
-        $ref: '#/definitions/db.Census'
-      id:
+      address:
         example: deadbeef
         format: hex
         type: string
-      metadata:
-        example: aGVsbG8gd29ybGQ=
-        format: base64
+      census:
+        $ref: '#/definitions/db.Census'
+      id:
         type: string
+      metadata:
+        additionalProperties: {}
+        type: object
       orgAdress:
         items:
           type: integer
@@ -1129,7 +1131,7 @@ definitions:
           type: integer
         type: array
       processes:
-        description: Array of process IDs included in this bundle
+        description: Array of process addresses included in this bundle
         example:
         - deadbeef
         items:
@@ -3099,6 +3101,50 @@ paths:
       summary: Get plan information
       tags:
       - plans
+  /process:
+    post:
+      consumes:
+      - application/json
+      description: Create a new voting process. Requires Manager/Admin role.
+      parameters:
+      - description: Process creation information
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/apicommon.CreateProcessRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Process ID
+          schema:
+            type: string
+        "400":
+          description: Invalid input data
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "404":
+          description: Published census not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "409":
+          description: Process already exists
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+      security:
+      - BearerAuth: []
+      summary: Create a new voting process
+      tags:
+      - process
   /process/{processId}:
     get:
       consumes:
@@ -3131,54 +3177,6 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
       summary: Get process information
-      tags:
-      - process
-    post:
-      consumes:
-      - application/json
-      description: Create a new voting process. Requires Manager/Admin role.
-      parameters:
-      - description: Process ID
-        in: path
-        name: processId
-        required: true
-        type: string
-      - description: Process creation information
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/apicommon.CreateProcessRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            type: string
-        "400":
-          description: Invalid input data
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "404":
-          description: Published census not found
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "409":
-          description: Process already exists
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "500":
-          description: Internal server error
-          schema:
-            $ref: '#/definitions/errors.Error'
-      security:
-      - BearerAuth: []
-      summary: Create a new voting process
       tags:
       - process
   /process/{processId}/sign-info:


### PR DESCRIPTION
__Breaking changes:__

- `Process.ID` changed from `HexBytes` to `ObjectID` for database consistency
- Added `Process.Address` field for blockchain/vochain process address
- `Process.Metadata` changed from `[]byte` to `map[string]any` for better API usability
- `CreateProcessRequest` now uses process address instead of census data
- API endpoint changed from `POST /process/{id}` to `POST /process`

__Improvements:__

- Clear separation between database identity (ObjectID) and blockchain identity (Address)
- More intuitive API contract with structured metadata
- Updated all tests, documentation, and related code

This refactoring improves data model clarity while maintaining feature parity.


Closes #300 