### PR TITLE
refactor(auth): replace hashing with encryption for verification codes

### DIFF
--- a/api/helpers.go
+++ b/api/helpers.go
@@ -127,10 +127,13 @@ func (a *API) generateVerificationCodeAndLink(target any, codeType db.CodeType) 
 			return "", "", fmt.Errorf("invalid target type")
 		}
 		// generate the verification code for the user and the expiration time
-		hashCode := internal.HashVerificationCode(user.Email, verificationCode)
+		sealedCode, err := internal.SealToken(verificationCode, user.Email, a.secret)
+		if err != nil {
+			return "", "", err
+		}
 		exp := time.Now().Add(apicommon.VerificationCodeExpiration)
 		// store the verification code in the database
-		if err := a.db.SetVerificationCode(&db.User{ID: user.ID}, hashCode, codeType, exp); err != nil {
+		if err := a.db.SetVerificationCode(&db.User{ID: user.ID}, sealedCode, codeType, exp); err != nil {
 			return "", "", err
 		}
 		// set the web app URI and the link parameters

--- a/db/types.go
+++ b/db/types.go
@@ -29,7 +29,7 @@ type CodeType string
 
 type UserVerification struct {
 	ID         uint64    `json:"id" bson:"_id"`
-	Code       string    `json:"code" bson:"code"`
+	SealedCode []byte    `json:"sealedCode" bson:"sealedCode"`
 	Type       CodeType  `json:"type" bson:"type"`
 	Expiration time.Time `json:"expiration" bson:"expiration"`
 	Attempts   int       `json:"attempts" bson:"attempts"`

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -8,6 +8,12 @@ import (
 	"github.com/nyaruka/phonenumbers"
 )
 
+const (
+	email  = "user@example.com"
+	secret = "secret"
+	token  = "123456"
+)
+
 func TestSanitizePhone(t *testing.T) {
 	c := quicktest.New(t)
 	defaultCC := phonenumbers.GetCountryCodeForRegion(DefaultPhoneCountry)
@@ -95,5 +101,214 @@ func TestSanitizePhone(t *testing.T) {
 
 		// Both should result in the same sanitized number
 		c.Assert(resultWithoutCC, quicktest.Equals, resultWithCC)
+	})
+}
+
+func TestEncryptDecryptToken(t *testing.T) {
+	c := quicktest.New(t)
+
+	tests := []struct {
+		name    string
+		token   string
+		email   string
+		secret  string
+		wantErr bool
+	}{
+		{
+			name:    "valid token encryption and decryption",
+			token:   "123456",
+			email:   "user@example.com",
+			secret:  "my-secret-key",
+			wantErr: false,
+		},
+		{
+			name:    "valid long token",
+			token:   "a1b2c3d4e5f6g7h8i9j0",
+			email:   "test@test.com",
+			secret:  "another-secret",
+			wantErr: false,
+		},
+		{
+			name:    "valid with special characters in email",
+			token:   "987654",
+			email:   "user+test@example.co.uk",
+			secret:  "secret123",
+			wantErr: false,
+		},
+		{
+			name:    "empty token should fail",
+			token:   "",
+			email:   "user@example.com",
+			secret:  "secret",
+			wantErr: true,
+		},
+		{
+			name:    "empty email should fail",
+			token:   "123456",
+			email:   "",
+			secret:  "secret",
+			wantErr: true,
+		},
+		{
+			name:    "empty secret should fail",
+			token:   "123456",
+			email:   "user@example.com",
+			secret:  "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *quicktest.C) {
+			// Encrypt the token
+			encrypted, err := SealToken(tt.token, tt.email, tt.secret)
+
+			if tt.wantErr {
+				c.Assert(err, quicktest.IsNotNil)
+				return
+			}
+
+			c.Assert(err, quicktest.IsNil)
+			c.Assert(encrypted, quicktest.Not(quicktest.Equals), "")
+			c.Assert(encrypted, quicktest.Not(quicktest.Equals), tt.token)
+
+			// Decrypt the token
+			decrypted, err := OpenToken(encrypted, tt.email, tt.secret)
+			c.Assert(err, quicktest.IsNil)
+			c.Assert(decrypted, quicktest.Equals, tt.token)
+		})
+	}
+
+	// Test that each encryption produces different output (due to random nonce)
+	c.Run("different nonces produce different ciphertexts", func(c *quicktest.C) {
+		encrypted1, err := SealToken(token, email, secret)
+		c.Assert(err, quicktest.IsNil)
+
+		encrypted2, err := SealToken(token, email, secret)
+		c.Assert(err, quicktest.IsNil)
+
+		// Even with same inputs, outputs should differ due to random nonce
+		c.Assert(encrypted1, quicktest.Not(quicktest.Equals), encrypted2)
+
+		// But both should decrypt to the same token
+		decrypted1, err := OpenToken(encrypted1, email, secret)
+		c.Assert(err, quicktest.IsNil)
+		c.Assert(decrypted1, quicktest.Equals, token)
+
+		decrypted2, err := OpenToken(encrypted2, email, secret)
+		c.Assert(err, quicktest.IsNil)
+		c.Assert(decrypted2, quicktest.Equals, token)
+	})
+
+	// Test that different secrets produce different results
+	c.Run("different secrets produce different keys", func(c *quicktest.C) {
+		encrypted1, err := SealToken(token, email, "secret1")
+		c.Assert(err, quicktest.IsNil)
+
+		encrypted2, err := SealToken(token, email, "secret2")
+		c.Assert(err, quicktest.IsNil)
+
+		// Different secrets should produce different outputs
+		c.Assert(encrypted1, quicktest.Not(quicktest.Equals), encrypted2)
+
+		// And trying to decrypt with wrong secret should fail
+		_, err = OpenToken(encrypted1, email, "secret2")
+		c.Assert(err, quicktest.IsNotNil)
+	})
+
+	// Test that different emails produce different results (email is part of key and AAD)
+	c.Run("different emails produce different results", func(c *quicktest.C) {
+		encrypted1, err := SealToken(token, "user1@example.com", secret)
+		c.Assert(err, quicktest.IsNil)
+
+		encrypted2, err := SealToken(token, "user2@example.com", secret)
+		c.Assert(err, quicktest.IsNil)
+
+		// Different emails should produce different outputs
+		c.Assert(encrypted1, quicktest.Not(quicktest.Equals), encrypted2)
+
+		// And trying to decrypt with wrong email should fail
+		_, err = OpenToken(encrypted1, "user2@example.com", secret)
+		c.Assert(err, quicktest.IsNotNil)
+	})
+}
+
+func TestDecryptTokenFromHexErrors(t *testing.T) {
+	c := quicktest.New(t)
+
+	// Get a valid encrypted token for manipulation tests
+	validEncrypted, err := SealToken(token, email, secret)
+	c.Assert(err, quicktest.IsNil)
+
+	tests := []struct {
+		name       string
+		sealedCode []byte
+		email      string
+		secret     string
+		wantError  string
+	}{
+		{
+			name:       "empty code",
+			sealedCode: []byte{},
+			email:      email,
+			secret:     secret,
+			wantError:  "sealedToken, email, and secret cannot be empty",
+		},
+		{
+			name:       "empty email",
+			sealedCode: validEncrypted,
+			email:      "",
+			secret:     secret,
+			wantError:  "sealedToken, email, and secret cannot be empty",
+		},
+		{
+			name:       "empty secret",
+			sealedCode: validEncrypted,
+			email:      email,
+			secret:     "",
+			wantError:  "sealedToken, email, and secret cannot be empty",
+		},
+		{
+			name:       "hex too short",
+			sealedCode: []byte{0x00, 0x01},
+			email:      email,
+			secret:     secret,
+			wantError:  "invalid encrypted data: too short",
+		},
+		{
+			name:       "wrong email",
+			sealedCode: validEncrypted,
+			email:      "wrong@example.com",
+			secret:     secret,
+			wantError:  "failed to decrypt token",
+		},
+		{
+			name:       "wrong secret",
+			sealedCode: validEncrypted,
+			email:      email,
+			secret:     "wrong-secret",
+			wantError:  "failed to decrypt token",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *quicktest.C) {
+			_, err := OpenToken(tt.sealedCode, tt.email, tt.secret)
+			c.Assert(err, quicktest.IsNotNil)
+			c.Assert(err.Error(), quicktest.Contains, tt.wantError)
+		})
+	}
+
+	// Test tampering detection
+	c.Run("tampered ciphertext is detected", func(c *quicktest.C) {
+		encrypted, err := SealToken(token, email, secret)
+		c.Assert(err, quicktest.IsNil)
+
+		// Tamper with the last byte of the hex string
+		copy(encrypted[:1], []byte{0xff})
+
+		_, err = OpenToken(encrypted, email, secret)
+		c.Assert(err, quicktest.IsNotNil)
+		c.Assert(err.Error(), quicktest.Contains, "failed to decrypt token")
 	})
 }

