### PR TITLE
fix(csp): remove cooldown time from auth-only token

### DIFF
--- a/csp/auth.go
+++ b/csp/auth.go
@@ -182,23 +182,6 @@ func (*CSP) verifySolution(uID, bID internal.HexBytes, solution string) bool {
 // that don't require challenge verification. It generates a token and immediately
 // marks it as verified.
 func (c *CSP) createAuthOnlyToken(bID, uID internal.HexBytes) (internal.HexBytes, error) {
-	// get last token for the user and bundle
-	lastToken, err := c.Storage.LastCSPAuth(uID, bID)
-	if err != nil && err != db.ErrTokenNotFound {
-		log.Warnw("error getting last token",
-			"userID", uID,
-			"bundleID", bID,
-			"error", err)
-		return nil, ErrStorageFailure
-	}
-	// check if the last token was created less than the cooldown time
-	if lastToken != nil && time.Since(lastToken.CreatedAt) < c.notificationCoolDownTime {
-		log.Warnw("cooldown time not reached",
-			"userID", uID,
-			"bundleID", bID)
-		return nil, errors.ErrAttemptCoolDownTime
-	}
-
 	// generate a new token (we don't need the code for auth-only)
 	bToken, err := uuid.New().MarshalBinary()
 	if err != nil {

--- a/csp/auth_test.go
+++ b/csp/auth_test.go
@@ -75,6 +75,35 @@ func TestBundleAuthToken(t *testing.T) {
 		c.Assert(err, qt.ErrorIs, errors.ErrAttemptCoolDownTime)
 	})
 
+	c.Run("auth-only ignores cooldown", func(c *qt.C) {
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		token, err := csp.BundleAuthToken(
+			testBundleID,
+			testUserID,
+			"",
+			"",
+			apicommon.DefaultLang,
+			"",
+			"",
+			testAddress.Address(),
+		)
+		c.Assert(err, qt.IsNil)
+		c.Assert(token, qt.Not(qt.IsNil))
+
+		token, err = csp.BundleAuthToken(
+			testBundleID,
+			testUserID,
+			"",
+			"",
+			apicommon.DefaultLang,
+			"",
+			"",
+			testAddress.Address(),
+		)
+		c.Assert(err, qt.IsNil)
+		c.Assert(token, qt.Not(qt.IsNil))
+	})
+
 	c.Run("success test", func(c *qt.C) {
 		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
 		bundleID := internal.HexBytes(testBundleID)


### PR DESCRIPTION
fix #395 