### PR TITLE
feat(groups): autogroup all members

### DIFF
--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -223,6 +223,9 @@ type OrganizationMemberGroupInfo struct {
 	CensusIDs []string `json:"censusIds,omitempty" bson:"censusIds"`
 	// Count of members in the group
 	MembersCount int `json:"membersCount,omitempty" bson:"membersCount"`
+	// IsAutoGroup indicates this is the auto-generated "All members" group.
+	// It cannot be deleted and its membership cannot be manually modified.
+	IsAutoGroup bool `json:"isAutoGroup,omitempty" bson:"isAutoGroup"`
 }
 
 // OrganizationMemberGroupsResponse represents the response for listing organization member groups.

--- a/api/organization_groups.go
+++ b/api/organization_groups.go
@@ -78,6 +78,7 @@ func (a *API) organizationMemberGroupsHandler(w http.ResponseWriter, r *http.Req
 			UpdatedAt:    group.UpdatedAt,
 			CensusIDs:    group.CensusIDs,
 			MembersCount: len(group.MemberIDs),
+			IsAutoGroup:  group.IsAutoGroup,
 		})
 	}
 	apicommon.HTTPWriteJSON(w, memberGroups)
@@ -142,6 +143,7 @@ func (a *API) organizationMemberGroupHandler(w http.ResponseWriter, r *http.Requ
 		CensusIDs:   group.CensusIDs,
 		CreatedAt:   group.CreatedAt,
 		UpdatedAt:   group.UpdatedAt,
+		IsAutoGroup: group.IsAutoGroup,
 	})
 }
 
@@ -287,11 +289,14 @@ func (a *API) updateOrganizationMemberGroupHandler(w http.ResponseWriter, r *htt
 		toUpdate.RemoveMembers,
 	)
 	if err != nil {
-		if err == db.ErrNotFound {
+		switch err {
+		case db.ErrNotFound, db.ErrInvalidData:
 			errors.ErrInvalidData.Withf("group not found").Write(w)
-			return
+		case db.ErrAutoGroupMembersCannotBeModified:
+			errors.ErrAutoGroupMembersCannotBeModified.Write(w)
+		default:
+			errors.ErrGenericInternalServerError.Withf("could not update organization member group: %v", err).Write(w)
 		}
-		errors.ErrGenericInternalServerError.Withf("could not update organization member group: %v", err).Write(w)
 		return
 	}
 	apicommon.HTTPWriteOK(w)
@@ -338,11 +343,14 @@ func (a *API) deleteOrganizationMemberGroupHandler(w http.ResponseWriter, r *htt
 		return
 	}
 	if err := a.db.DeleteOrganizationMemberGroup(groupID, org.Address); err != nil {
-		if err == db.ErrNotFound {
+		switch err {
+		case db.ErrNotFound:
 			errors.ErrInvalidData.Withf("group not found").Write(w)
-			return
+		case db.ErrAutoGroupCannotBeDeleted:
+			errors.ErrAutoGroupCannotBeDeleted.Write(w)
+		default:
+			errors.ErrGenericInternalServerError.Withf("could not delete organization member group: %v", err).Write(w)
 		}
-		errors.ErrGenericInternalServerError.Withf("could not delete organization member group: %v", err).Write(w)
 		return
 	}
 	apicommon.HTTPWriteOK(w)

--- a/api/organization_groups.go
+++ b/api/organization_groups.go
@@ -135,16 +135,29 @@ func (a *API) organizationMemberGroupHandler(w http.ResponseWriter, r *http.Requ
 		errors.ErrGenericInternalServerError.Withf("could not get organization member group: %v", err).Write(w)
 		return
 	}
-	apicommon.HTTPWriteJSON(w, &apicommon.OrganizationMemberGroupInfo{
+
+	info := &apicommon.OrganizationMemberGroupInfo{
 		ID:          group.ID.Hex(),
 		Title:       group.Title,
 		Description: group.Description,
-		MemberIDs:   group.MemberIDs,
 		CensusIDs:   group.CensusIDs,
 		CreatedAt:   group.CreatedAt,
 		UpdatedAt:   group.UpdatedAt,
 		IsAutoGroup: group.IsAutoGroup,
-	})
+	}
+	// Auto groups store no member IDs in the document; expose the live count
+	// instead, consistent with the groups-listing response.
+	if group.IsAutoGroup {
+		count, err := a.db.CountOrgMembers(org.Address)
+		if err != nil {
+			errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+			return
+		}
+		info.MembersCount = int(count)
+	} else {
+		info.MemberIDs = group.MemberIDs
+	}
+	apicommon.HTTPWriteJSON(w, info)
 }
 
 // createOrganizationMemberGroupHandler godoc

--- a/api/organization_groups_autogroup_test.go
+++ b/api/organization_groups_autogroup_test.go
@@ -1,0 +1,306 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/api/apicommon"
+)
+
+// TestAutoGroupCreatedOnMemberUpload verifies that uploading members automatically
+// creates the "All members" auto group as the first group in the listing.
+func TestAutoGroupCreatedOnMemberUpload(t *testing.T) {
+	c := qt.New(t)
+
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	// No members yet — no auto group should appear.
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups, qt.HasLen, 0)
+
+	// Add members via bulk upload.
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(3)...)
+
+	// Auto group must now exist and be the first (and only) group.
+	groupsResp = requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups, qt.HasLen, 1)
+
+	autoGroup := groupsResp.Groups[0]
+	c.Assert(autoGroup.IsAutoGroup, qt.IsTrue)
+	c.Assert(autoGroup.Title, qt.Equals, "All members")
+	c.Assert(autoGroup.MembersCount, qt.Equals, 3)
+}
+
+// TestAutoGroupCreatedOnSingleMemberAdd verifies the auto group is created when a
+// single member is added via the upsert endpoint.
+func TestAutoGroupCreatedOnSingleMemberAdd(t *testing.T) {
+	c := qt.New(t)
+
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	// Upsert a single member.
+	member := apicommon.OrgMember{
+		MemberNumber: "001",
+		Name:         "Alice",
+		Surname:      "Smith",
+		Email:        "alice@example.com",
+	}
+	requestAndAssertCode(http.StatusOK,
+		t, http.MethodPut, adminToken, &member,
+		"organizations", orgAddress.String(), "members")
+
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups, qt.HasLen, 1)
+	c.Assert(groupsResp.Groups[0].IsAutoGroup, qt.IsTrue)
+	c.Assert(groupsResp.Groups[0].MembersCount, qt.Equals, 1)
+}
+
+// TestAutoGroupAlwaysMirrorsFullMemberbase verifies that the auto group member count
+// stays in sync as members are added and removed.
+func TestAutoGroupAlwaysMirrorsFullMemberbase(t *testing.T) {
+	c := qt.New(t)
+
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(5)...)
+
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups, qt.HasLen, 1)
+	autoGroupID := groupsResp.Groups[0].ID
+	c.Assert(groupsResp.Groups[0].MembersCount, qt.Equals, 5)
+
+	// Fetch the single group details — MemberIDs must contain all 5.
+	groupDetail := requestAndParse[apicommon.OrganizationMemberGroupInfo](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups", autoGroupID)
+	c.Assert(groupDetail.MemberIDs, qt.HasLen, 5)
+
+	// Add 2 more members.
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(2)...)
+
+	groupsResp = requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups[0].MembersCount, qt.Equals, 7)
+
+	// Remove specific members.
+	allMembers := getOrgMembers(t, adminToken, orgAddress)
+	toDelete := []string{allMembers.Members[0].ID, allMembers.Members[1].ID}
+	deleteReq := &apicommon.DeleteMembersRequest{IDs: toDelete}
+	requestAndAssertCode(http.StatusOK,
+		t, http.MethodDelete, adminToken, deleteReq,
+		"organizations", orgAddress.String(), "members")
+
+	groupsResp = requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups[0].MembersCount, qt.Equals, 5)
+}
+
+// TestAutoGroupPaginatedMembersList verifies that the paginated members endpoint
+// works correctly for the auto group.
+func TestAutoGroupPaginatedMembersList(t *testing.T) {
+	c := qt.New(t)
+
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(4)...)
+
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	autoGroupID := groupsResp.Groups[0].ID
+
+	membersResp := requestAndParse[apicommon.ListOrganizationMemberGroupResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups", autoGroupID, "members")
+	c.Assert(membersResp.Members, qt.HasLen, 4)
+}
+
+// TestAutoGroupCannotBeDeleted verifies that attempting to delete the auto group
+// returns 403 Forbidden.
+func TestAutoGroupCannotBeDeleted(t *testing.T) {
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(2)...)
+
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	autoGroupID := groupsResp.Groups[0].ID
+
+	requestAndAssertCode(http.StatusForbidden,
+		t, http.MethodDelete, adminToken, nil,
+		"organizations", orgAddress.String(), "groups", autoGroupID)
+}
+
+// TestAutoGroupMembersCannotBeManuallyModified verifies that trying to add or
+// remove members from the auto group returns 403 Forbidden.
+func TestAutoGroupMembersCannotBeManuallyModified(t *testing.T) {
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(2)...)
+
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	autoGroupID := groupsResp.Groups[0].ID
+
+	allMembers := getOrgMembers(t, adminToken, orgAddress)
+
+	updateReq := &apicommon.UpdateOrganizationMemberGroupsRequest{
+		RemoveMembers: []string{allMembers.Members[0].ID},
+	}
+	requestAndAssertCode(http.StatusForbidden,
+		t, http.MethodPut, adminToken, updateReq,
+		"organizations", orgAddress.String(), "groups", autoGroupID)
+}
+
+// TestAutoGroupTitleDescriptionCanBeUpdated verifies that updating only the
+// title/description of the auto group is allowed.
+func TestAutoGroupTitleDescriptionCanBeUpdated(t *testing.T) {
+	c := qt.New(t)
+
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(1)...)
+
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	autoGroupID := groupsResp.Groups[0].ID
+
+	updateReq := &apicommon.UpdateOrganizationMemberGroupsRequest{
+		Title:       "My Renamed All-Members Group",
+		Description: "Custom description",
+	}
+	requestAndAssertCode(http.StatusOK,
+		t, http.MethodPut, adminToken, updateReq,
+		"organizations", orgAddress.String(), "groups", autoGroupID)
+
+	groupDetail := requestAndParse[apicommon.OrganizationMemberGroupInfo](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups", autoGroupID)
+	c.Assert(groupDetail.Title, qt.Equals, "My Renamed All-Members Group")
+	c.Assert(groupDetail.Description, qt.Equals, "Custom description")
+	c.Assert(groupDetail.IsAutoGroup, qt.IsTrue)
+}
+
+// TestAutoGroupDisappearsWhenAllMembersDeleted verifies that deleting all members
+// removes the auto group entirely, and it reappears when a member is re-added.
+func TestAutoGroupDisappearsWhenAllMembersDeleted(t *testing.T) {
+	c := qt.New(t)
+
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(3)...)
+
+	// Auto group exists.
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups, qt.HasLen, 1)
+
+	// Delete all members.
+	deleteAllReq := &apicommon.DeleteMembersRequest{All: true}
+	requestAndAssertCode(http.StatusOK,
+		t, http.MethodDelete, adminToken, deleteAllReq,
+		"organizations", orgAddress.String(), "members")
+
+	// Auto group should be gone.
+	groupsResp = requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups, qt.HasLen, 0)
+
+	// Re-add a member — auto group should reappear.
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(1)...)
+
+	groupsResp = requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups, qt.HasLen, 1)
+	c.Assert(groupsResp.Groups[0].IsAutoGroup, qt.IsTrue)
+	c.Assert(groupsResp.Groups[0].MembersCount, qt.Equals, 1)
+}
+
+// TestAutoGroupDisappearsWhenLastMemberDeleted verifies that deleting the final
+// member one-by-one removes the auto group.
+func TestAutoGroupDisappearsWhenLastMemberDeleted(t *testing.T) {
+	c := qt.New(t)
+
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(1)...)
+
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups, qt.HasLen, 1)
+
+	memberID := getOrgMembers(t, adminToken, orgAddress).Members[0].ID
+	deleteReq := &apicommon.DeleteMembersRequest{IDs: []string{memberID}}
+	requestAndAssertCode(http.StatusOK,
+		t, http.MethodDelete, adminToken, deleteReq,
+		"organizations", orgAddress.String(), "members")
+
+	groupsResp = requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups, qt.HasLen, 0)
+}
+
+// TestAutoGroupAppearsFirstInPagination verifies that when multiple groups exist,
+// the auto group is always the first element on page 1.
+func TestAutoGroupAppearsFirstInPagination(t *testing.T) {
+	c := qt.New(t)
+
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(3)...)
+
+	allMembersResp := getOrgMembers(t, adminToken, orgAddress)
+	memberIDs := make([]string, len(allMembersResp.Members))
+	for i, m := range allMembersResp.Members {
+		memberIDs[i] = m.ID
+	}
+
+	// Create two regular groups.
+	for _, title := range []string{"Group A", "Group B"} {
+		createReq := &apicommon.CreateOrganizationMemberGroupRequest{
+			Title:     title,
+			MemberIDs: memberIDs[:1],
+		}
+		requestAndAssertCode(http.StatusOK,
+			t, http.MethodPost, adminToken, createReq,
+			"organizations", orgAddress.String(), "groups")
+	}
+
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+
+	// Total: 1 auto + 2 regular = 3.
+	c.Assert(groupsResp.Pagination.TotalItems, qt.Equals, int64(3))
+	// First element must be the auto group.
+	c.Assert(groupsResp.Groups[0].IsAutoGroup, qt.IsTrue)
+}

