### PR TITLE
feat(subscriptions): limit memberbase size based on census size

### DIFF
--- a/db/org_members.go
+++ b/db/org_members.go
@@ -663,6 +663,25 @@ func (ms *MongoStorage) GetAllOrgMemberIDs(orgAddress common.Address) ([]string,
 	return memberIDs, nil
 }
 
+// CountOrgMembers  counts the number of the organization members
+func (ms *MongoStorage) CountOrgMembers(orgAddress common.Address) (int64, error) {
+	if orgAddress.Cmp(common.Address{}) == 0 {
+		return 0, ErrInvalidData
+	}
+
+	// create a context with a timeout
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	// Create filter - draft processes have nil address, published processes have non-nil address
+	filter := bson.M{
+		"orgAddress": orgAddress,
+	}
+
+	// Count total documents
+	return ms.orgMembers.CountDocuments(ctx, filter)
+}
+
 // validateOrgMembers checks if the provided member IDs are valid
 func (ms *MongoStorage) validateOrgMembers(ctx context.Context, orgAddress common.Address, members []string) error {
 	if len(members) == 0 {

--- a/db/org_members_test.go
+++ b/db/org_members_test.go
@@ -259,6 +259,11 @@ func TestOrgMembers(t *testing.T) {
 		c.Assert(member2.Phone.Bytes(), qt.DeepEquals, internal.HashOrgData(testOrgAddress, members[1].PlaintextPhone))
 		c.Assert(member2.HashedPass, qt.DeepEquals, internal.HashPassword(testSalt, members[1].Password))
 
+		// Verify that the org members count is correct
+		count, err := testDB.CountOrgMembers(testOrgAddress)
+		c.Assert(err, qt.IsNil)
+		c.Assert(count, qt.Equals, int64(2))
+
 		// Test with empty organization address
 		testOrgWithEmptyAddress := &Organization{
 			Address: common.Address{},

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -43,20 +43,21 @@ var (
 	ErrProviderAlreadyLinkedToAnotherAccount = Error{Code: 40044, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("OAuth provider already linked to another account"), LogLevel: "info"}
 
 	// Validation errors (400)
-	ErrEmailMalformed          = Error{Code: 40002, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid email format")}
-	ErrPasswordTooShort        = Error{Code: 40003, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("password must be at least 8 characters")}
-	ErrMalformedBody           = Error{Code: 40004, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid JSON request body")}
-	ErrInvalidUserData         = Error{Code: 40005, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid user information provided")}
-	ErrMalformedURLParam       = Error{Code: 40010, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid URL parameter")}
-	ErrNoOrganizationProvided  = Error{Code: 40011, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("organization address is required")}
-	ErrInvalidOrganizationData = Error{Code: 40013, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid organization information provided")}
-	ErrUserAlreadyVerified     = Error{Code: 40015, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("user account is already verified")}
-	ErrVerificationMaxAttempts = Error{Code: 40017, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("verification resend max attempts reached")}
-	ErrStorageInvalidObject    = Error{Code: 40024, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid storage object or parameters")}
-	ErrNotSupported            = Error{Code: 40025, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("feature not supported")}
-	ErrUserNoVoted             = Error{Code: 40036, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("user has not voted yet"), LogLevel: "info"}
-	ErrInvalidData             = Error{Code: 40037, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid data provided")}
-	ErrInvalidCensusData       = Error{Code: 40030, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid census data provided")}
+	ErrEmailMalformed                  = Error{Code: 40002, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid email format")}
+	ErrPasswordTooShort                = Error{Code: 40003, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("password must be at least 8 characters")}
+	ErrMalformedBody                   = Error{Code: 40004, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid JSON request body")}
+	ErrInvalidUserData                 = Error{Code: 40005, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid user information provided")}
+	ErrMalformedURLParam               = Error{Code: 40010, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid URL parameter")}
+	ErrNoOrganizationProvided          = Error{Code: 40011, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("organization address is required")}
+	ErrInvalidOrganizationData         = Error{Code: 40013, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid organization information provided")}
+	ErrUserAlreadyVerified             = Error{Code: 40015, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("user account is already verified")}
+	ErrVerificationMaxAttempts         = Error{Code: 40017, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("verification resend max attempts reached")}
+	ErrStorageInvalidObject            = Error{Code: 40024, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid storage object or parameters")}
+	ErrNotSupported                    = Error{Code: 40025, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("feature not supported")}
+	ErrUserNoVoted                     = Error{Code: 40036, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("user has not voted yet"), LogLevel: "info"}
+	ErrInvalidData                     = Error{Code: 40037, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid data provided")}
+	ErrInvalidCensusData               = Error{Code: 40030, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid census data provided")}
+	ErrExceedsOrganizationMembersLimit = Error{Code: 40045, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("operation would exceed organization members limit")}
 
 	// Transaction errors (400)
 	ErrCouldNotSignTransaction = Error{Code: 40006, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("transaction signing failed")}

--- a/subscriptions/subscriptions_test.go
+++ b/subscriptions/subscriptions_test.go
@@ -205,6 +205,10 @@ func (m *mockMongoStorage) OrganizationWithParent(address common.Address) (
 	return org, nil, nil
 }
 
+func (*mockMongoStorage) CountOrgMembers(_ common.Address) (int64, error) {
+	return 0, nil
+}
+
 func (*mockMongoStorage) CountProcesses(_ common.Address, _ db.DraftFilter) (int64, error) {
 	return 0, nil
 }


### PR DESCRIPTION
Enforce subscription limits so an organization’s memberbase cannot grow beyond the plan’s allowed census size.

- __What changed__:

  - Added limit checks in member-related flows.
  - Compared memberbase growth against the plan’s `MaxCensus` constraint.
  - Blocked operations that would exceed the allowed size.

- __Error handling__:

  - Returns clear, domain-specific errors when the limit is reached.
  - Prevents invalid writes before they hit storage.


Closes #415 
