### PR TITLE
Fix signup codes expiration and related flow

### DIFF
--- a/api/apicommon/const.go
+++ b/api/apicommon/const.go
@@ -20,6 +20,9 @@ const DefaultLang = "en"
 // before it is invalidated
 var VerificationCodeExpiration = 10 * time.Minute
 
+// VerificationCodeMaxAttempts is the maximum number of attempts to verify a code
+const VerificationCodeMaxAttempts = 3
+
 const (
 	// VerificationCodeLength is the length of the verification code in bytes
 	VerificationCodeLength = 3

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -191,6 +191,20 @@ func (a *API) generateVerificationCodeAndLink(target any, codeType db.CodeType) 
 	return verificationCode, verificationLink, err
 }
 
+// generateVerificationLink method generates a verification link for the user
+// provided using the code provided and the API web app configuration.
+// It returns the generated verification link and an error if the link
+// could not be generated.
+func (a *API) generateVerificationLink(user *db.User, code string) (string, error) {
+	webAppURI := mailtemplates.VerifyAccountNotification.WebAppURI
+	linkParams := map[string]any{
+		"email": user.Email,
+		"code":  code,
+	}
+
+	return a.buildWebAppURL(webAppURI, linkParams)
+}
+
 // calculatePagination calculates PreviousPage, NextPage and LastPage.
 //
 // If page is negative or higher than LastPage, returns ErrPageNotFound

--- a/db/types.go
+++ b/db/types.go
@@ -32,6 +32,7 @@ type UserVerification struct {
 	Code       string    `json:"code" bson:"code"`
 	Type       CodeType  `json:"type" bson:"type"`
 	Expiration time.Time `json:"expiration" bson:"expiration"`
+	Attempts   int       `json:"attempts" bson:"attempts"`
 }
 
 // TODO this is the default role function while it should be

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4162,15 +4162,12 @@ paths:
           schema:
             type: string
         "400":
-          description: Invalid input data
+          description: Invalid input data, user already verified, or max resend attempts
+            reached
           schema:
             $ref: '#/definitions/errors.Error'
         "401":
           description: Unauthorized
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "409":
-          description: User already verified or verification code still valid
           schema:
             $ref: '#/definitions/errors.Error'
         "500":

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -43,7 +43,7 @@ var (
 	ErrNoOrganizationProvided  = Error{Code: 40011, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("organization address is required")}
 	ErrInvalidOrganizationData = Error{Code: 40013, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid organization information provided")}
 	ErrUserAlreadyVerified     = Error{Code: 40015, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("user account is already verified")}
-	ErrVerificationCodeValid   = Error{Code: 40017, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("verification code is still valid")}
+	ErrVerificationMaxAttempts = Error{Code: 40017, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("verification resend max attempts reached")}
 	ErrStorageInvalidObject    = Error{Code: 40024, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid storage object or parameters")}
 	ErrNotSupported            = Error{Code: 40025, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("feature not supported")}
 	ErrUserNoVoted             = Error{Code: 40036, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("user has not voted yet"), LogLevel: "info"}


### PR DESCRIPTION
Closes #308


The verification code attempt limiting feature introduces a mechanism to prevent abuse of the verification code system by limiting the number of attempts for code verification and resending.

### Key Components Added/Modified:

__1. Database Layer (`db/types.go`)__

- Added `Attempts int` field to `UserVerification` struct to track verification attempts

__2. Database Operations (`db/verifications.go`)__

- Added `VericificationCodeIncrementAttempts(code string, t CodeType) error` method
- Modified `SetVerificationCode()` to initialize `Attempts: 1` when creating new verification codes

__3. API Layer (`api/users.go`)__

- Enhanced `resendUserVerificationCodeHandler()` with attempt limiting logic:

  - Checks if `code.Attempts < apicommon.VerificationCodeMaxAttempts` (3 attempts)
  - If under limit: resends existing code and increments attempt counter
  - If at/over limit: returns `ErrVerificationMaxAttempts` error
  - Only generates new code if existing code is expired

__4. Constants (`api/apicommon/const.go`)__

- Defined `VerificationCodeMaxAttempts = 3` constant

__5. Error Definitions (`errors/errors_definition.go`)__

- Added `ErrVerificationMaxAttempts` error (Code: 40017, HTTP 400) for when maximum attempts are reached
- Error message: "verification resend max attemts reached" (contains typo: "attemts")

### How the Feature Works:

1. When a verification code is first created, `Attempts` is set to 1

2. Each time a user requests to resend a verification code:

   - If attempts < 3 and code is still valid: resends existing code and increments attempts
   - If attempts ≥ 3: returns error preventing further resends
   - If code is expired: generates new code (regardless of attempts on old code)

3. This prevents users from repeatedly requesting verification code resends beyond the 3-attempt limit
