### PR TITLE
refactor(census): Implements adding Participants to ean existing census

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -256,7 +256,6 @@ func (a *API) initRouter() http.Handler {
 		handle(r, http.MethodPost, objectStorageUploadTypedEndpoint, a.objectStorage.UploadImageWithFormHandler)
 		handle(r, http.MethodPost, censusEndpoint, a.createCensusHandler)
 		handle(r, http.MethodPost, censusIDEndpoint, a.addCensusParticipantsHandler)
-		handle(r, http.MethodGet, censusAddParticipantsJobStatusEndpoint, a.censusAddParticipantsJobStatusHandler)
 		handle(r, http.MethodPost, censusPublishEndpoint, a.publishCensusHandler)
 		handle(r, http.MethodPost, censusGroupPublishEndpoint, a.publishCensusGroupHandler)
 		handle(r, http.MethodGet, censusParticipantsEndpoint, a.censusParticipantsHandler)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1083,20 +1083,20 @@ func getCensusAndExpectError(t *testing.T, adminToken string, censusID string) e
 	return requestAndExpectError(t, http.MethodGet, adminToken, nil, censusEndpoint, censusID)
 }
 
-func postCensusParticipants(t *testing.T, adminToken string, censusID string, members ...apicommon.OrgMember,
+func postCensusParticipants(t *testing.T, adminToken string, censusID string, memberIDs ...string,
 ) apicommon.AddMembersResponse {
 	t.Helper()
 	resp := requestAndParse[apicommon.AddMembersResponse](t, http.MethodPost, adminToken,
-		&apicommon.AddMembersRequest{Members: members},
+		&apicommon.AddCensusParticipantsRequest{MemberIDs: memberIDs},
 		censusEndpoint, censusID)
-	qt.Assert(t, resp.Added, qt.Equals, uint32(len(members)))
+	qt.Assert(t, resp.Added, qt.Equals, uint32(len(memberIDs)))
 	return resp
 }
 
-func postCensusParticipantsAndExpectError(t *testing.T, adminToken string, censusID string, members ...apicommon.OrgMember,
+func postCensusParticipantsAndExpectError(t *testing.T, adminToken string, censusID string, memberIDs ...string,
 ) errors.Error {
 	t.Helper()
-	return requestAndExpectError(t, http.MethodPost, adminToken, &apicommon.AddMembersRequest{Members: members},
+	return requestAndExpectError(t, http.MethodPost, adminToken, &apicommon.AddCensusParticipantsRequest{MemberIDs: memberIDs},
 		censusEndpoint, censusID)
 }
 

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -823,7 +823,7 @@ type OrganizationCensuses struct {
 	Censuses []OrganizationCensus `json:"censuses"`
 }
 
-// AddMembersRequest defines the payload for adding members to a census.
+// AddMembersRequest defines the payload for adding members to an organization.
 // swagger:model AddMembersRequest
 type AddMembersRequest struct {
 	// List of members to add
@@ -837,6 +837,14 @@ func (r *AddMembersRequest) ToDB() []*db.OrgMember {
 		members = append(members, p.ToDB())
 	}
 	return members
+}
+
+// AddCensusParticipantsRequest defines the payload for adding existing
+// organization members to an existing census.
+// swagger:model AddCensusParticipantsRequest
+type AddCensusParticipantsRequest struct {
+	// List of existing organization member IDs to add to the census
+	MemberIDs []string `json:"memberIds"`
 }
 
 type DeleteMembersRequest struct {

--- a/api/docs.md
+++ b/api/docs.md
@@ -66,7 +66,6 @@
   - [📝 Create Census](#-create-census)
   - [ℹ️ Get Census Info](#ℹ%EF%B8%8F-get-census-info)
   - [👥 Add Members](#-add-members)
-  - [🔍 Check Add Members Job Status](#-check-add-members-job-status)
   - [📢 Publish Census](#-publish-census)
   - [📋 Get Published Census Info](#-get-published-census-info)
   - [📢 Publish Group Census](#-publish-group-census)
@@ -2005,36 +2004,22 @@ Returns the census ID
 * **Method** `POST`
 * **Headers**
   * `Authentication: Bearer <user_token>`
-* **Query params**
-  * `async` - Process asynchronously and return job ID (default: false)
 * **Request body**
 ```json
 {
-  "members": [
-    {
-      "email": "member@example.com",
-      "phone": "+1234567890"
-    }
-  ]
+  "memberIds": ["66f2d6f0c7a6d022b96c5d30", "66f2d6f0c7a6d022b96c5d31"]
 }
 ```
 
-* **Response (Synchronous)**
-Returns the number of members successfully added
-```json
-42
-```
-
-* **Response (Asynchronous)**
-Returns a job ID that can be used to check the status of the operation
+* **Response**
 ```json
 {
-  "jobID": "deadbeef"
+  "added": 2
 }
 ```
 
 * **Description**
-Adds multiple members to a census in bulk. Requires Manager or Admin role for the organization that owns the census. If the request contains no members or if the members array is empty, returns 0. Can be processed synchronously or asynchronously by setting the `async` query parameter to `true`.
+Adds existing organization members to an existing census by their member IDs. Requires Manager or Admin role for the organization that owns the census. If `memberIds` is empty, the endpoint returns `{"added": 0}`.
 
 * **Errors**
 
@@ -2045,31 +2030,7 @@ Adds multiple members to a census in bulk. Requires Manager or Admin role for th
 | `400` | `40004` | `malformed JSON body` |
 | `400` | `40010` | `malformed URL parameter` |
 | `400` | `40010` | `census not found` |
-| `500` | `50002` | `internal server error` |
-| `500` | `50004` | `not all members were added` |
-
-### 🔍 Check Add Members Job Status
-
-* **Path** `/census/job/{jobid}`
-* **Method** `GET`
-* **Response**
-```json
-{
-  "progress": 75,
-  "added": 150,
-  "total": 200
-}
-```
-
-* **Description**
-Checks the progress of a job to add members to a census. Returns the progress percentage, number of members added so far, and total number of members to add. If the job is completed (progress = 100), the job information is automatically deleted after 60 seconds.
-
-* **Errors**
-
-| HTTP Status | Error code | Message |
-|:---:|:---:|:---|
-| `400` | `40010` | `malformed URL parameter` |
-| `404` | `40404` | `job not found` |
+| `400` | `40037` | `invalid data provided` |
 | `500` | `50002` | `internal server error` |
 
 ### 📢 Publish Census

--- a/api/process_test.go
+++ b/api/process_test.go
@@ -38,39 +38,12 @@ func testCreateOrgAndCensus(
 	censusID := postCensus(t, adminToken, orgAddress, authFields, twoFaFields)
 	t.Logf("Created census with ID: %s\n", censusID)
 
-	// Add members to the census
-	members := &apicommon.AddMembersRequest{
-		Members: []apicommon.OrgMember{
-			{
-				MemberNumber: "P001",
-				Name:         "John Doe",
-				Email:        "john.doe@example.com",
-				Phone:        "+34612345678",
-				Password:     "password123",
-				Other: map[string]any{
-					"department": "Engineering",
-					"age":        30,
-				},
-			},
-			{
-				MemberNumber: "P002",
-				Name:         "Jane Smith",
-				Email:        "jane.smith@example.com",
-				Phone:        "+34698765432",
-				Password:     "password456",
-				Other: map[string]any{
-					"department": "Marketing",
-					"age":        28,
-				},
-			},
-		},
-	}
-
-	resp, code := testRequest(t, http.MethodPost, adminToken, members, censusEndpoint, censusID)
-	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+	// Add existing organization members to the census
+	orgMembers := postOrgMembers(t, adminToken, orgAddress, newOrgMembers(2)...)
+	postCensusParticipants(t, adminToken, censusID, memberIDs(orgMembers)...)
 
 	// Publish the census
-	resp, code = testRequest(t, http.MethodPost, adminToken, nil, censusEndpoint, censusID, "publish")
+	resp, code := testRequest(t, http.MethodPost, adminToken, nil, censusEndpoint, censusID, "publish")
 	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 
 	var publishedCensus apicommon.PublishedCensusResponse

--- a/api/routes.go
+++ b/api/routes.go
@@ -124,10 +124,8 @@ const (
 	// POST /census to create a new census
 	censusEndpoint = "/census"
 	// GET /census/{id} to get census information
-	// POST /census/{id} to add members to census
+	// POST /census/{id} to add organization members to census by member ID
 	censusIDEndpoint = "/census/{id}"
-	// GET /census/check/{jobid} to check the status of the add members job
-	censusAddParticipantsJobStatusEndpoint = "/census/job/{jobid}"
 	// POST /census/{id}/publish to publish a census
 	censusPublishEndpoint = "/census/{id}/publish"
 	// POST /census/{id}/group/{groupid}/publish to publish a group census

--- a/db/errors.go
+++ b/db/errors.go
@@ -21,3 +21,12 @@ var (
 	// ErrUpdateWouldCreateDuplicates is returned when trying to update an OrgMember
 	ErrUpdateWouldCreateDuplicates = fmt.Errorf("update would create duplicates")
 )
+
+// errorsAsStrings converts a slice of errors to a slice of strings
+func errorsAsStrings(errs []error) []string {
+	s := []string{}
+	for _, err := range errs {
+		s = append(s, err.Error())
+	}
+	return s
+}

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -18,6 +18,14 @@ definitions:
         - $ref: '#/definitions/apicommon.UserInfo'
         description: User information for registration or identification
     type: object
+  apicommon.AddCensusParticipantsRequest:
+    properties:
+      memberIds:
+        description: List of existing organization member IDs to add to the census
+        items:
+          type: string
+        type: array
+    type: object
   apicommon.AddMembersJobResponse:
     properties:
       added:
@@ -1017,15 +1025,6 @@ definitions:
           $ref: '#/definitions/db.OrgMemberTwoFaField'
         type: array
     type: object
-  db.BulkCensusParticipantStatus:
-    properties:
-      added:
-        type: integer
-      progress:
-        type: integer
-      total:
-        type: integer
-    type: object
   db.Census:
     properties:
       authFields:
@@ -1578,28 +1577,28 @@ paths:
     post:
       consumes:
       - application/json
-      description: Add multiple participants to a census. Requires Manager/Admin role.
+      description: |-
+        Add existing organization members to a census by member ID (synchronous).
+        Members already in the census are skipped.
+        Returns number of participants added plus per-member errors in the response `errors` field.
+        Requires Manager/Admin role.
       parameters:
       - description: Census ID
         in: path
         name: id
         required: true
         type: string
-      - description: Process asynchronously and return job ID
-        in: query
-        name: async
-        type: boolean
-      - description: Participants to add
+      - description: Participant member IDs to add
         in: body
         name: request
         required: true
         schema:
-          $ref: '#/definitions/apicommon.AddMembersRequest'
+          $ref: '#/definitions/apicommon.AddCensusParticipantsRequest'
       produces:
       - application/json
       responses:
         "200":
-          description: OK
+          description: Added count and optional per-member errors
           schema:
             $ref: '#/definitions/apicommon.AddMembersResponse'
         "400":
@@ -1620,7 +1619,7 @@ paths:
             $ref: '#/definitions/errors.Error'
       security:
       - BearerAuth: []
-      summary: Add participants to a census
+      summary: Add organization members to a census
       tags:
       - census
   /census/{id}/group/{groupid}/publish:
@@ -1753,37 +1752,6 @@ paths:
       security:
       - BearerAuth: []
       summary: Publish a census for voting
-      tags:
-      - census
-  /census/job/{jobid}:
-    get:
-      consumes:
-      - application/json
-      description: |-
-        Check the progress of a job to add participants to a census. Returns the progress of the job.
-        If the job is completed, the job is deleted after 60 seconds.
-      parameters:
-      - description: Job ID
-        in: path
-        name: jobid
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/db.BulkCensusParticipantStatus'
-        "400":
-          description: Invalid job ID
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "404":
-          description: Job not found
-          schema:
-            $ref: '#/definitions/errors.Error'
-      summary: Check the progress of adding participants
       tags:
       - census
   /oauth/login:

--- a/subscriptions/subscriptions_test.go
+++ b/subscriptions/subscriptions_test.go
@@ -209,6 +209,10 @@ func (*mockMongoStorage) CountOrgMembers(_ common.Address) (int64, error) {
 	return 0, nil
 }
 
+func (*mockMongoStorage) CountCensusParticipants(string) (int64, error) {
+	return 0, nil
+}
+
 func (*mockMongoStorage) CountProcesses(_ common.Address, _ db.DraftFilter) (int64, error) {
 	return 0, nil
 }


### PR DESCRIPTION
## Summary
- Adds/updates census participant insertion flow to support adding participants by **member IDs** through `POST /census/{id}`, centered in `api/census.go` and `db/census_participant.go`.
- Introduces substantial DB-side participant logic and tests (`db/census_participant.go`, `db/census_participant_test.go`), including new error handling in `db/errors.go` and cleanup/removal of overlapping logic from `db/org_members.go`.
- Refactors API-layer census behavior and tests (`api/census.go`, `api/census_test.go`, `api/api_test.go`, `api/process_test.go`) to align with the new participant-addition path and validation behavior.
- Updates API contract/docs and routing touchpoints (`api/apicommon/types.go`, `api/routes.go`, `api/docs.md`, `docs/swagger.yaml`) to reflect the participant-by-member-ID flow.
- Includes related subscription-area adjustments with tests (`subscriptions/subscriptions.go`, `subscriptions/subscriptions_test.go`) as part of the branch delta.


Closes #424 