--- a/migrations/0005_rename_verifications_code.go
+++ b/migrations/0005_rename_verifications_code.go
@@ -1,0 +1,64 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func init() {
+	AddMigration(5, "drop_verifications_and_replace_indexes",
+		upDropVerificationsAndReplaceIndexes, downDropVerificationsAndReplaceIndexes)
+}
+
+func upDropVerificationsAndReplaceIndexes(ctx context.Context, database *mongo.Database) error {
+	// there's no way to convert code <-> sealedCode so we set all to expired
+	_, err := database.Collection("verifications").UpdateMany(ctx,
+		bson.M{"code": bson.M{"$exists": true}},
+		bson.M{"$set": bson.M{"expiration": time.Now()}})
+	if err != nil {
+		return fmt.Errorf("failed to expire verifications: %w", err)
+	}
+
+	return renameFieldAndReindex(ctx, database.Collection("verifications"), "sealedCode", "code",
+		[]string{
+			"code_1_type_1",
+		},
+		[]mongo.IndexModel{
+			{
+				Keys: bson.D{
+					{Key: "sealedCode", Value: 1},
+					{Key: "type", Value: 1},
+				},
+				Options: options.Index().SetUnique(true),
+			},
+		})
+}
+
+func downDropVerificationsAndReplaceIndexes(ctx context.Context, database *mongo.Database) error {
+	// there's no way to convert code <-> sealedCode so we set all to expired
+	_, err := database.Collection("verifications").UpdateMany(ctx,
+		bson.M{"sealedCode": bson.M{"$exists": true}},
+		bson.M{"$set": bson.M{"expiration": time.Now()}})
+	if err != nil {
+		return fmt.Errorf("failed to expire verifications: %w", err)
+	}
+
+	return renameFieldAndReindex(ctx, database.Collection("verifications"), "sealedCode", "code",
+		[]string{
+			"sealedCode_1_type_1",
+		},
+		[]mongo.IndexModel{
+			{
+				Keys: bson.D{
+					{Key: "code", Value: 1},
+					{Key: "type", Value: 1},
+				},
+				Options: options.Index().SetUnique(true),
+			},
+		})
+}