--- a/api/organization_groups_autogroup_test.go
+++ b/api/organization_groups_autogroup_test.go
@@ -81,11 +81,11 @@ func TestAutoGroupAlwaysMirrorsFullMemberbase(t *testing.T) {
 	autoGroupID := groupsResp.Groups[0].ID
 	c.Assert(groupsResp.Groups[0].MembersCount, qt.Equals, 5)
 
-	// Fetch the single group details — MemberIDs must contain all 5.
+	// Fetch the single group details — MembersCount must reflect all 5.
 	groupDetail := requestAndParse[apicommon.OrganizationMemberGroupInfo](
 		t, http.MethodGet, adminToken, nil,
 		"organizations", orgAddress.String(), "groups", autoGroupID)
-	c.Assert(groupDetail.MemberIDs, qt.HasLen, 5)
+	c.Assert(groupDetail.MembersCount, qt.Equals, 5)
 
 	// Add 2 more members.
 	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(2)...)

--- a/api/organization_groups_test.go
+++ b/api/organization_groups_test.go
@@ -133,7 +133,10 @@ func TestOrganizationGroups(t *testing.T) {
 		groupsResponse := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
 			t, http.MethodGet, adminToken, nil,
 			"organizations", orgAddress.String(), "groups")
-		c.Assert(groupsResponse.Groups, qt.HasLen, 2) // We created two groups in the previous test (Test 1 and Test 6)
+		// Now 3 groups: the auto "All members" group + two regular groups created above
+		c.Assert(groupsResponse.Groups, qt.HasLen, 3)
+		// First group must always be the auto group
+		c.Assert(groupsResponse.Groups[0].IsAutoGroup, qt.IsTrue)
 
 		// Test 2: Try to get groups without authentication
 		requestAndAssertCode(http.StatusUnauthorized,
@@ -151,8 +154,8 @@ func TestOrganizationGroups(t *testing.T) {
 			t, http.MethodGet, adminToken, nil,
 			"organizations", "invalid-address", "groups")
 
-		// Save the first group ID for later tests
-		firstGroupID := groupsResponse.Groups[0].ID
+		// Save the first non-auto group ID for later tests
+		firstGroupID := groupsResponse.Groups[1].ID
 		c.Assert(firstGroupID, qt.Not(qt.Equals), "")
 
 		// Test 5: Get a specific group by ID
@@ -177,7 +180,15 @@ func TestOrganizationGroups(t *testing.T) {
 			"organizations", orgAddress.String(), "groups")
 		c.Assert(len(groupsResponse.Groups) > 0, qt.IsTrue)
 
-		groupID := groupsResponse.Groups[0].ID
+		// Pick the first non-auto group for update/member-manipulation tests.
+		var groupID string
+		for _, g := range groupsResponse.Groups {
+			if !g.IsAutoGroup {
+				groupID = g.ID
+				break
+			}
+		}
+		c.Assert(groupID, qt.Not(qt.Equals), "")
 
 		// Test 1: Update the group's title and description
 		updateRequest := &apicommon.UpdateOrganizationMemberGroupsRequest{

--- a/db/census.go
+++ b/db/census.go
@@ -104,7 +104,7 @@ func (ms *MongoStorage) PopulateGroupCensus(
 		}
 		return 0, fmt.Errorf("error retrieving organization group: %w", err)
 	}
-	if len(group.MemberIDs) == 0 {
+	if !group.IsAutoGroup && len(group.MemberIDs) == 0 {
 		return 0, fmt.Errorf("group has no members")
 	}
 

--- a/db/errors.go
+++ b/db/errors.go
@@ -20,6 +20,10 @@ var (
 	ErrTokenNotVerified = fmt.Errorf("token not verified")
 	// ErrUpdateWouldCreateDuplicates is returned when trying to update an OrgMember
 	ErrUpdateWouldCreateDuplicates = fmt.Errorf("update would create duplicates")
+	// ErrAutoGroupCannotBeDeleted is returned when trying to delete the auto-generated "All members" group
+	ErrAutoGroupCannotBeDeleted = fmt.Errorf("auto-generated group cannot be deleted")
+	// ErrAutoGroupMembersCannotBeModified is returned when trying to manually add/remove members from the auto group
+	ErrAutoGroupMembersCannotBeModified = fmt.Errorf("auto-generated group membership cannot be manually modified")
 )
 
 // errorsAsStrings converts a slice of errors to a slice of strings

--- a/db/org_members.go
+++ b/db/org_members.go
@@ -341,10 +341,10 @@ func (ms *MongoStorage) addOrgMemberBatches(
 	// Ensure the auto group exists now that members have been added.
 	if job.Added > 0 {
 		ms.keysLock.Lock()
+		defer ms.keysLock.Unlock()
 		if err := ms.EnsureAutoMemberGroup(org.Address); err != nil {
 			log.Warnw("could not ensure auto member group after bulk add", "error", err)
 		}
-		ms.keysLock.Unlock()
 	}
 }
 

--- a/db/org_members.go
+++ b/db/org_members.go
@@ -43,12 +43,17 @@ func (ms *MongoStorage) SetOrgMember(salt string, orgMember *OrgMember) (string,
 		return "", err
 	}
 	ms.keysLock.Lock()
-	defer ms.keysLock.Unlock()
 	filter := bson.M{"_id": member.ID}
 	opts := options.Update().SetUpsert(true)
 	_, err = ms.orgMembers.UpdateOne(ctx, filter, updateDoc, opts)
+	ms.keysLock.Unlock()
 	if err != nil {
 		return "", err
+	}
+
+	// Ensure the auto group exists now that at least one member is present.
+	if err := ms.EnsureAutoMemberGroup(orgMember.OrgAddress); err != nil {
+		log.Warnw("could not ensure auto member group after SetOrgMember", "error", err)
 	}
 
 	return member.ID.Hex(), nil
@@ -61,8 +66,18 @@ func (ms *MongoStorage) DelOrgMember(id string) error {
 		return ErrInvalidData
 	}
 
+	// Fetch the member first so we know which org it belongs to (needed for auto group cleanup).
+	ctxFetch, cancelFetch := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancelFetch()
+	var existing OrgMember
+	if err := ms.orgMembers.FindOne(ctxFetch, bson.M{"_id": objID}).Decode(&existing); err != nil {
+		if err == mongo.ErrNoDocuments {
+			return ErrNotFound
+		}
+		return fmt.Errorf("could not fetch member before deletion: %w", err)
+	}
+
 	ms.keysLock.Lock()
-	defer ms.keysLock.Unlock()
 	// create a context with a timeout
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
@@ -70,7 +85,16 @@ func (ms *MongoStorage) DelOrgMember(id string) error {
 	// delete the orgMember from the database using the ID
 	filter := bson.M{"_id": objID}
 	_, err = ms.orgMembers.DeleteOne(ctx, filter)
-	return err
+	ms.keysLock.Unlock()
+	if err != nil {
+		return err
+	}
+
+	// Clean up the auto group if the org now has no members.
+	if err := ms.DeleteAutoMemberGroupIfEmpty(existing.OrgAddress); err != nil {
+		log.Warnw("could not clean up auto member group after DelOrgMember", "error", err)
+	}
+	return nil
 }
 
 // OrgMember retrieves a orgMember from the DB based on it ID
@@ -313,6 +337,13 @@ func (ms *MongoStorage) addOrgMemberBatches(
 			Errors:   append(job.Errors, errs...),
 		}
 	}
+
+	// Ensure the auto group exists now that members have been added.
+	if job.Added > 0 {
+		if err := ms.EnsureAutoMemberGroup(org.Address); err != nil {
+			log.Warnw("could not ensure auto member group after bulk add", "error", err)
+		}
+	}
 }
 
 // AddBulkOrgMembers adds multiple organization members to the database in batches of 200 entries.
