### PR TITLE
Adds org member weight in API/DB

### DIFF
--- a/db/types.go
+++ b/db/types.go
@@ -224,6 +224,7 @@ type OrgMember struct {
 	ParsedBirthDate time.Time      `json:"parsedBirthDate" bson:"parsedBirthDate"`
 	Password        string         `json:"password" bson:"password"`
 	HashedPass      []byte         `json:"pass" bson:"pass" swaggertype:"string" format:"base64" example:"aGVsbG8gd29ybGQ="`
+	Weight          uint64         `json:"weight" bson:"weight"`
 	Other           map[string]any `json:"other" bson:"other"`
 	CreatedAt       time.Time      `json:"createdAt" bson:"createdAt"`
 	UpdatedAt       time.Time      `json:"updatedAt" bson:"updatedAt"`

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -327,6 +327,9 @@ definitions:
       surname:
         description: Member's surname
         type: string
+      weight:
+        description: Member's census weight
+        type: string
     type: object
   apicommon.OrganizationAddMetaRequest:
     properties:

--- a/migrations/0006_add_members_weight.go
+++ b/migrations/0006_add_members_weight.go
@@ -1,0 +1,36 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func init() {
+	AddMigration(6, "add_members_weight", upAddMembersWeight, downAddMembersWeight)
+}
+
+func upAddMembersWeight(ctx context.Context, database *mongo.Database) error {
+	// add weight field with default 1 to all orgMembers
+	// if the field already exists, do not overwrite
+	_, err := database.Collection("orgMembers").UpdateMany(ctx,
+		bson.M{"weight": bson.M{"$exists": false}},
+		bson.M{"$set": bson.M{"weight": 1}})
+	if err != nil {
+		return fmt.Errorf("failed to expire verifications: %w", err)
+	}
+	return nil
+}
+
+func downAddMembersWeight(ctx context.Context, database *mongo.Database) error {
+	// remove weight field from all orgMembers
+	_, err := database.Collection("orgMembers").UpdateMany(ctx,
+		bson.M{"weight": bson.M{"$exists": true}},
+		bson.M{"$unset": bson.M{"weight": ""}})
+	if err != nil {
+		return fmt.Errorf("failed to remove weight from orgMembers: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Add support for member weighting in organizations. The API receives the weight as a string or empty. Empty is converted to the default value 1. Zeros are a valid value:

- Add Weight field to OrgMember structs in api/db
- Implement validation in api conversion to db
- Create migration 0006 to add weight field with default value of 1 to existing members
- Include rollback migration to remove weight field if needed

Closes #285 