### PR DESCRIPTION
## Improved Verification Code Security with AES-GCM Encryption

This PR replaces the simple hash-based verification code storage with AES-GCM encryption, improving security while maintaining short verification codes in email links.

### Changes

**New encryption utilities** (`internal/utils.go`):
- Added `EncryptTokenToHex()`: Encrypts verification tokens using AES-GCM with argon2-derived keys
- Added `DecryptTokenFromHex()`: Decrypts stored tokens back to their original form
- Uses email as both key derivation salt and additional authenticated data (AAD) for binding

**Updated verification code handling** (`api/helpers.go`, `api/users.go`):
- `generateVerificationCodeAndLink()`: Now encrypts codes before database storage (previously used simple hashing)
- `verifyUserAccountHandler()`: Decrypts stored codes for verification
- `resendUserVerificationCodeHandler()`: Decrypts codes to regenerate verification links with original short codes
- `resetUserPasswordHandler()`: Decrypts password reset codes before user lookup

**Test coverage** (`internal/utils_test.go`, `api/users_test.go`):
- Comprehensive encryption/decryption tests covering valid cases, error conditions, and tampering detection
- Verified that different nonces produce different ciphertexts for same inputs
- Added verification link extraction and validation in user tests

### Benefits

- **Enhanced security**: Encrypted storage with authenticated encryption (GCM mode)
- **Maintained UX**: Short verification codes remain in email links (6 characters)
- **Email binding**: Tokens are cryptographically bound to user emails, preventing reuse across accounts
- **Backward compatibility**: Uses existing argon2 key derivation infrastructure

Closes https://github.com/vocdoni/saas-backend/issues/328