### PR TITLE
fix(auth addresses): should return all orgs the user belongs to

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -195,9 +195,9 @@ func (a *API) initRouter() http.Handler {
 		// refresh the token
 		log.Infow("new route", "method", "POST", "path", authRefresTokenEndpoint)
 		r.Post(authRefresTokenEndpoint, a.refreshTokenHandler)
-		// writable organization addresses
+		// organizations the user belongs to
 		log.Infow("new route", "method", "GET", "path", authAddressesEndpoint)
-		r.Get(authAddressesEndpoint, a.writableOrganizationAddressesHandler)
+		r.Get(authAddressesEndpoint, a.organizationAddressesHandler)
 		// get user information
 		log.Infow("new route", "method", "GET", "path", usersMeEndpoint)
 		r.Get(usersMeEndpoint, a.userInfoHandler)

--- a/api/auth.go
+++ b/api/auth.go
@@ -90,10 +90,10 @@ func (a *API) authLoginHandler(w http.ResponseWriter, r *http.Request) {
 	apicommon.HTTPWriteJSON(w, res)
 }
 
-// writableOrganizationAddressesHandler godoc
+// organizationAddressesHandler godoc
 //
-//	@Summary		Get writable organization addresses
-//	@Description	Get the list of organization addresses where the user has write access
+//	@Summary		Get a list of addresses the user belongs to
+//	@Description	Get the list of organization addresses the user belongs to
 //	@Tags			auth
 //	@Accept			json
 //	@Produce		json
@@ -103,9 +103,9 @@ func (a *API) authLoginHandler(w http.ResponseWriter, r *http.Request) {
 //	@Failure		404	{object}	errors.Error	"No organizations found"
 //	@Router			/auth/addresses [get]
 //
-// writableOrganizationAddressesHandler returns the list of addresses of the
-// organizations where the user has write access.
-func (*API) writableOrganizationAddressesHandler(w http.ResponseWriter, r *http.Request) {
+// organizationAddressesHandler returns the list of addresses of the
+// organizations to which the authenticated user belongs
+func (*API) organizationAddressesHandler(w http.ResponseWriter, r *http.Request) {
 	// get the user from the request context
 	user, ok := apicommon.UserFromContext(r.Context())
 	if !ok {
@@ -123,11 +123,7 @@ func (*API) writableOrganizationAddressesHandler(w http.ResponseWriter, r *http.
 	}
 	// get the addresses of the organizations where the user has write access
 	for _, org := range user.Organizations {
-		// check if the user has organization write permission to the organization based on the
-		// role of the user in the organization
-		if db.HasOrganizationWritePermission(org.Role) {
-			userAddresses.Addresses = append(userAddresses.Addresses, org.Address)
-		}
+		userAddresses.Addresses = append(userAddresses.Addresses, org.Address)
 	}
 	// write the response back to the user
 	apicommon.HTTPWriteJSON(w, userAddresses)


### PR DESCRIPTION
The `/auth/addresses` endpoint is used by our remote signer to know which addresses can it use. Until now, we had this method returning only addresses to which the user is an admin of, but this is a mistake.

- The remote signer needs addresses here in order to be able to properly initialize
- Because we send every signing request to the backend to be signed, there's where the read/write check should be done, not in the addresses endpoint

fixes #307 but I'm creating a new issue (#313) to properly review all endpoints, because some of the currently blocked endpoints might need to be readable too