@@ -348,7 +379,7 @@ func (ms *MongoStorage) UpsertOrgMemberAndCensusParticipants(org *Organization, 
 	defer cancel()
 
 	ms.keysLock.Lock()
-	defer ms.keysLock.Unlock()
+	// Lock is released explicitly below, before calling EnsureAutoMemberGroup.
 
 	// if this member exists already, check the orgAddress is not being changed
 	orgMemberInDB := &OrgMember{}
@@ -357,30 +388,40 @@ func (ms *MongoStorage) UpsertOrgMemberAndCensusParticipants(org *Organization, 
 			member.Phone = orgMemberInDB.Phone
 		}
 		if orgMemberInDB.OrgAddress != org.Address {
+			ms.keysLock.Unlock()
 			return primitive.NilObjectID, fmt.Errorf("modifying orgAddress is not allowed")
 		}
 	}
 
 	preparedMember, validationErrors := prepareOrgMember(org, member, salt, time.Now())
 	if len(validationErrors) > 0 {
+		ms.keysLock.Unlock()
 		return primitive.NilObjectID, fmt.Errorf("errors: %s", errorsAsStrings(validationErrors))
 	}
 
 	// Update the census participants first, to bail out early in case this would create any duplicates conflict
 	if err := ms.updateCensusParticipantsForMember(ctx, preparedMember); err != nil {
+		ms.keysLock.Unlock()
 		return primitive.NilObjectID, fmt.Errorf("failed to update census participants: %w", err)
 	}
 
 	updateDoc, err := dynamicUpdateDocument(preparedMember, []string{"weight"})
 	if err != nil {
+		ms.keysLock.Unlock()
 		return primitive.NilObjectID, err
 	}
 
 	filter := bson.M{"_id": preparedMember.ID}
 	opts := options.Update().SetUpsert(true)
 	_, err = ms.orgMembers.UpdateOne(ctx, filter, updateDoc, opts)
+	ms.keysLock.Unlock()
 	if err != nil {
 		return primitive.NilObjectID, fmt.Errorf("failed to upsert org member: %w", err)
+	}
+
+	// Ensure the auto group exists now that at least one member is present.
+	if err := ms.EnsureAutoMemberGroup(org.Address); err != nil {
+		log.Warnw("could not ensure auto member group after upsert", "error", err)
 	}
 
 	return preparedMember.ID, nil
@@ -557,6 +598,11 @@ func (ms *MongoStorage) DeleteOrgMembers(orgAddress common.Address, ids []string
 		return 0, fmt.Errorf("failed to update groups after deleting orgMembers: %w", err)
 	}
 
+	// Clean up the auto group if the org now has no members.
+	if err := ms.DeleteAutoMemberGroupIfEmpty(orgAddress); err != nil {
+		log.Warnw("could not clean up auto member group after DeleteOrgMembers", "error", err)
+	}
+
 	return int(result.DeletedCount), nil
 }
 
@@ -576,10 +622,10 @@ func (ms *MongoStorage) DeleteAllOrgMembers(orgAddress common.Address) (int, err
 	}
 
 	ms.keysLock.Lock()
-	defer ms.keysLock.Unlock()
 
 	result, err := ms.orgMembers.DeleteMany(ctx, filter)
 	if err != nil {
+		ms.keysLock.Unlock()
 		return 0, fmt.Errorf("failed to delete all orgMembers: %w", err)
 	}
 
@@ -595,8 +641,14 @@ func (ms *MongoStorage) DeleteAllOrgMembers(orgAddress common.Address) (int, err
 	}
 
 	_, err = ms.orgMemberGroups.UpdateMany(ctx, groupFilter, groupUpdate)
+	ms.keysLock.Unlock()
 	if err != nil {
 		return 0, fmt.Errorf("failed to update groups after deleting all orgMembers: %w", err)
+	}
+
+	// All members are gone — remove the auto group too.
+	if err := ms.deleteAutoMemberGroup(orgAddress); err != nil {
+		log.Warnw("could not delete auto member group after DeleteAllOrgMembers", "error", err)
 	}
 
 	return int(result.DeletedCount), nil

--- a/db/org_members.go
+++ b/db/org_members.go
@@ -43,10 +43,10 @@ func (ms *MongoStorage) SetOrgMember(salt string, orgMember *OrgMember) (string,
 		return "", err
 	}
 	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
 	filter := bson.M{"_id": member.ID}
 	opts := options.Update().SetUpsert(true)
 	_, err = ms.orgMembers.UpdateOne(ctx, filter, updateDoc, opts)
