### PR TITLE
chore(oauth): set specific error code when oauth password do not match

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -209,7 +209,7 @@ func (a *API) oauthLoginHandler(w http.ResponseWriter, r *http.Request) {
 	// Login
 	// check that the address generated password matches the one in the database
 	if pass := internal.HexHashPassword(passwordSalt, loginInfo.UserOAuthSignature); pass != user.Password {
-		errors.ErrUnauthorized.Write(w)
+		errors.ErrNonOauthAccount.Write(w)
 		return
 	}
 	// generate a new token with the user name as the subject

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -29,6 +29,7 @@ import (
 var (
 	// Authentication errors (401)
 	ErrUnauthorized            = Error{Code: 40001, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("authentication required"), LogLevel: "info"}
+	ErrNonOauthAccount         = Error{Code: 40101, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("account is not registered using OAuth"), LogLevel: "info"}
 	ErrUserNoVerified          = Error{Code: 40014, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("account email not verified"), LogLevel: "info"}
 	ErrVerificationCodeExpired = Error{Code: 40016, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("verification code has expired"), LogLevel: "info"}
 	ErrInvitationExpired       = Error{Code: 40019, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invitation code has expired"), LogLevel: "info"}


### PR DESCRIPTION
I've decided to use an error starting with `401` because I felt like that's what all the other 401 errors should be starting with (we're not gonna change that now though, but I felt like it was a good moment to start a new trend).

refs #286