### PR TITLE
feat(csp): add weight field to authentication response

### DIFF
--- a/csp/handlers/handlers.go
+++ b/csp/handlers/handlers.go
@@ -211,7 +211,7 @@ func (c *CSPHandlers) signAndRespond(w http.ResponseWriter, authToken, address, 
 		return
 	}
 
-	apicommon.HTTPWriteJSON(w, &AuthResponse{Signature: signature})
+	apicommon.HTTPWriteJSON(w, &AuthResponse{Signature: signature, Weight: weight})
 }
 
 // BundleSignHandler godoc

--- a/csp/handlers/types.go
+++ b/csp/handlers/types.go
@@ -29,6 +29,7 @@ type AuthRequest struct {
 type AuthResponse struct {
 	AuthToken internal.HexBytes `json:"authToken,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`
 	Signature internal.HexBytes `json:"signature,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`
+	Weight    internal.HexBytes `json:"weight,omitempty" swaggertype:"string" format:"hex" example:"2a"`
 }
 
 // AuthRequest defines the payload for finishing the authentication process.

--- a/csp/sign.go
+++ b/csp/sign.go
@@ -70,7 +70,7 @@ func (c *CSP) prepareSaltedKeySigner(token, address, processID, weight internal.
 		case db.ErrTokenNotVerified:
 			return nil, nil, nil, ErrAuthTokenNotVerified
 		default:
-			return nil, nil, nil, ErrStorageFailure
+			return nil, nil, nil, ErrSign
 		}
 	} else if consumed {
 		return nil, nil, nil, ErrProcessAlreadyConsumed
@@ -118,14 +118,14 @@ func (c *CSP) finishSaltedKeySigner(token, address, processID internal.HexBytes)
 	// check if the process is already consumed for this user
 	if consumed, err := c.Storage.IsCSPProcessConsumed(authTokenData.UserID, processID); err != nil {
 		fmt.Println(err)
-		return ErrStorageFailure
+		return ErrSign
 	} else if consumed {
 		return ErrProcessAlreadyConsumed
 	}
 	// update the process data to mark it as consumed, and set the token used
 	if err := c.Storage.ConsumeCSPProcess(token, processID, address); err != nil {
 		log.Warn(err)
-		return ErrStorageFailure
+		return ErrSign
 	}
 	return nil
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1233,6 +1233,10 @@ definitions:
         example: deadbeef
         format: hex
         type: string
+      weight:
+        example: 2a
+        format: hex
+        type: string
     type: object
   handlers.ConsumedAddressRequest:
     properties:


### PR DESCRIPTION
Add weight field to AuthResponse structure and include it in the sign-and-respond flow. This allows clients to receive the weight value directly in the authentication response alongside the signature.

Also refactor error handling in signing functions by replacing generic ErrStorageFailure with more specific ErrSign error type for better error classification and debugging.

Changes:
- Add Weight field to AuthResponse struct with proper JSON and Swagger tags
- Include weight in signAndRespond HTTP response
- Replace ErrStorageFailure with ErrSign in prepareSaltedKeySigner and finishSaltedKeySigner functions
- Update Swagger documentation to reflect new weight field