-	ms.keysLock.Unlock()
 	if err != nil {
 		return "", err
 	}
@@ -78,6 +78,7 @@ func (ms *MongoStorage) DelOrgMember(id string) error {
 	}
 
 	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
 	// create a context with a timeout
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
@@ -85,7 +86,6 @@ func (ms *MongoStorage) DelOrgMember(id string) error {
 	// delete the orgMember from the database using the ID
 	filter := bson.M{"_id": objID}
 	_, err = ms.orgMembers.DeleteOne(ctx, filter)
-	ms.keysLock.Unlock()
 	if err != nil {
 		return err
 	}
@@ -340,9 +340,11 @@ func (ms *MongoStorage) addOrgMemberBatches(
 
 	// Ensure the auto group exists now that members have been added.
 	if job.Added > 0 {
+		ms.keysLock.Lock()
 		if err := ms.EnsureAutoMemberGroup(org.Address); err != nil {
 			log.Warnw("could not ensure auto member group after bulk add", "error", err)
 		}
+		ms.keysLock.Unlock()
 	}
 }
 
@@ -379,7 +381,7 @@ func (ms *MongoStorage) UpsertOrgMemberAndCensusParticipants(org *Organization, 
 	defer cancel()
 
 	ms.keysLock.Lock()
-	// Lock is released explicitly below, before calling EnsureAutoMemberGroup.
+	defer ms.keysLock.Unlock()
 
 	// if this member exists already, check the orgAddress is not being changed
 	orgMemberInDB := &OrgMember{}
@@ -388,33 +390,28 @@ func (ms *MongoStorage) UpsertOrgMemberAndCensusParticipants(org *Organization, 
 			member.Phone = orgMemberInDB.Phone
 		}
 		if orgMemberInDB.OrgAddress != org.Address {
-			ms.keysLock.Unlock()
 			return primitive.NilObjectID, fmt.Errorf("modifying orgAddress is not allowed")
 		}
 	}
 
 	preparedMember, validationErrors := prepareOrgMember(org, member, salt, time.Now())
 	if len(validationErrors) > 0 {
-		ms.keysLock.Unlock()
 		return primitive.NilObjectID, fmt.Errorf("errors: %s", errorsAsStrings(validationErrors))
 	}
 
 	// Update the census participants first, to bail out early in case this would create any duplicates conflict
 	if err := ms.updateCensusParticipantsForMember(ctx, preparedMember); err != nil {
-		ms.keysLock.Unlock()
 		return primitive.NilObjectID, fmt.Errorf("failed to update census participants: %w", err)
 	}
 
 	updateDoc, err := dynamicUpdateDocument(preparedMember, []string{"weight"})
 	if err != nil {
-		ms.keysLock.Unlock()
 		return primitive.NilObjectID, err
 	}
 
 	filter := bson.M{"_id": preparedMember.ID}
 	opts := options.Update().SetUpsert(true)
 	_, err = ms.orgMembers.UpdateOne(ctx, filter, updateDoc, opts)
-	ms.keysLock.Unlock()
 	if err != nil {
 		return primitive.NilObjectID, fmt.Errorf("failed to upsert org member: %w", err)
 	}
@@ -562,6 +559,9 @@ func (ms *MongoStorage) DeleteOrgMembers(orgAddress common.Address, ids []string
 		},
 	}
 
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+
 	result, err := ms.orgMembers.DeleteMany(ctx, filter)
 	if err != nil {
 		return 0, fmt.Errorf("failed to delete orgMembers: %w", err)
@@ -622,10 +622,10 @@ func (ms *MongoStorage) DeleteAllOrgMembers(orgAddress common.Address) (int, err
 	}
 
 	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
 
 	result, err := ms.orgMembers.DeleteMany(ctx, filter)
 	if err != nil {
-		ms.keysLock.Unlock()
 		return 0, fmt.Errorf("failed to delete all orgMembers: %w", err)
 	}
 
@@ -641,7 +641,6 @@ func (ms *MongoStorage) DeleteAllOrgMembers(orgAddress common.Address) (int, err
 	}
 
 	_, err = ms.orgMemberGroups.UpdateMany(ctx, groupFilter, groupUpdate)
-	ms.keysLock.Unlock()
 	if err != nil {
 		return 0, fmt.Errorf("failed to update groups after deleting all orgMembers: %w", err)
 	}

--- a/db/org_members_groups.go
+++ b/db/org_members_groups.go
@@ -376,7 +376,7 @@ func (ms *MongoStorage) CheckGroupMembersFields(
 
 		// if the key is already seen, add to duplicates
 		// and continue to the next member
-		if len(authFields) > 0 {
+		if len(authFields) > 0 || len(twoFaFields) > 0 {
 			key := buildCompositeKey(bm, authFields, twoFaFields)
 			if val, seen := seenKeys[key]; seen {
 				duplicates[m.ID] = struct{}{}

--- a/db/org_members_groups.go
+++ b/db/org_members_groups.go
@@ -41,20 +41,11 @@ func (ms *MongoStorage) OrganizationMemberGroup(
 		}
 		return nil, err
 	}
-	// For the auto group, populate MemberIDs dynamically from the full orgMembers collection.
-	if group.IsAutoGroup {
-		ids, err := ms.GetAllOrgMemberIDs(orgAddress)
-		if err != nil {
-			return nil, fmt.Errorf("could not populate auto group members: %w", err)
-		}
-		group.MemberIDs = ids
-	}
 	return group, nil
 }
 
 // OrganizationMemberGroups returns the list of an organization's members groups.
-// The auto-generated "All members" group, if it exists, is always prepended as
-// the first element of the first page.
+// The auto-generated "All members" group, if it exists, always sorts first.
 func (ms *MongoStorage) OrganizationMemberGroups(
 	orgAddress common.Address,
 	page, limit int64,
@@ -63,44 +54,32 @@ func (ms *MongoStorage) OrganizationMemberGroups(
 		return 0, nil, ErrInvalidData
 	}
 
-	// Fetch the auto group separately (may not exist yet).
-	autoGroup, err := ms.orgAutoMemberGroup(orgAddress)
-	if err != nil {
-		return 0, nil, fmt.Errorf("could not fetch auto group: %w", err)
-	}
-
-	// Query only non-auto groups for regular pagination.
-	filter := bson.M{"orgAddress": orgAddress, "isAutoGroup": bson.M{"$ne": true}}
-	totalRegular, groups, err := paginatedDocuments[*OrganizationMemberGroup](
-		ms.orgMemberGroups, page, limit, filter, options.Find())
+	filter := bson.M{"orgAddress": orgAddress}
+	// Sort: auto group first (isAutoGroup DESC), then stable by _id ASC.
+	findOpts := options.Find().SetSort(bson.D{
+		{Key: "isAutoGroup", Value: -1},
+		{Key: "_id", Value: 1},
+	})
+	total, groups, err := paginatedDocuments[*OrganizationMemberGroup](
+		ms.orgMemberGroups, page, limit, filter, findOpts)
 	if err != nil {
 		return 0, nil, err
 	}
 
-	if autoGroup == nil {
-		// No auto group exists yet (org has no members).
-		return totalRegular, groups, nil
-	}
-
-	// Populate auto group member count dynamically.
-	memberCount, err := ms.CountOrgMembers(orgAddress)
-	if err != nil {
-		return 0, nil, fmt.Errorf("could not count auto group members: %w", err)
-	}
-	// MemberIDs slice stores the count implicitly; use a slice of the right length so
-	// callers that rely on len(MemberIDs) for display get the correct number without
-	// fetching all IDs.
-	autoGroup.MemberIDs = make([]string, memberCount)
-
-	// Prepend the auto group on the first page only.
-	total := totalRegular + 1
-	if page == 1 {
-		groups = append([]*OrganizationMemberGroup{autoGroup}, groups...)
-		// Trim to limit so callers never receive more items than requested.
-		if int64(len(groups)) > limit {
-			groups = groups[:limit]
+	// For any auto group in the results, populate member count dynamically.
+	for _, g := range groups {
+		if !g.IsAutoGroup {
+			continue
 		}
+		memberCount, err := ms.CountOrgMembers(orgAddress)
+		if err != nil {
+			return 0, nil, fmt.Errorf("could not count auto group members: %w", err)
+		}
+		// Use a slice of the right length so callers that rely on len(MemberIDs)
+		// for display get the correct count without fetching all IDs.
+		g.MemberIDs = make([]string, memberCount)
 	}
+
 	return total, groups, nil
 }
 
@@ -543,34 +522,22 @@ func buildCompositeKey(bm bson.M, authFields OrgMemberAuthFields, twoFaFields Or
 	return strings.Join(keyParts, "|")
 }
 
-// orgAutoMemberGroup fetches the auto-generated "All members" group for an organization,
-// or returns nil if it does not yet exist. It does NOT populate MemberIDs.
-func (ms *MongoStorage) orgAutoMemberGroup(orgAddress common.Address) (*OrganizationMemberGroup, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-	defer cancel()
-
-	filter := bson.M{"orgAddress": orgAddress, "isAutoGroup": true}
-	var group OrganizationMemberGroup
-	if err := ms.orgMemberGroups.FindOne(ctx, filter).Decode(&group); err != nil {
-		if err == mongo.ErrNoDocuments {
-			return nil, nil
-		}
-		return nil, err
-	}
-	return &group, nil
-}
-
 // EnsureAutoMemberGroup creates the auto-generated "All members" group for an organization
 // if it does not already exist. It is idempotent and safe to call after every member addition.
 func (ms *MongoStorage) EnsureAutoMemberGroup(orgAddress common.Address) error {
 	if orgAddress.Cmp(common.Address{}) == 0 {
 		return ErrInvalidData
 	}
-	existing, err := ms.orgAutoMemberGroup(orgAddress)
-	if err != nil {
+
+	checkCtx, checkCancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer checkCancel()
+
+	var existing OrganizationMemberGroup
+	err := ms.orgMemberGroups.FindOne(checkCtx, bson.M{"orgAddress": orgAddress, "isAutoGroup": true}).Decode(&existing)
+	if err != nil && err != mongo.ErrNoDocuments {
 		return fmt.Errorf("could not check for existing auto group: %w", err)
 	}
-	if existing != nil {
+	if err == nil {
 		return nil // already exists
 	}
 

--- a/db/org_members_groups.go
+++ b/db/org_members_groups.go
@@ -589,9 +589,6 @@ func (ms *MongoStorage) EnsureAutoMemberGroup(orgAddress common.Address) error {
 		UpdatedAt:   time.Now(),
 	}
 
-	ms.keysLock.Lock()
-	defer ms.keysLock.Unlock()
-
 	if _, err := ms.orgMemberGroups.InsertOne(ctx, group); err != nil {
 		return fmt.Errorf("could not create auto group: %w", err)
 	}
@@ -619,9 +616,6 @@ func (ms *MongoStorage) DeleteAutoMemberGroupIfEmpty(orgAddress common.Address) 
 func (ms *MongoStorage) deleteAutoMemberGroup(orgAddress common.Address) error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
-
-	ms.keysLock.Lock()
-	defer ms.keysLock.Unlock()
 
 	filter := bson.M{"orgAddress": orgAddress, "isAutoGroup": true}
 	_, err := ms.orgMemberGroups.DeleteOne(ctx, filter)

--- a/db/org_members_groups.go
+++ b/db/org_members_groups.go
@@ -41,10 +41,20 @@ func (ms *MongoStorage) OrganizationMemberGroup(
 		}
 		return nil, err
 	}
+	// For the auto group, populate MemberIDs dynamically from the full orgMembers collection.
+	if group.IsAutoGroup {
+		ids, err := ms.GetAllOrgMemberIDs(orgAddress)
+		if err != nil {
+			return nil, fmt.Errorf("could not populate auto group members: %w", err)
+		}
+		group.MemberIDs = ids
+	}
 	return group, nil
 }
 
-// OrganizationMemberGroups returns the list of an organization's members groups
+// OrganizationMemberGroups returns the list of an organization's members groups.
+// The auto-generated "All members" group, if it exists, is always prepended as
+// the first element of the first page.
 func (ms *MongoStorage) OrganizationMemberGroups(
 	orgAddress common.Address,
 	page, limit int64,
@@ -53,9 +63,45 @@ func (ms *MongoStorage) OrganizationMemberGroups(
 		return 0, nil, ErrInvalidData
 	}
 
-	filter := bson.M{"orgAddress": orgAddress}
+	// Fetch the auto group separately (may not exist yet).
+	autoGroup, err := ms.orgAutoMemberGroup(orgAddress)
+	if err != nil {
+		return 0, nil, fmt.Errorf("could not fetch auto group: %w", err)
+	}
 
-	return paginatedDocuments[*OrganizationMemberGroup](ms.orgMemberGroups, page, limit, filter, options.Find())
+	// Query only non-auto groups for regular pagination.
+	filter := bson.M{"orgAddress": orgAddress, "isAutoGroup": bson.M{"$ne": true}}
+	totalRegular, groups, err := paginatedDocuments[*OrganizationMemberGroup](
+		ms.orgMemberGroups, page, limit, filter, options.Find())
+	if err != nil {
+		return 0, nil, err
+	}
+
+	if autoGroup == nil {
+		// No auto group exists yet (org has no members).
+		return totalRegular, groups, nil
+	}
+
+	// Populate auto group member count dynamically.
+	memberCount, err := ms.CountOrgMembers(orgAddress)
+	if err != nil {
+		return 0, nil, fmt.Errorf("could not count auto group members: %w", err)
+	}
+	// MemberIDs slice stores the count implicitly; use a slice of the right length so
+	// callers that rely on len(MemberIDs) for display get the correct number without
+	// fetching all IDs.
+	autoGroup.MemberIDs = make([]string, memberCount)
+
+	// Prepend the auto group on the first page only.
+	total := totalRegular + 1
+	if page == 1 {
+		groups = append([]*OrganizationMemberGroup{autoGroup}, groups...)
+		// Trim to limit so callers never receive more items than requested.
+		if int64(len(groups)) > limit {
+			groups = groups[:limit]
+		}
+	}
+	return total, groups, nil
 }
 
 // CreateOrganizationMemberGroup Creates an organization member group
@@ -98,8 +144,9 @@ func (ms *MongoStorage) CreateOrganizationMemberGroup(group *OrganizationMemberG
 }
 
 // UpdateOrganizationMemberGroup updates an organization members group by adding
-// and/or removing members. If a member exists in both lists, it will be removed
-// TODO allow to update the rest of the fields as well. Maybe a different function?
+// and/or removing members. If a member exists in both lists, it will be removed.
+// For the auto-generated group, only title and description can be updated;
+// manual membership changes are not allowed and return ErrAutoGroupMembersCannotBeModified.
 func (ms *MongoStorage) UpdateOrganizationMemberGroup(
 	groupID string, orgAddress common.Address,
 	title, description string, addedMembers, removedMembers []string,
@@ -113,6 +160,10 @@ func (ms *MongoStorage) UpdateOrganizationMemberGroup(
 			return ErrInvalidData
 		}
 		return fmt.Errorf("could not retrieve organization members group: %w", err)
+	}
+	// Auto groups do not allow manual member manipulation.
+	if group.IsAutoGroup && (len(addedMembers) > 0 || len(removedMembers) > 0) {
+		return ErrAutoGroupMembersCannotBeModified
 	}
 	// create a context with a timeout
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
@@ -214,10 +265,23 @@ func (ms *MongoStorage) addOrganizationMemberGroupCensus(
 	return err
 }
 
-// DeleteOrganizationMemberGroup deletes an organization member group by its ID
+// DeleteOrganizationMemberGroup deletes an organization member group by its ID.
+// Returns ErrAutoGroupCannotBeDeleted if the group is the auto-generated "All members" group.
 func (ms *MongoStorage) DeleteOrganizationMemberGroup(groupID string, orgAddress common.Address) error {
 	if orgAddress.Cmp(common.Address{}) == 0 {
 		return ErrInvalidData
+	}
+	// Prevent deletion of the auto group.
+	group, err := ms.OrganizationMemberGroup(groupID, orgAddress)
+	if err != nil {
+		if err == ErrNotFound {
+			// Preserve original behaviour: silently succeed when group doesn't exist.
+			return nil
+		}
+		return fmt.Errorf("could not retrieve group: %w", err)
+	}
+	if group.IsAutoGroup {
+		return ErrAutoGroupCannotBeDeleted
 	}
 	// create a context with a timeout
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
@@ -253,7 +317,10 @@ func (ms *MongoStorage) ListOrganizationMemberGroup(
 	if err != nil {
 		return 0, nil, fmt.Errorf("could not retrieve organization members group: %w", err)
 	}
-
+	// For auto groups, all org members are included; query directly without an ID filter.
+	if group.IsAutoGroup {
+		return ms.OrgMembers(orgAddress, page, limit, "")
+	}
 	return ms.orgMembersByIDs(
 		orgAddress,
 		group.MemberIDs,
@@ -375,20 +442,24 @@ func (ms *MongoStorage) getGroupMembersFields(
 			}
 			return nil, fmt.Errorf("failed to fetch group %s for organization %s: %w", groupID, orgAddress, err)
 		}
-		// Check if the group has members
-		if len(group.MemberIDs) == 0 {
-			return nil, fmt.Errorf("no members in group %s for organization %s", groupID, orgAddress)
-		}
-		objectIDs := make([]primitive.ObjectID, len(group.MemberIDs))
-		for i, id := range group.MemberIDs {
-			objID, err := primitive.ObjectIDFromHex(id)
-			if err != nil {
-				return nil, fmt.Errorf("invalid member ID %s: %w", id, ErrInvalidData)
+		// Auto groups always contain every member; no extra ID filter is needed.
+		// For regular groups, restrict to the stored member IDs.
+		if !group.IsAutoGroup {
+			// Check if the group has members
+			if len(group.MemberIDs) == 0 {
+				return nil, fmt.Errorf("no members in group %s for organization %s", groupID, orgAddress)
 			}
-			objectIDs[i] = objID
-		}
-		if len(objectIDs) > 0 {
-			filter = append(filter, bson.E{Key: "_id", Value: bson.M{"$in": objectIDs}})
+			objectIDs := make([]primitive.ObjectID, len(group.MemberIDs))
+			for i, id := range group.MemberIDs {
+				objID, err := primitive.ObjectIDFromHex(id)
+				if err != nil {
+					return nil, fmt.Errorf("invalid member ID %s: %w", id, ErrInvalidData)
+				}
+				objectIDs[i] = objID
+			}
+			if len(objectIDs) > 0 {
+				filter = append(filter, bson.E{Key: "_id", Value: bson.M{"$in": objectIDs}})
+			}
 		}
 	}
 
@@ -470,4 +541,89 @@ func buildCompositeKey(bm bson.M, authFields OrgMemberAuthFields, twoFaFields Or
 	}
 
 	return strings.Join(keyParts, "|")
+}
+
+// orgAutoMemberGroup fetches the auto-generated "All members" group for an organization,
+// or returns nil if it does not yet exist. It does NOT populate MemberIDs.
+func (ms *MongoStorage) orgAutoMemberGroup(orgAddress common.Address) (*OrganizationMemberGroup, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	filter := bson.M{"orgAddress": orgAddress, "isAutoGroup": true}
+	var group OrganizationMemberGroup
+	if err := ms.orgMemberGroups.FindOne(ctx, filter).Decode(&group); err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &group, nil
+}
+
+// EnsureAutoMemberGroup creates the auto-generated "All members" group for an organization
+// if it does not already exist. It is idempotent and safe to call after every member addition.
+func (ms *MongoStorage) EnsureAutoMemberGroup(orgAddress common.Address) error {
+	if orgAddress.Cmp(common.Address{}) == 0 {
+		return ErrInvalidData
+	}
+	existing, err := ms.orgAutoMemberGroup(orgAddress)
+	if err != nil {
+		return fmt.Errorf("could not check for existing auto group: %w", err)
+	}
+	if existing != nil {
+		return nil // already exists
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	group := OrganizationMemberGroup{
+		ID:          primitive.NewObjectID(),
+		OrgAddress:  orgAddress,
+		Title:       AutoGroupTitle,
+		Description: AutoGroupDescription,
+		MemberIDs:   []string{},
+		CensusIDs:   []string{},
+		IsAutoGroup: true,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+
+	if _, err := ms.orgMemberGroups.InsertOne(ctx, group); err != nil {
+		return fmt.Errorf("could not create auto group: %w", err)
+	}
+	return nil
+}
+
+// DeleteAutoMemberGroupIfEmpty deletes the auto-generated "All members" group when the
+// organization has no more members. Should be called after any member deletion.
+func (ms *MongoStorage) DeleteAutoMemberGroupIfEmpty(orgAddress common.Address) error {
+	if orgAddress.Cmp(common.Address{}) == 0 {
+		return ErrInvalidData
+	}
+	count, err := ms.CountOrgMembers(orgAddress)
+	if err != nil {
+		return fmt.Errorf("could not count org members: %w", err)
+	}
+	if count > 0 {
+		return nil // still has members, keep the auto group
+	}
+	return ms.deleteAutoMemberGroup(orgAddress)
+}
+
+// deleteAutoMemberGroup unconditionally removes the auto-generated "All members" group.
+// Used when all members have been deleted at once.
+func (ms *MongoStorage) deleteAutoMemberGroup(orgAddress common.Address) error {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+
+	filter := bson.M{"orgAddress": orgAddress, "isAutoGroup": true}
+	_, err := ms.orgMemberGroups.DeleteOne(ctx, filter)
+	return err
 }

--- a/db/org_members_groups_test.go
+++ b/db/org_members_groups_test.go
@@ -1053,6 +1053,93 @@ func TestOrganizationMemberGroup(t *testing.T) {
 		c.Assert(results, qt.Not(qt.IsNil))
 		c.Assert(results.Duplicates, qt.HasLen, 0, qt.Commentf("Should NOT detect duplicates when 2FA fields make members unique"))
 		c.Assert(results.Members, qt.HasLen, 2, qt.Commentf("Should include both members as valid"))
+
+		// Test 13: Regression — duplicate detection must fire when ONLY twoFa
+		// fields are configured (authFields is empty).
+		//
+		// Before the fix the guard was `if len(authFields) > 0`, so the entire
+		// duplicate-detection block was skipped whenever authFields was empty,
+		// even if twoFaFields contained the only meaningful identity fields.
+		// This caused the census participant bulk-write to fail later with
+		// E11000 duplicate-key errors instead of surfacing a clean validation
+		// error here.
+		//
+		// Phone uniqueness is not enforced by the orgMembers unique index
+		// (the index uses the field name "hashedPhone" while data is stored
+		// under "phone"), so two members with the same phone but different
+		// emails can coexist — making phone the ideal field for this test.
+		regPhone1 := &OrgMember{
+			OrgAddress:     testOrgAddress,
+			Email:          "regression_dup1@test.com",
+			PlaintextPhone: "+34611222001", // same phone as regression_dup2
+			MemberNumber:   "reg_dup_001",
+			Name:           "Regression",
+			Surname:        "DupOne",
+			Password:       testPassword,
+		}
+		regPhone1ID, err := testDB.SetOrgMember(testSalt, regPhone1)
+		c.Assert(err, qt.IsNil)
+
+		regPhone2 := &OrgMember{
+			OrgAddress:     testOrgAddress,
+			Email:          "regression_dup2@test.com",
+			PlaintextPhone: "+34611222001", // same phone as regression_dup1
+			MemberNumber:   "reg_dup_002",
+			Name:           "Regression",
+			Surname:        "DupTwo",
+			Password:       testPassword,
+		}
+		regPhone2ID, err := testDB.SetOrgMember(testSalt, regPhone2)
+		c.Assert(err, qt.IsNil)
+
+		regPhoneUnique := &OrgMember{
+			OrgAddress:     testOrgAddress,
+			Email:          "regression_unique@test.com",
+			PlaintextPhone: "+34611222002", // unique phone
+			MemberNumber:   "reg_unique_003",
+			Name:           "Regression",
+			Surname:        "Unique",
+			Password:       testPassword,
+		}
+		regUniqueID, err := testDB.SetOrgMember(testSalt, regPhoneUnique)
+		c.Assert(err, qt.IsNil)
+
+		regGroup := &OrganizationMemberGroup{
+			OrgAddress:  testOrgAddress,
+			Title:       "Regression TwoFa-Only Dup Group",
+			Description: "Group for twoFa-only duplicate detection regression",
+			MemberIDs:   []string{regPhone1ID, regPhone2ID, regUniqueID},
+		}
+		regGroupID, err := testDB.CreateOrganizationMemberGroup(regGroup)
+		c.Assert(err, qt.IsNil)
+
+		// authFields intentionally empty — only twoFa fields provided.
+		results, err = testDB.CheckGroupMembersFields(
+			testOrgAddress,
+			regGroupID,
+			OrgMemberAuthFields{},
+			OrgMemberTwoFaFields{OrgMemberTwoFaFieldPhone},
+		)
+		c.Assert(err, qt.IsNil)
+		c.Assert(results, qt.Not(qt.IsNil))
+		// Both members sharing the same phone must be flagged as duplicates.
+		c.Assert(results.Duplicates, qt.HasLen, 2)
+		dupHex := make([]string, len(results.Duplicates))
+		for i, id := range results.Duplicates {
+			dupHex[i] = id.Hex()
+		}
+		c.Assert(contains(dupHex, regPhone1ID), qt.IsTrue)
+		c.Assert(contains(dupHex, regPhone2ID), qt.IsTrue)
+		// The member with the unique phone must not be flagged as a duplicate.
+		c.Assert(contains(dupHex, regUniqueID), qt.IsFalse)
+		// The second-seen duplicate must not appear in Members at all.
+		memberHex := make([]string, len(results.Members))
+		for i, id := range results.Members {
+			memberHex[i] = id.Hex()
+		}
+		c.Assert(contains(memberHex, regUniqueID), qt.IsTrue)
+		c.Assert(contains(memberHex, regPhone2ID), qt.IsFalse)
+		c.Assert(results.MissingData, qt.HasLen, 0)
 	})
 
 	// Test DeleteOrgMembers with automatic group cleanup

--- a/db/org_members_groups_test.go
+++ b/db/org_members_groups_test.go
@@ -158,11 +158,12 @@ func TestOrganizationMemberGroup(t *testing.T) {
 		_, memberIDs := setupTestOrgMembersGroupPrerequisites(t, "_list")
 
 		t.Run("EmptyList", func(_ *testing.T) {
-			// Test getting groups for organization with no groups
+			// Test getting groups for organization — members were added above so the
+			// auto group is already present.
 			totalItems, groups, err := testDB.OrganizationMemberGroups(testOrgAddress, 1, 10)
 			c.Assert(err, qt.IsNil)
-			c.Assert(groups, qt.HasLen, 0)
-			c.Assert(totalItems, qt.Equals, int64(0))
+			c.Assert(groups, qt.HasLen, 1) // only the auto group
+			c.Assert(totalItems, qt.Equals, int64(1))
 		})
 
 		t.Run("MultipleGroups", func(_ *testing.T) {
@@ -179,10 +180,11 @@ func TestOrganizationMemberGroup(t *testing.T) {
 			}
 
 			// Test getting all groups for the organization
+			// 3 regular groups + 1 auto group = 4 total
 			totalItems, groups, err := testDB.OrganizationMemberGroups(testOrgAddress, 1, 10)
 			c.Assert(err, qt.IsNil)
-			c.Assert(groups, qt.HasLen, 3)
-			c.Assert(totalItems, qt.Equals, int64(3))
+			c.Assert(groups, qt.HasLen, 4)
+			c.Assert(totalItems, qt.Equals, int64(4))
 
 			// Verify each group has the correct organization address
 			for _, group := range groups {
@@ -247,17 +249,19 @@ func TestOrganizationMemberGroup(t *testing.T) {
 			}
 
 			// Test getting groups for original organization
+			// 2 regular groups + 1 auto group = 3 total
 			_, groups1, err := testDB.OrganizationMemberGroups(testOrgAddress, 1, 10)
 			c.Assert(err, qt.IsNil)
-			c.Assert(groups1, qt.HasLen, 2)
+			c.Assert(groups1, qt.HasLen, 3)
 			for _, group := range groups1 {
 				c.Assert(group.OrgAddress, qt.DeepEquals, testOrgAddress)
 			}
 
 			// Test getting groups for different organization
+			// 3 regular groups + 1 auto group = 4 total
 			_, groups2, err := testDB.OrganizationMemberGroups(testAnotherOrgAddress, 1, 10)
 			c.Assert(err, qt.IsNil)
-			c.Assert(groups2, qt.HasLen, 3)
+			c.Assert(groups2, qt.HasLen, 4)
 			for _, group := range groups2 {
 				c.Assert(group.OrgAddress, qt.DeepEquals, testAnotherOrgAddress)
 			}

--- a/db/types.go
+++ b/db/types.go
@@ -369,6 +369,13 @@ type OrgMemberAggregationResults struct {
 	MissingData []primitive.ObjectID `json:"missingData" bson:"missingData"`
 }
 
+const (
+	// AutoGroupTitle is the title of the auto-generated group that always contains every member.
+	AutoGroupTitle = "All members"
+	// AutoGroupDescription is the description shown to users for the auto-generated group.
+	AutoGroupDescription = "This group is automatically generated and always contains every member of your member base."
+)
+
 // An Organization members' group is a precursor of a census, and is simply a
 // collection of members that are grouped together for a specific purpose
 type OrganizationMemberGroup struct {
@@ -376,10 +383,15 @@ type OrganizationMemberGroup struct {
 	OrgAddress  common.Address     `json:"orgAddress" bson:"orgAddress"`
 	Title       string             `json:"title" bson:"title"`
 	Description string             `json:"description" bson:"description"`
-	MemberIDs   []string           `json:"memberIds" bson:"memberIds"`
-	CreatedAt   time.Time          `json:"createdAt" bson:"createdAt"`
-	UpdatedAt   time.Time          `json:"updatedAt" bson:"updatedAt"`
-	CensusIDs   []string           `json:"censusIds" bson:"censusIds"`
+	// MemberIDs is intentionally empty for auto groups (IsAutoGroup == true).
+	// Their membership is derived dynamically from the full orgMembers collection.
+	MemberIDs []string  `json:"memberIds" bson:"memberIds"`
+	CreatedAt time.Time `json:"createdAt" bson:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt" bson:"updatedAt"`
+	CensusIDs []string  `json:"censusIds" bson:"censusIds"`
+	// IsAutoGroup marks this group as the auto-generated "All members" group.
+	// Auto groups cannot be deleted and their membership cannot be manually modified.
+	IsAutoGroup bool `json:"isAutoGroup" bson:"isAutoGroup"`
 }
 
 // Relates an OrgMember to a Census

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -542,6 +542,11 @@ definitions:
       id:
         description: Unique identifier for the group
         type: string
+      isAutoGroup:
+        description: |-
+          IsAutoGroup indicates this is the auto-generated "All members" group.
+          It cannot be deleted and its membership cannot be manually modified.
+        type: boolean
       memberIds:
         description: List of member IDs in the group
         items:

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -92,6 +92,8 @@ var (
 	ErrProcessCensusSizeExceedsSMSAllowance   = Error{Code: 40047, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("process census size exceeds sms allowance")}
 	ErrMaxOrganizationsReached                = Error{Code: 40048, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("user has reached maximum number of organizations")}
 	ErrExceedsOrganizationMembersLimit        = Error{Code: 40145, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("operation would exceed organization members limit")}
+	ErrAutoGroupCannotBeDeleted               = Error{Code: 40150, HTTPstatus: http.StatusForbidden, Err: fmt.Errorf("the \"All members\" group is auto-generated and cannot be deleted")}
+	ErrAutoGroupMembersCannotBeModified       = Error{Code: 40151, HTTPstatus: http.StatusForbidden, Err: fmt.Errorf("membership of the auto-generated \"All members\" group cannot be manually modified")}
 
 	// CSP errors (408)
 	ErrZeroWeightVoter = Error{Code: 40801, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("voter weight cannot be zero")}

--- a/migrations/0011_create_all_members_auto_group.go
+++ b/migrations/0011_create_all_members_auto_group.go
@@ -1,0 +1,73 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func init() {
+	AddMigration(11, "create_all_members_auto_group", upCreateAllMembersAutoGroup, downCreateAllMembersAutoGroup)
+}
+
+// upCreateAllMembersAutoGroup creates the "All members" auto group for every
+// organization that already has at least one member but does not yet have an
+// auto group.  New organizations receive their auto group automatically when
+// the first member is added via the application layer, so this migration only
+// needs to back-fill existing data.
+func upCreateAllMembersAutoGroup(ctx context.Context, database *mongo.Database) error {
+	orgMembers := database.Collection("orgMembers")
+	orgMemberGroups := database.Collection("orgMemberGroups")
+
+	// Find all distinct orgAddress values that have at least one member.
+	addresses, err := orgMembers.Distinct(ctx, "orgAddress", bson.D{})
+	if err != nil {
+		return fmt.Errorf("failed to list distinct org addresses: %w", err)
+	}
+
+	for _, addr := range addresses {
+		// Check whether an auto group already exists for this org (idempotent).
+		count, err := orgMemberGroups.CountDocuments(ctx,
+			bson.M{"orgAddress": addr, "isAutoGroup": true},
+			options.Count().SetLimit(1),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to check existing auto group for %v: %w", addr, err)
+		}
+		if count > 0 {
+			continue // already has an auto group, skip
+		}
+
+		now := time.Now()
+		group := bson.M{
+			"_id":         primitive.NewObjectID(),
+			"orgAddress":  addr,
+			"title":       "All members",
+			"description": "This group is automatically generated and always contains every member of your member base.",
+			"memberIds":   []string{},
+			"censusIds":   []string{},
+			"isAutoGroup": true,
+			"createdAt":   now,
+			"updatedAt":   now,
+		}
+
+		if _, err := orgMemberGroups.InsertOne(ctx, group); err != nil {
+			return fmt.Errorf("failed to insert auto group for %v: %w", addr, err)
+		}
+	}
+
+	return nil
+}
+
+// downCreateAllMembersAutoGroup removes all auto groups created by this migration.
+// It is safe to run multiple times.
+func downCreateAllMembersAutoGroup(_ context.Context, _ *mongo.Database) error {
+	// We intentionally do not delete auto groups on rollback to avoid data loss:
+	// the groups are harmless and may already be referenced by census records.
+	return nil
+}

--- a/migrations/0011_create_all_members_auto_group.go
+++ b/migrations/0011_create_all_members_auto_group.go
@@ -32,11 +32,13 @@ func upCreateAllMembersAutoGroup(ctx context.Context, database *mongo.Database) 
 	if err != nil {
 		return fmt.Errorf("failed to list organizations: %w", err)
 	}
-	defer cursor.Close(ctx)
+	defer func() {
+		_ = cursor.Close(ctx)
+	}()
 
 	for cursor.Next(ctx) {
 		var org struct {
-			ID interface{} `bson:"_id"`
+			ID any `bson:"_id"`
 		}
 		if err := cursor.Decode(&org); err != nil {
 			return fmt.Errorf("failed to decode organization: %w", err)

--- a/migrations/0011_create_all_members_auto_group.go
+++ b/migrations/0011_create_all_members_auto_group.go
@@ -21,16 +21,39 @@ func init() {
 // the first member is added via the application layer, so this migration only
 // needs to back-fill existing data.
 func upCreateAllMembersAutoGroup(ctx context.Context, database *mongo.Database) error {
+	organizations := database.Collection("organizations")
 	orgMembers := database.Collection("orgMembers")
 	orgMemberGroups := database.Collection("orgMemberGroups")
 
-	// Find all distinct orgAddress values that have at least one member.
-	addresses, err := orgMembers.Distinct(ctx, "orgAddress", bson.D{})
+	// Fetch all org addresses from the organizations collection.
+	// This is more efficient than Distinct on orgMembers for large member bases,
+	// since the organizations collection is far smaller.
+	cursor, err := organizations.Find(ctx, bson.D{}, options.Find().SetProjection(bson.M{"_id": 1}))
 	if err != nil {
-		return fmt.Errorf("failed to list distinct org addresses: %w", err)
+		return fmt.Errorf("failed to list organizations: %w", err)
 	}
+	defer cursor.Close(ctx)
 
-	for _, addr := range addresses {
+	for cursor.Next(ctx) {
+		var org struct {
+			ID interface{} `bson:"_id"`
+		}
+		if err := cursor.Decode(&org); err != nil {
+			return fmt.Errorf("failed to decode organization: %w", err)
+		}
+		addr := org.ID
+
+		// Skip orgs that have no members yet.
+		memberCount, err := orgMembers.CountDocuments(ctx,
+			bson.M{"orgAddress": addr},
+			options.Count().SetLimit(1),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to count members for %v: %w", addr, err)
+		}
+		if memberCount == 0 {
+			continue
+		}
 		// Check whether an auto group already exists for this org (idempotent).
 		count, err := orgMemberGroups.CountDocuments(ctx,
 			bson.M{"orgAddress": addr, "isAutoGroup": true},
@@ -61,13 +84,16 @@ func upCreateAllMembersAutoGroup(ctx context.Context, database *mongo.Database) 
 		}
 	}
 
-	return nil
+	return cursor.Err()
 }
 
-// downCreateAllMembersAutoGroup removes all auto groups created by this migration.
+// downCreateAllMembersAutoGroup deletes all auto groups created by this migration.
 // It is safe to run multiple times.
-func downCreateAllMembersAutoGroup(_ context.Context, _ *mongo.Database) error {
-	// We intentionally do not delete auto groups on rollback to avoid data loss:
-	// the groups are harmless and may already be referenced by census records.
+func downCreateAllMembersAutoGroup(ctx context.Context, database *mongo.Database) error {
+	orgMemberGroups := database.Collection("orgMemberGroups")
+	_, err := orgMemberGroups.DeleteMany(ctx, bson.M{"isAutoGroup": true})
+	if err != nil {
+		return fmt.Errorf("failed to delete auto groups: %w", err)
+	}
 	return nil
 }

--- a/subscriptions/subscriptions.go
+++ b/subscriptions/subscriptions.go
@@ -275,12 +275,21 @@ func (p *Subscriptions) OrgCanPublishGroupCensus(census *db.Census, groupID stri
 		return errors.ErrGroupNotFound.WithErr(err)
 	}
 
+	memberCount := len(group.MemberIDs)
+	if group.IsAutoGroup {
+		count, err := p.db.CountOrgMembers(org.Address)
+		if err != nil {
+			return errors.ErrGenericInternalServerError.WithErr(err)
+		}
+		memberCount = int(count)
+	}
+
 	remainingEmails := plan.Features.TwoFaEmail - org.Counters.SentEmails
-	if census.TwoFaFields.Contains(db.OrgMemberTwoFaFieldEmail) && len(group.MemberIDs) > remainingEmails {
+	if census.TwoFaFields.Contains(db.OrgMemberTwoFaFieldEmail) && memberCount > remainingEmails {
 		return errors.ErrProcessCensusSizeExceedsEmailAllowance.Withf("remaining emails: %d", remainingEmails)
 	}
 	remainingSMS := plan.Features.TwoFaSms - org.Counters.SentSMS
-	if census.TwoFaFields.Contains(db.OrgMemberTwoFaFieldPhone) && len(group.MemberIDs) > remainingSMS {
+	if census.TwoFaFields.Contains(db.OrgMemberTwoFaFieldPhone) && memberCount > remainingSMS {
 		return errors.ErrProcessCensusSizeExceedsSMSAllowance.Withf("remaining sms: %d", remainingSMS)
 	}
 


### PR DESCRIPTION
 ### Summary                                                                                                   
                                                                                                               
 When a user uploads a memberbase (or adds the first member), the platform now automatically creates an "All   
 members" group that always mirrors the entire memberbase. This eliminates the need to manually create a group 
 before starting a voting process, making the onboarding flow significantly smoother.                          
                                                                                                               
 ### How it works                                                                                              
                                                                                                               
 Rather than maintaining a real list of member IDs in sync, the auto group is stored as a lightweight document 
 with isAutoGroup: true and no stored member IDs. Its membership is resolved dynamically at read time by       
 querying the orgMembers collection directly — so it is always perfectly in sync with zero maintenance         
 overhead.                                                                                                     
                                                                                                               
 ### Behaviour                                                                                                 
                                                                                                               
 - Created automatically when the first member is added to an organization (via bulk upload, single upsert, or 
 CSV import)                                                                                                   
 - Always appears first in the groups listing (page 1 only, never duplicated on subsequent pages)              
 - Cannot be deleted — returns 403 Forbidden                                                                   
 - Membership cannot be manually modified — returns 403 Forbidden; title and description can still be updated  
 - Disappears automatically when all members are removed, and reappears when a member is added again           
 - Works transparently with the census flow (validation, creation) since the group has a real MongoDB ObjectID 
 - The isAutoGroup: true flag is exposed in API responses so frontends can display appropriate messaging       
                                                                                                               
 ### Changes                                                                                                   
                                                                                                               
 - db/types.go — added IsAutoGroup bool to OrganizationMemberGroup; added AutoGroupTitle /                     
 AutoGroupDescription constants                                                                                
 - db/errors.go — added ErrAutoGroupCannotBeDeleted and ErrAutoGroupMembersCannotBeModified                    
 - db/org_members_groups.go — dynamic member population on read; auto group prepended on page 1;               
 delete/member-edit blocked; ListOrganizationMemberGroup and census field validation handle auto groups        
 correctly; new EnsureAutoMemberGroup, DeleteAutoMemberGroupIfEmpty, deleteAutoMemberGroup helpers             
 - db/org_members.go — hooked auto group lifecycle into all member mutation paths (SetOrgMember,               
 AddBulkOrgMembers, UpsertOrgMemberAndCensusParticipants, DelOrgMember, DeleteOrgMembers,                      
 DeleteAllOrgMembers); fixed lock release ordering to avoid deadlocks                                          
 - errors/errors_definition.go — two new 403 Forbidden error codes                                             
 - api/apicommon/types.go — IsAutoGroup bool added to OrganizationMemberGroupInfo                              
 - api/organization_groups.go — isAutoGroup passed through in all responses; handlers return correct errors    
 for delete/update attempts on auto groups                                                                     
 - migrations/0011_create_all_members_auto_group.go — back-fills the auto group for all existing organizations 
 that already have members (idempotent)                                                                        
                                                                                                               
 ### Tests                                                                                                     
                                                                                                               
 10 new integration tests covering all acceptance criteria, plus updates to existing group tests to account    
 for the auto group now appearing in listings.

closes #434