### PR TITLE
feat(csp): allow resend csp  notifications during voter login

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -296,6 +296,7 @@ func (a *API) initRouter() http.Handler {
 		handle(r, http.MethodGet, processBundleInfoEndpoint, a.processBundleInfoHandler)
 		handle(r, http.MethodPost, processBundleWeightEndpoint, cspHandlers.UserWeightHandler)
 		handle(r, http.MethodPost, processBundleAuthEndpoint, cspHandlers.BundleAuthHandler)
+		handle(r, http.MethodPost, processBundleAuthResendEndpoint, cspHandlers.BundleAuthResendHandler)
 		handle(r, http.MethodPost, processBundleSignEndpoint, cspHandlers.BundleSignHandler)
 		handle(r, http.MethodGet, processBundleMemberEndpoint, a.processBundleParticipantInfoHandler)
 	})

--- a/api/routes.go
+++ b/api/routes.go
@@ -152,6 +152,8 @@ const (
 	processBundleInfoEndpoint = "/process/bundle/{bundleId}"
 	// POST /process/bundle/{bundleId}/auth/{step} to check if the voter is authorized
 	processBundleAuthEndpoint = "/process/bundle/{bundleId}/auth/{step}"
+	// POST /process/bundle/{bundleId}/auth/resend to resend the auth challenge
+	processBundleAuthResendEndpoint = "/process/bundle/{bundleId}/auth/resend"
 	// POST /process/bundle/{bundleId}/weight to get the voter weight for the bundle
 	processBundleWeightEndpoint = "/process/bundle/{bundleId}/weight"
 	// POST /process/bundle/{bundleId}/sign to sign with two-factor authentication

--- a/csp/auth.go
+++ b/csp/auth.go
@@ -47,12 +47,15 @@ func (c *CSP) BundleAuthToken(bID, uID internal.HexBytes, to string,
 		return nil, ErrStorageFailure
 	}
 	// check if the last token was created less than the cooldown time
-	if lastToken != nil && time.Since(lastToken.CreatedAt) < c.notificationCoolDownTime {
-		log.Warnw("cooldown time not reached",
-			"userID", uID,
-			"bundleID", bID,
-			"lastToken", lastToken.Token)
-		return nil, errors.ErrAttemptCoolDownTime
+	if lastToken != nil {
+		remainingTime := c.notificationCoolDownTime - time.Since(lastToken.CreatedAt)
+		if remainingTime > 0 {
+			log.Warnw("cooldown time not reached",
+				"userID", uID,
+				"bundleID", bID,
+				"lastToken", lastToken.Token)
+			return nil, errors.ErrAttemptCoolDownTime.WithData(map[string]any{"coolDownTime": remainingTime.Milliseconds()})
+		}
 	}
 	// generate a new token, secret and code from the attempt number
 	token, code, err := c.generateToken(uID, bID)
@@ -73,13 +76,13 @@ func (c *CSP) BundleAuthToken(bID, uID internal.HexBytes, to string,
 		"bundleID", bID,
 		"token", token)
 	// compose the notification challenge
-	remainingTime := c.notificationCoolDownTime.String()
+	remainingTimeN := c.notificationCoolDownTime.String()
 	orgInfo := notifications.OrganizationInfo{
 		Address: orgAddress,
 		Name:    orgName,
 		Logo:    orgLogo,
 	}
-	ch, err := notifications.NewNotificationChallenge(ctype, lang, uID, bID, to, code, orgInfo, remainingTime)
+	ch, err := notifications.NewNotificationChallenge(ctype, lang, uID, bID, to, code, orgInfo, remainingTimeN)
 	if err != nil {
 		log.Warnw("error composing notification challenge",
 			"userID", uID,
@@ -98,6 +101,83 @@ func (c *CSP) BundleAuthToken(bID, uID internal.HexBytes, to string,
 		return nil, ErrNotificationFailure
 	}
 	return token, nil
+}
+
+func (c *CSP) ResendChallenge(token internal.HexBytes, to string,
+	ctype notifications.ChallengeType, lang string,
+	orgName, orgLogo string, orgAddress common.Address,
+) error {
+	// check the input parameters
+	if len(token) == 0 {
+		return ErrInvalidAuthToken
+	}
+	if to == "" || ctype == "" {
+		return errors.ErrInvalidData.Withf("missing challenge destination or type")
+	}
+
+	// get the user data from the token
+	authTokenData, err := c.Storage.CSPAuth(token)
+	if err != nil {
+		log.Warnw("error getting user data by token",
+			"token", token,
+			"error", err)
+		return ErrInvalidAuthToken
+	}
+
+	remainingTime := c.notificationCoolDownTime - time.Since(authTokenData.CreatedAt)
+	if remainingTime.Seconds() < 0 {
+		log.Warnw("resend requested but cooldown time reached",
+			"userID", authTokenData.UserID,
+			"bundleID", authTokenData.BundleID,
+			"lastToken", authTokenData.Token)
+		return ErrTokenExpired
+	} else if authTokenData.Verified {
+		return errors.ErrUserAlreadyVerified.WithData(map[string]any{"coolDownTime": remainingTime.Seconds()})
+	}
+	// compose the notification challenge
+	remainingTimeN := c.notificationCoolDownTime.String()
+	orgInfo := notifications.OrganizationInfo{
+		Address: orgAddress,
+		Name:    orgName,
+		Logo:    orgLogo,
+	}
+	code, err := c.regenerateTokenCode(authTokenData.UserID, authTokenData.BundleID)
+	if err != nil {
+		log.Warnw("error regenerating token code",
+			"userID", authTokenData.UserID,
+			"bundleID", authTokenData.BundleID,
+			"token", token,
+			"error", err)
+		return ErrChallengeCodeFailure
+	}
+	ch, err := notifications.NewNotificationChallenge(
+		ctype,
+		lang,
+		authTokenData.UserID,
+		authTokenData.BundleID,
+		to,
+		code,
+		orgInfo,
+		remainingTimeN,
+	)
+	if err != nil {
+		log.Warnw("error composing notification challenge",
+			"userID", authTokenData.UserID,
+			"bundleID", authTokenData.BundleID,
+			"token", token,
+			"error", err)
+		return ErrNotificationFailure
+	}
+	// push the challenge to the queue to be sent
+	if err := c.notifyQueue.Push(ch); err != nil {
+		log.Warnw("error pushing notification challenge",
+			"userID", authTokenData.UserID,
+			"bundleID", authTokenData.BundleID,
+			"token", token,
+			"error", err)
+		return ErrNotificationFailure
+	}
+	return nil
 }
 
 // VerifyBundleAuthToken method verifies the authentication token for a user
@@ -167,6 +247,15 @@ func (*CSP) generateToken(uID, bID internal.HexBytes) (
 		return nil, "", ErrInvalidAuthToken
 	}
 	return bToken, code, nil
+}
+
+func (*CSP) regenerateTokenCode(uID, bID internal.HexBytes) (
+	string, error,
+) {
+	secret := otpSecret(uID, bID)
+	otp := gotp.NewDefaultHOTP(secret)
+	code := otp.At(0)
+	return code, nil
 }
 
 // verifySolution method verifies the solution for a user process. It generates

--- a/csp/auth_test.go
+++ b/csp/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base32"
+	"io"
 	"regexp"
 	"testing"
 	"time"
@@ -73,6 +74,26 @@ func TestBundleAuthToken(t *testing.T) {
 		_, err = csp.BundleAuthToken(testBundleID, testUserID, "",
 			notifications.EmailChallenge, apicommon.DefaultLang, "", "", testAddress.Address())
 		c.Assert(err, qt.ErrorIs, errors.ErrAttemptCoolDownTime)
+
+		var apiErr errors.Error
+		c.Assert(errors.As(err, &apiErr), qt.IsTrue)
+
+		data, ok := apiErr.Data.(map[string]any)
+		c.Assert(ok, qt.IsTrue)
+
+		coolDownTime, ok := data["coolDownTime"]
+		c.Assert(ok, qt.IsTrue)
+
+		switch v := coolDownTime.(type) {
+		case int:
+			c.Assert(v > 0, qt.IsTrue)
+		case int64:
+			c.Assert(v > 0, qt.IsTrue)
+		case float64:
+			c.Assert(v > 0, qt.IsTrue)
+		default:
+			c.Fatalf("coolDownTime should be a positive numeric value in a client-friendly unit, got %T", coolDownTime)
+		}
 	})
 
 	c.Run("auth-only ignores cooldown", func(c *qt.C) {
@@ -206,6 +227,211 @@ func TestVerifyBundleAuthToken(t *testing.T) {
 	})
 }
 
+func TestResendChallenge(t *testing.T) {
+	c := qt.New(t)
+
+	testDB, err := db.New(testMongoURI, test.RandomDatabaseName())
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	csp, err := New(ctx, &Config{
+		DB:                       testDB,
+		MailService:              testMailService,
+		SMSService:               testSMSService,
+		NotificationThrottleTime: time.Second,
+		NotificationCoolDownTime: time.Second * 5,
+		RootKey:                  *testRootKey,
+	})
+	c.Assert(err, qt.IsNil)
+
+	c.Run("empty token", func(c *qt.C) {
+		err := csp.ResendChallenge(
+			nil,
+			testUserEmail,
+			notifications.EmailChallenge,
+			apicommon.DefaultLang,
+			testOrgName,
+			testOrgLogo,
+			testAddress.Address(),
+		)
+		c.Assert(err, qt.ErrorIs, ErrInvalidAuthToken)
+	})
+
+	c.Run("empty destination and type", func(c *qt.C) {
+		err := csp.ResendChallenge(
+			testToken,
+			"",
+			"",
+			apicommon.DefaultLang,
+			testOrgName,
+			testOrgLogo,
+			testAddress.Address(),
+		)
+		c.Assert(err, qt.ErrorIs, errors.ErrInvalidData)
+	})
+
+	c.Run("empty destination", func(c *qt.C) {
+		err := csp.ResendChallenge(
+			testToken,
+			"",
+			notifications.EmailChallenge,
+			apicommon.DefaultLang,
+			testOrgName,
+			testOrgLogo,
+			testAddress.Address(),
+		)
+		c.Assert(err, qt.ErrorIs, errors.ErrInvalidData)
+	})
+
+	c.Run("empty challenge type", func(c *qt.C) {
+		err := csp.ResendChallenge(
+			testToken,
+			testUserEmail,
+			"",
+			apicommon.DefaultLang,
+			testOrgName,
+			testOrgLogo,
+			testAddress.Address(),
+		)
+		c.Assert(err, qt.ErrorIs, errors.ErrInvalidData)
+	})
+
+	c.Run("token not found", func(c *qt.C) {
+		err := csp.ResendChallenge(
+			testToken,
+			testUserEmail,
+			notifications.EmailChallenge,
+			apicommon.DefaultLang,
+			testOrgName,
+			testOrgLogo,
+			testAddress.Address(),
+		)
+		c.Assert(err, qt.ErrorIs, ErrInvalidAuthToken)
+	})
+
+	c.Run("token already verified", func(c *qt.C) {
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		c.Assert(csp.Storage.VerifyCSPAuth(testToken), qt.IsNil)
+
+		err := csp.ResendChallenge(
+			testToken,
+			testUserEmail,
+			notifications.EmailChallenge,
+			apicommon.DefaultLang,
+			testOrgName,
+			testOrgLogo,
+			testAddress.Address(),
+		)
+		c.Assert(err, qt.ErrorIs, errors.ErrUserAlreadyVerified)
+	})
+
+	c.Run("success", func(c *qt.C) {
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+
+		expectedCode, err := csp.regenerateTokenCode(testUserID, testBundleID)
+		c.Assert(err, qt.IsNil)
+
+		err = csp.ResendChallenge(
+			testToken,
+			testUserEmail,
+			notifications.EmailChallenge,
+			apicommon.DefaultLang,
+			testOrgName,
+			testOrgLogo,
+			testAddress.Address(),
+		)
+		c.Assert(err, qt.IsNil)
+
+		time.Sleep(time.Second * 3)
+		mailCode := fetchOTPCodeFromEmail(c, testUserEmail)
+		c.Assert(mailCode, qt.Equals, expectedCode)
+	})
+}
+
+func TestBundleAuthTokenResendAndVerifyFlow(t *testing.T) {
+	c := qt.New(t)
+
+	testDB, err := db.New(testMongoURI, test.RandomDatabaseName())
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	csp, err := New(ctx, &Config{
+		DB:                       testDB,
+		MailService:              testMailService,
+		SMSService:               testSMSService,
+		NotificationThrottleTime: time.Second,
+		NotificationCoolDownTime: time.Second * 5,
+		RootKey:                  *testRootKey,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	token, err := csp.BundleAuthToken(
+		testBundleID,
+		testUserID,
+		testUserEmail,
+		notifications.EmailChallenge,
+		apicommon.DefaultLang,
+		testOrgName,
+		testOrgLogo,
+		testAddress.Address(),
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(token, qt.Not(qt.IsNil))
+
+	expectedFirstCode, err := csp.regenerateTokenCode(testUserID, testBundleID)
+	c.Assert(err, qt.IsNil)
+	firstCode := fetchOTPCodeFromEmail(c, testUserEmail)
+	c.Assert(firstCode, qt.Equals, expectedFirstCode)
+
+	err = csp.ResendChallenge(
+		token,
+		testUserEmail,
+		notifications.EmailChallenge,
+		apicommon.DefaultLang,
+		testOrgName,
+		testOrgLogo,
+		testAddress.Address(),
+	)
+	c.Assert(err, qt.IsNil)
+	resendCode := fetchOTPCodeFromEmail(c, testUserEmail)
+	c.Assert(resendCode, qt.Equals, expectedFirstCode)
+
+	secondBundleID := internal.HexBytes("bundleID-2")
+	secondToken, err := csp.BundleAuthToken(
+		secondBundleID,
+		testUserID,
+		testUserEmail,
+		notifications.EmailChallenge,
+		apicommon.DefaultLang,
+		testOrgName,
+		testOrgLogo,
+		testAddress.Address(),
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(secondToken, qt.Not(qt.IsNil))
+
+	expectedSecondCode, err := csp.regenerateTokenCode(testUserID, secondBundleID)
+	c.Assert(err, qt.IsNil)
+	secondCode := fetchOTPCodeFromEmail(c, testUserEmail)
+	c.Assert(secondCode, qt.Equals, expectedSecondCode)
+	c.Assert(secondCode, qt.Not(qt.Equals), resendCode)
+
+	err = csp.VerifyBundleAuthToken(token, resendCode)
+	c.Assert(err, qt.IsNil)
+	err = csp.VerifyBundleAuthToken(secondToken, secondCode)
+	c.Assert(err, qt.IsNil)
+
+	authTokenResult, err := csp.Storage.CSPAuth(token)
+	c.Assert(err, qt.IsNil)
+	c.Assert(authTokenResult.Verified, qt.IsTrue)
+	authTokenSecondResult, err := csp.Storage.CSPAuth(secondToken)
+	c.Assert(err, qt.IsNil)
+	c.Assert(authTokenSecondResult.Verified, qt.IsTrue)
+}
+
 func TestGenerateToken(t *testing.T) {
 	c := qt.New(t)
 	secret := otpSecret(testUserID, testBundleID)
@@ -237,4 +463,35 @@ func TestOTPSecret(t *testing.T) {
 	encodedSecret := base32.StdEncoding.EncodeToString(expectedSecret[:])
 	secret := otpSecret(testUserID, testBundleID)
 	c.Assert(secret, qt.Equals, encodedSecret)
+}
+
+func fetchOTPCodeFromEmail(c *qt.C, email string) string {
+	var mailBody string
+	var err error
+
+	for range 25 {
+		mailBody, err = testMailService.FindEmail(context.Background(), email)
+		if err == nil {
+			break
+		}
+		if err == io.EOF {
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+		c.Assert(err, qt.IsNil)
+	}
+	c.Assert(err, qt.IsNil)
+
+	seedNotification, err := mailtemplates.VerifyOTPCodeNotification.Localized(apicommon.DefaultLang).
+		ExecPlain(struct {
+			Code             string
+			Organization     string
+			OrganizationLogo string
+		}{`(.{6})`, testOrgName, testOrgLogo})
+	c.Assert(err, qt.IsNil)
+
+	rgxNotification := regexp.MustCompile(seedNotification.PlainBody)
+	mailCode := rgxNotification.FindStringSubmatch(mailBody)
+	c.Assert(mailCode, qt.HasLen, 2)
+	return mailCode[1]
 }

--- a/csp/errors.go
+++ b/csp/errors.go
@@ -16,6 +16,8 @@ var (
 	// ErrTooManyAttempts is returned when no more SMS attempts available for a
 	// user.
 	ErrTooManyAttempts = fmt.Errorf("too many SMS attempts")
+	// ErrTokenExpired is returned when the authentication token has expired.
+	ErrTokenExpired = fmt.Errorf("authentication token has expired")
 	// ErrUserUnknown is returned if the userID is not found in the database.
 	ErrUserUnknown = fmt.Errorf("user is unknown")
 	// ErrUserAlreadyVerified is returned if the user is already verified when

--- a/csp/handlers/handlers.go
+++ b/csp/handlers/handlers.go
@@ -161,6 +161,131 @@ func (c *CSPHandlers) BundleAuthHandler(w http.ResponseWriter, r *http.Request) 
 	c.handleAuthStep(w, r, step, *bundleID, bundle.Census.ID.Hex())
 }
 
+// BundleAuthResendHandler godoc
+//
+//	@Summary		Resend authentication challenge for a process bundle
+//	@Description	Resend the challenge for an existing (non-verified) authentication token.
+//	@Description	The request must include the auth token and a valid contact method for the bundle census type
+//	@Description	(email, phone, or either depending on census configuration).
+//	@Description	The same token is returned if the challenge is queued successfully.
+//	@Tags			process
+//	@Accept			json
+//	@Produce		json
+//	@Param			bundleId	path		string						true	"Bundle ID"
+//	@Param			request		body		handlers.AuthResendRequest	true	"Resend request with auth token and contact data"
+//	@Success		200			{object}	handlers.AuthResponse
+//	@Failure		400			{object}	errors.Error	"Malformed URL/body, missing auth token, invalid contact data, or token already verified"
+//	@Failure		401			{object}	errors.Error	"Unauthorized, invalid/expired token, token not belonging to bundle, or contact mismatch"
+//	@Failure		404			{object}	errors.Error	"Organization not found"
+//	@Failure		500			{object}	errors.Error	"Internal server error (storage/challenge generation/notification failures)"
+//	@Router			/process/bundle/{bundleId}/auth/resend [post]
+func (c *CSPHandlers) BundleAuthResendHandler(w http.ResponseWriter, r *http.Request) {
+	// Parse the bundle ID
+	bundleID, ok := parseBundleID(w, r)
+	if !ok {
+		return
+	}
+
+	// Get the bundle
+	bundle, ok := c.getBundle(w, *bundleID)
+	if !ok {
+		return
+	}
+
+	// Parse the request body for the auth token and contact information
+	var req AuthResendRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		errors.ErrMalformedBody.Write(w)
+		return
+	}
+	if len(req.AuthToken) == 0 {
+		errors.ErrInvalidData.Withf("missing auth token").Write(w)
+		return
+	}
+
+	// Load token data and enforce that the token belongs to the bundle in the path.
+	auth, ok := c.getAuthInfo(w, req.AuthToken)
+	if !ok {
+		return
+	}
+	if !bytes.Equal(*bundleID, auth.BundleID) {
+		errors.ErrUnauthorized.Withf("token does not belong to the bundle").Write(w)
+		return
+	}
+
+	lang := apicommon.DefaultLang
+	if l, ok := r.Context().Value(apicommon.LangMetadataKey).(string); ok && l != "" {
+		lang = l
+	}
+
+	org, err := c.mainDB.Organization(bundle.OrgAddress)
+	if err != nil {
+		if err == db.ErrNotFound {
+			errors.ErrOrganizationNotFound.Write(w)
+			return
+		}
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+
+	oid, err := primitive.ObjectIDFromHex(auth.UserID.String())
+	if err != nil {
+		errors.ErrUnauthorized.WithErr(fmt.Errorf("invalid user ID in token: %w", err)).Write(w)
+		return
+	}
+	member, err := c.mainDB.OrgMember(bundle.OrgAddress, oid.Hex())
+	if err != nil {
+		errors.ErrUserNotFound.WithErr(err).Write(w)
+		return
+	}
+
+	// Determine the contact method and resend the challenge based on the census type
+	// and provided contact information
+	toDestination, challengeType, err := determineContactMethod(
+		&bundle.Census, org,
+		&AuthRequest{Email: req.Email, Phone: req.Phone},
+		member,
+	)
+	if err != nil {
+		if apiErr, ok := err.(errors.Error); ok {
+			apiErr.Write(w)
+		} else {
+			errors.ErrUnauthorized.WithErr(err).Write(w)
+		}
+		return
+	}
+
+	name := DefaultOrgName
+	logo := DefaultOrgLogo
+
+	if n, ok := org.Meta["name"].(string); ok {
+		name = n
+		// if name is found then retrieve the logo as well
+		if l, ok := org.Meta["logo"].(string); ok {
+			logo = l
+		}
+	}
+
+	// Resend the challenge with the same token and new contact information
+	if err := c.csp.ResendChallenge(req.AuthToken, toDestination, challengeType, lang, name, logo, org.Address); err != nil {
+		if apiErr, ok := err.(errors.Error); ok {
+			apiErr.Write(w)
+			return
+		}
+
+		switch err {
+		case csp.ErrInvalidAuthToken, csp.ErrTokenExpired:
+			errors.ErrUnauthorized.WithErr(err).Write(w)
+		case csp.ErrStorageFailure:
+			errors.ErrInternalStorageError.WithErr(err).Write(w)
+		default:
+			errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		}
+		return
+	}
+	apicommon.HTTPWriteJSON(w, &AuthResponse{AuthToken: req.AuthToken})
+}
+
 // parseSignRequest parses the sign request from the request body
 func parseSignRequest(w http.ResponseWriter, r *http.Request) (*SignRequest, bool) {
 	var req SignRequest

--- a/csp/handlers/types.go
+++ b/csp/handlers/types.go
@@ -23,6 +23,13 @@ type AuthRequest struct {
 	Phone        string `json:"phone"`
 }
 
+// AuthResendRequest defines the payload for the 2FA resend request.
+type AuthResendRequest struct {
+	AuthToken internal.HexBytes `json:"authToken" swaggertype:"string" format:"hex" example:"deadbeef"`
+	Email     string            `json:"email"`
+	Phone     string            `json:"phone"`
+}
+
 // AuthResponse defines the payload for the authentication response, including
 // the authToken and the signature. It is used during the authentication
 // process for both steps: the challenge request and the challenge validation.

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1270,6 +1270,17 @@ definitions:
       subscription_status:
         type: string
     type: object
+  handlers.AuthResendRequest:
+    properties:
+      authToken:
+        example: deadbeef
+        format: hex
+        type: string
+      email:
+        type: string
+      phone:
+        type: string
+    type: object
   handlers.AuthResponse:
     properties:
       authToken:
@@ -3718,6 +3729,56 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
       summary: Authenticate for a process bundle
+      tags:
+      - process
+  /process/bundle/{bundleId}/auth/resend:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Resend the challenge for an existing (non-verified) authentication token.
+        The request must include the auth token and a valid contact method for the bundle census type
+        (email, phone, or either depending on census configuration).
+        The same token is returned if the challenge is queued successfully.
+      parameters:
+      - description: Bundle ID
+        in: path
+        name: bundleId
+        required: true
+        type: string
+      - description: Resend request with auth token and contact data
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.AuthResendRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.AuthResponse'
+        "400":
+          description: Malformed URL/body, missing auth token, invalid contact data,
+            or token already verified
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "401":
+          description: Unauthorized, invalid/expired token, token not belonging to
+            bundle, or contact mismatch
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "404":
+          description: Organization not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error (storage/challenge generation/notification
+            failures)
+          schema:
+            $ref: '#/definitions/errors.Error'
+      summary: Resend authentication challenge for a process bundle
       tags:
       - process
   /process/bundle/{bundleId}/sign:


### PR DESCRIPTION
### Summary
- Adds CSP support to resend an existing login challenge during the token cooldown window, instead of always creating a new auth token.
- Refactors cooldown handling in `BundleAuthToken` to return cooldown metadata (`coolDownTime`) in the error payload when requests are too early.
- Introduces `ResendChallenge(...)` in `csp/auth.go`, including validation, token lookup, cooldown/expiry checks, verified-user guard, code regeneration, and queueing a new notification.
- Adds deterministic code regeneration helper (`regenerateTokenCode`) and extends CSP error coverage (`csp/errors.go`) for resend-related failure paths.
- Wires CSP handler/type layer changes (`csp/handlers/handlers.go`, `csp/handlers/types.go`) to support the resend flow and expands test coverage heavily in `csp/auth_test.go` (invalid input, missing token, verified token, expired token, success, and resend+verify flow).


### Notes
- Diff scope: 5 files changed, 439 insertions, 8 deletions.

Closes #427