### PR TITLE
chore: merge v2.5.0 from developt to stage

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -296,6 +296,7 @@ func (a *API) initRouter() http.Handler {
 		handle(r, http.MethodGet, processBundleInfoEndpoint, a.processBundleInfoHandler)
 		handle(r, http.MethodPost, processBundleWeightEndpoint, cspHandlers.UserWeightHandler)
 		handle(r, http.MethodPost, processBundleAuthEndpoint, cspHandlers.BundleAuthHandler)
+		handle(r, http.MethodPost, processBundleAuthResendEndpoint, cspHandlers.BundleAuthResendHandler)
 		handle(r, http.MethodPost, processBundleSignEndpoint, cspHandlers.BundleSignHandler)
 		handle(r, http.MethodGet, processBundleMemberEndpoint, a.processBundleParticipantInfoHandler)
 	})

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -223,6 +223,9 @@ type OrganizationMemberGroupInfo struct {
 	CensusIDs []string `json:"censusIds,omitempty" bson:"censusIds"`
 	// Count of members in the group
 	MembersCount int `json:"membersCount,omitempty" bson:"membersCount"`
+	// IsAutoGroup indicates this is the auto-generated "All members" group.
+	// It cannot be deleted and its membership cannot be manually modified.
+	IsAutoGroup bool `json:"isAutoGroup,omitempty" bson:"isAutoGroup"`
 }
 
 // OrganizationMemberGroupsResponse represents the response for listing organization member groups.

--- a/api/organization_groups.go
+++ b/api/organization_groups.go
@@ -78,6 +78,7 @@ func (a *API) organizationMemberGroupsHandler(w http.ResponseWriter, r *http.Req
 			UpdatedAt:    group.UpdatedAt,
 			CensusIDs:    group.CensusIDs,
 			MembersCount: len(group.MemberIDs),
+			IsAutoGroup:  group.IsAutoGroup,
 		})
 	}
 	apicommon.HTTPWriteJSON(w, memberGroups)
@@ -134,15 +135,29 @@ func (a *API) organizationMemberGroupHandler(w http.ResponseWriter, r *http.Requ
 		errors.ErrGenericInternalServerError.Withf("could not get organization member group: %v", err).Write(w)
 		return
 	}
-	apicommon.HTTPWriteJSON(w, &apicommon.OrganizationMemberGroupInfo{
+
+	info := &apicommon.OrganizationMemberGroupInfo{
 		ID:          group.ID.Hex(),
 		Title:       group.Title,
 		Description: group.Description,
-		MemberIDs:   group.MemberIDs,
 		CensusIDs:   group.CensusIDs,
 		CreatedAt:   group.CreatedAt,
 		UpdatedAt:   group.UpdatedAt,
-	})
+		IsAutoGroup: group.IsAutoGroup,
+	}
+	// Auto groups store no member IDs in the document; expose the live count
+	// instead, consistent with the groups-listing response.
+	if group.IsAutoGroup {
+		count, err := a.db.CountOrgMembers(org.Address)
+		if err != nil {
+			errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+			return
+		}
+		info.MembersCount = int(count)
+	} else {
+		info.MemberIDs = group.MemberIDs
+	}
+	apicommon.HTTPWriteJSON(w, info)
 }
 
 // createOrganizationMemberGroupHandler godoc
@@ -287,11 +302,14 @@ func (a *API) updateOrganizationMemberGroupHandler(w http.ResponseWriter, r *htt
 		toUpdate.RemoveMembers,
 	)
 	if err != nil {
-		if err == db.ErrNotFound {
+		switch err {
+		case db.ErrNotFound, db.ErrInvalidData:
 			errors.ErrInvalidData.Withf("group not found").Write(w)
-			return
+		case db.ErrAutoGroupMembersCannotBeModified:
+			errors.ErrAutoGroupMembersCannotBeModified.Write(w)
+		default:
+			errors.ErrGenericInternalServerError.Withf("could not update organization member group: %v", err).Write(w)
 		}
-		errors.ErrGenericInternalServerError.Withf("could not update organization member group: %v", err).Write(w)
 		return
 	}
 	apicommon.HTTPWriteOK(w)
@@ -338,11 +356,14 @@ func (a *API) deleteOrganizationMemberGroupHandler(w http.ResponseWriter, r *htt
 		return
 	}
 	if err := a.db.DeleteOrganizationMemberGroup(groupID, org.Address); err != nil {
-		if err == db.ErrNotFound {
+		switch err {
+		case db.ErrNotFound:
 			errors.ErrInvalidData.Withf("group not found").Write(w)
-			return
+		case db.ErrAutoGroupCannotBeDeleted:
+			errors.ErrAutoGroupCannotBeDeleted.Write(w)
+		default:
+			errors.ErrGenericInternalServerError.Withf("could not delete organization member group: %v", err).Write(w)
 		}
-		errors.ErrGenericInternalServerError.Withf("could not delete organization member group: %v", err).Write(w)
 		return
 	}
 	apicommon.HTTPWriteOK(w)

--- a/api/organization_groups_autogroup_test.go
+++ b/api/organization_groups_autogroup_test.go
@@ -1,0 +1,306 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/api/apicommon"
+)
+
+// TestAutoGroupCreatedOnMemberUpload verifies that uploading members automatically
+// creates the "All members" auto group as the first group in the listing.
+func TestAutoGroupCreatedOnMemberUpload(t *testing.T) {
+	c := qt.New(t)
+
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	// No members yet — no auto group should appear.
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups, qt.HasLen, 0)
+
+	// Add members via bulk upload.
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(3)...)
+
+	// Auto group must now exist and be the first (and only) group.
+	groupsResp = requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups, qt.HasLen, 1)
+
+	autoGroup := groupsResp.Groups[0]
+	c.Assert(autoGroup.IsAutoGroup, qt.IsTrue)
+	c.Assert(autoGroup.Title, qt.Equals, "All members")
+	c.Assert(autoGroup.MembersCount, qt.Equals, 3)
+}
+
+// TestAutoGroupCreatedOnSingleMemberAdd verifies the auto group is created when a
+// single member is added via the upsert endpoint.
+func TestAutoGroupCreatedOnSingleMemberAdd(t *testing.T) {
+	c := qt.New(t)
+
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	// Upsert a single member.
+	member := apicommon.OrgMember{
+		MemberNumber: "001",
+		Name:         "Alice",
+		Surname:      "Smith",
+		Email:        "alice@example.com",
+	}
+	requestAndAssertCode(http.StatusOK,
+		t, http.MethodPut, adminToken, &member,
+		"organizations", orgAddress.String(), "members")
+
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups, qt.HasLen, 1)
+	c.Assert(groupsResp.Groups[0].IsAutoGroup, qt.IsTrue)
+	c.Assert(groupsResp.Groups[0].MembersCount, qt.Equals, 1)
+}
+
+// TestAutoGroupAlwaysMirrorsFullMemberbase verifies that the auto group member count
+// stays in sync as members are added and removed.
+func TestAutoGroupAlwaysMirrorsFullMemberbase(t *testing.T) {
+	c := qt.New(t)
+
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(5)...)
+
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups, qt.HasLen, 1)
+	autoGroupID := groupsResp.Groups[0].ID
+	c.Assert(groupsResp.Groups[0].MembersCount, qt.Equals, 5)
+
+	// Fetch the single group details — MembersCount must reflect all 5.
+	groupDetail := requestAndParse[apicommon.OrganizationMemberGroupInfo](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups", autoGroupID)
+	c.Assert(groupDetail.MembersCount, qt.Equals, 5)
+
+	// Add 2 more members.
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(2)...)
+
+	groupsResp = requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups[0].MembersCount, qt.Equals, 7)
+
+	// Remove specific members.
+	allMembers := getOrgMembers(t, adminToken, orgAddress)
+	toDelete := []string{allMembers.Members[0].ID, allMembers.Members[1].ID}
+	deleteReq := &apicommon.DeleteMembersRequest{IDs: toDelete}
+	requestAndAssertCode(http.StatusOK,
+		t, http.MethodDelete, adminToken, deleteReq,
+		"organizations", orgAddress.String(), "members")
+
+	groupsResp = requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups[0].MembersCount, qt.Equals, 5)
+}
+
+// TestAutoGroupPaginatedMembersList verifies that the paginated members endpoint
+// works correctly for the auto group.
+func TestAutoGroupPaginatedMembersList(t *testing.T) {
+	c := qt.New(t)
+
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(4)...)
+
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	autoGroupID := groupsResp.Groups[0].ID
+
+	membersResp := requestAndParse[apicommon.ListOrganizationMemberGroupResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups", autoGroupID, "members")
+	c.Assert(membersResp.Members, qt.HasLen, 4)
+}
+
+// TestAutoGroupCannotBeDeleted verifies that attempting to delete the auto group
+// returns 403 Forbidden.
+func TestAutoGroupCannotBeDeleted(t *testing.T) {
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(2)...)
+
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	autoGroupID := groupsResp.Groups[0].ID
+
+	requestAndAssertCode(http.StatusForbidden,
+		t, http.MethodDelete, adminToken, nil,
+		"organizations", orgAddress.String(), "groups", autoGroupID)
+}
+
+// TestAutoGroupMembersCannotBeManuallyModified verifies that trying to add or
+// remove members from the auto group returns 403 Forbidden.
+func TestAutoGroupMembersCannotBeManuallyModified(t *testing.T) {
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(2)...)
+
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	autoGroupID := groupsResp.Groups[0].ID
+
+	allMembers := getOrgMembers(t, adminToken, orgAddress)
+
+	updateReq := &apicommon.UpdateOrganizationMemberGroupsRequest{
+		RemoveMembers: []string{allMembers.Members[0].ID},
+	}
+	requestAndAssertCode(http.StatusForbidden,
+		t, http.MethodPut, adminToken, updateReq,
+		"organizations", orgAddress.String(), "groups", autoGroupID)
+}
+
+// TestAutoGroupTitleDescriptionCanBeUpdated verifies that updating only the
+// title/description of the auto group is allowed.
+func TestAutoGroupTitleDescriptionCanBeUpdated(t *testing.T) {
+	c := qt.New(t)
+
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(1)...)
+
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	autoGroupID := groupsResp.Groups[0].ID
+
+	updateReq := &apicommon.UpdateOrganizationMemberGroupsRequest{
+		Title:       "My Renamed All-Members Group",
+		Description: "Custom description",
+	}
+	requestAndAssertCode(http.StatusOK,
+		t, http.MethodPut, adminToken, updateReq,
+		"organizations", orgAddress.String(), "groups", autoGroupID)
+
+	groupDetail := requestAndParse[apicommon.OrganizationMemberGroupInfo](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups", autoGroupID)
+	c.Assert(groupDetail.Title, qt.Equals, "My Renamed All-Members Group")
+	c.Assert(groupDetail.Description, qt.Equals, "Custom description")
+	c.Assert(groupDetail.IsAutoGroup, qt.IsTrue)
+}
+
+// TestAutoGroupDisappearsWhenAllMembersDeleted verifies that deleting all members
+// removes the auto group entirely, and it reappears when a member is re-added.
+func TestAutoGroupDisappearsWhenAllMembersDeleted(t *testing.T) {
+	c := qt.New(t)
+
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(3)...)
+
+	// Auto group exists.
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups, qt.HasLen, 1)
+
+	// Delete all members.
+	deleteAllReq := &apicommon.DeleteMembersRequest{All: true}
+	requestAndAssertCode(http.StatusOK,
+		t, http.MethodDelete, adminToken, deleteAllReq,
+		"organizations", orgAddress.String(), "members")
+
+	// Auto group should be gone.
+	groupsResp = requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups, qt.HasLen, 0)
+
+	// Re-add a member — auto group should reappear.
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(1)...)
+
+	groupsResp = requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups, qt.HasLen, 1)
+	c.Assert(groupsResp.Groups[0].IsAutoGroup, qt.IsTrue)
+	c.Assert(groupsResp.Groups[0].MembersCount, qt.Equals, 1)
+}
+
+// TestAutoGroupDisappearsWhenLastMemberDeleted verifies that deleting the final
+// member one-by-one removes the auto group.
+func TestAutoGroupDisappearsWhenLastMemberDeleted(t *testing.T) {
+	c := qt.New(t)
+
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(1)...)
+
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups, qt.HasLen, 1)
+
+	memberID := getOrgMembers(t, adminToken, orgAddress).Members[0].ID
+	deleteReq := &apicommon.DeleteMembersRequest{IDs: []string{memberID}}
+	requestAndAssertCode(http.StatusOK,
+		t, http.MethodDelete, adminToken, deleteReq,
+		"organizations", orgAddress.String(), "members")
+
+	groupsResp = requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+	c.Assert(groupsResp.Groups, qt.HasLen, 0)
+}
+
+// TestAutoGroupAppearsFirstInPagination verifies that when multiple groups exist,
+// the auto group is always the first element on page 1.
+func TestAutoGroupAppearsFirstInPagination(t *testing.T) {
+	c := qt.New(t)
+
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	postOrgMembers(t, adminToken, orgAddress, newOrgMembers(3)...)
+
+	allMembersResp := getOrgMembers(t, adminToken, orgAddress)
+	memberIDs := make([]string, len(allMembersResp.Members))
+	for i, m := range allMembersResp.Members {
+		memberIDs[i] = m.ID
+	}
+
+	// Create two regular groups.
+	for _, title := range []string{"Group A", "Group B"} {
+		createReq := &apicommon.CreateOrganizationMemberGroupRequest{
+			Title:     title,
+			MemberIDs: memberIDs[:1],
+		}
+		requestAndAssertCode(http.StatusOK,
+			t, http.MethodPost, adminToken, createReq,
+			"organizations", orgAddress.String(), "groups")
+	}
+
+	groupsResp := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
+		t, http.MethodGet, adminToken, nil,
+		"organizations", orgAddress.String(), "groups")
+
+	// Total: 1 auto + 2 regular = 3.
+	c.Assert(groupsResp.Pagination.TotalItems, qt.Equals, int64(3))
+	// First element must be the auto group.
+	c.Assert(groupsResp.Groups[0].IsAutoGroup, qt.IsTrue)
+}

--- a/api/organization_groups_test.go
+++ b/api/organization_groups_test.go
@@ -133,7 +133,10 @@ func TestOrganizationGroups(t *testing.T) {
 		groupsResponse := requestAndParse[apicommon.OrganizationMemberGroupsResponse](
 			t, http.MethodGet, adminToken, nil,
 			"organizations", orgAddress.String(), "groups")
-		c.Assert(groupsResponse.Groups, qt.HasLen, 2) // We created two groups in the previous test (Test 1 and Test 6)
+		// Now 3 groups: the auto "All members" group + two regular groups created above
+		c.Assert(groupsResponse.Groups, qt.HasLen, 3)
+		// First group must always be the auto group
+		c.Assert(groupsResponse.Groups[0].IsAutoGroup, qt.IsTrue)
 
 		// Test 2: Try to get groups without authentication
 		requestAndAssertCode(http.StatusUnauthorized,
@@ -151,8 +154,8 @@ func TestOrganizationGroups(t *testing.T) {
 			t, http.MethodGet, adminToken, nil,
 			"organizations", "invalid-address", "groups")
 
-		// Save the first group ID for later tests
-		firstGroupID := groupsResponse.Groups[0].ID
+		// Save the first non-auto group ID for later tests
+		firstGroupID := groupsResponse.Groups[1].ID
 		c.Assert(firstGroupID, qt.Not(qt.Equals), "")
 
 		// Test 5: Get a specific group by ID
@@ -177,7 +180,15 @@ func TestOrganizationGroups(t *testing.T) {
 			"organizations", orgAddress.String(), "groups")
 		c.Assert(len(groupsResponse.Groups) > 0, qt.IsTrue)
 
-		groupID := groupsResponse.Groups[0].ID
+		// Pick the first non-auto group for update/member-manipulation tests.
+		var groupID string
+		for _, g := range groupsResponse.Groups {
+			if !g.IsAutoGroup {
+				groupID = g.ID
+				break
+			}
+		}
+		c.Assert(groupID, qt.Not(qt.Equals), "")
 
 		// Test 1: Update the group's title and description
 		updateRequest := &apicommon.UpdateOrganizationMemberGroupsRequest{

--- a/api/routes.go
+++ b/api/routes.go
@@ -152,6 +152,8 @@ const (
 	processBundleInfoEndpoint = "/process/bundle/{bundleId}"
 	// POST /process/bundle/{bundleId}/auth/{step} to check if the voter is authorized
 	processBundleAuthEndpoint = "/process/bundle/{bundleId}/auth/{step}"
+	// POST /process/bundle/{bundleId}/auth/resend to resend the auth challenge
+	processBundleAuthResendEndpoint = "/process/bundle/{bundleId}/auth/resend"
 	// POST /process/bundle/{bundleId}/weight to get the voter weight for the bundle
 	processBundleWeightEndpoint = "/process/bundle/{bundleId}/weight"
 	// POST /process/bundle/{bundleId}/sign to sign with two-factor authentication

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -205,7 +205,7 @@ func queryProcessOnly(database *db.MongoStorage, client *vocapi.HTTPclient, proc
 	}
 	fmt.Printf("Distinct Voter IDs in Org for Process:\n")
 	for _, orgMember := range orgMembers {
-		fmt.Printf("%s\n", orgMember.ID.Hex())
+		fmt.Printf("%s\n", orgMember.MemberNumber)
 	}
 
 	return nil

--- a/csp/auth.go
+++ b/csp/auth.go
@@ -47,12 +47,15 @@ func (c *CSP) BundleAuthToken(bID, uID internal.HexBytes, to string,
 		return nil, ErrStorageFailure
 	}
 	// check if the last token was created less than the cooldown time
-	if lastToken != nil && time.Since(lastToken.CreatedAt) < c.notificationCoolDownTime {
-		log.Warnw("cooldown time not reached",
-			"userID", uID,
-			"bundleID", bID,
-			"lastToken", lastToken.Token)
-		return nil, errors.ErrAttemptCoolDownTime
+	if lastToken != nil {
+		remainingTime := c.notificationCoolDownTime - time.Since(lastToken.CreatedAt)
+		if remainingTime > 0 {
+			log.Warnw("cooldown time not reached",
+				"userID", uID,
+				"bundleID", bID,
+				"lastToken", lastToken.Token)
+			return nil, errors.ErrAttemptCoolDownTime.WithData(map[string]any{"coolDownTime": remainingTime.Milliseconds()})
+		}
 	}
 	// generate a new token, secret and code from the attempt number
 	token, code, err := c.generateToken(uID, bID)
@@ -73,13 +76,13 @@ func (c *CSP) BundleAuthToken(bID, uID internal.HexBytes, to string,
 		"bundleID", bID,
 		"token", token)
 	// compose the notification challenge
-	remainingTime := c.notificationCoolDownTime.String()
+	remainingTimeN := c.notificationCoolDownTime.String()
 	orgInfo := notifications.OrganizationInfo{
 		Address: orgAddress,
 		Name:    orgName,
 		Logo:    orgLogo,
 	}
-	ch, err := notifications.NewNotificationChallenge(ctype, lang, uID, bID, to, code, orgInfo, remainingTime)
+	ch, err := notifications.NewNotificationChallenge(ctype, lang, uID, bID, to, code, orgInfo, remainingTimeN)
 	if err != nil {
 		log.Warnw("error composing notification challenge",
 			"userID", uID,
@@ -98,6 +101,83 @@ func (c *CSP) BundleAuthToken(bID, uID internal.HexBytes, to string,
 		return nil, ErrNotificationFailure
 	}
 	return token, nil
+}
+
+func (c *CSP) ResendChallenge(token internal.HexBytes, to string,
+	ctype notifications.ChallengeType, lang string,
+	orgName, orgLogo string, orgAddress common.Address,
+) error {
+	// check the input parameters
+	if len(token) == 0 {
+		return ErrInvalidAuthToken
+	}
+	if to == "" || ctype == "" {
+		return errors.ErrInvalidData.Withf("missing challenge destination or type")
+	}
+
+	// get the user data from the token
+	authTokenData, err := c.Storage.CSPAuth(token)
+	if err != nil {
+		log.Warnw("error getting user data by token",
+			"token", token,
+			"error", err)
+		return ErrInvalidAuthToken
+	}
+
+	remainingTime := c.notificationCoolDownTime - time.Since(authTokenData.CreatedAt)
+	if remainingTime.Seconds() < 0 {
+		log.Warnw("resend requested but cooldown time reached",
+			"userID", authTokenData.UserID,
+			"bundleID", authTokenData.BundleID,
+			"lastToken", authTokenData.Token)
+		return ErrTokenExpired
+	} else if authTokenData.Verified {
+		return errors.ErrUserAlreadyVerified.WithData(map[string]any{"coolDownTime": remainingTime.Seconds()})
+	}
+	// compose the notification challenge
+	remainingTimeN := c.notificationCoolDownTime.String()
+	orgInfo := notifications.OrganizationInfo{
+		Address: orgAddress,
+		Name:    orgName,
+		Logo:    orgLogo,
+	}
+	code, err := c.regenerateTokenCode(authTokenData.UserID, authTokenData.BundleID)
+	if err != nil {
+		log.Warnw("error regenerating token code",
+			"userID", authTokenData.UserID,
+			"bundleID", authTokenData.BundleID,
+			"token", token,
+			"error", err)
+		return ErrChallengeCodeFailure
+	}
+	ch, err := notifications.NewNotificationChallenge(
+		ctype,
+		lang,
+		authTokenData.UserID,
+		authTokenData.BundleID,
+		to,
+		code,
+		orgInfo,
+		remainingTimeN,
+	)
+	if err != nil {
+		log.Warnw("error composing notification challenge",
+			"userID", authTokenData.UserID,
+			"bundleID", authTokenData.BundleID,
+			"token", token,
+			"error", err)
+		return ErrNotificationFailure
+	}
+	// push the challenge to the queue to be sent
+	if err := c.notifyQueue.Push(ch); err != nil {
+		log.Warnw("error pushing notification challenge",
+			"userID", authTokenData.UserID,
+			"bundleID", authTokenData.BundleID,
+			"token", token,
+			"error", err)
+		return ErrNotificationFailure
+	}
+	return nil
 }
 
 // VerifyBundleAuthToken method verifies the authentication token for a user
@@ -167,6 +247,15 @@ func (*CSP) generateToken(uID, bID internal.HexBytes) (
 		return nil, "", ErrInvalidAuthToken
 	}
 	return bToken, code, nil
+}
+
+func (*CSP) regenerateTokenCode(uID, bID internal.HexBytes) (
+	string, error,
+) {
+	secret := otpSecret(uID, bID)
+	otp := gotp.NewDefaultHOTP(secret)
+	code := otp.At(0)
+	return code, nil
 }
 
 // verifySolution method verifies the solution for a user process. It generates

--- a/csp/auth_test.go
+++ b/csp/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base32"
+	"io"
 	"regexp"
 	"testing"
 	"time"
@@ -73,6 +74,26 @@ func TestBundleAuthToken(t *testing.T) {
 		_, err = csp.BundleAuthToken(testBundleID, testUserID, "",
 			notifications.EmailChallenge, apicommon.DefaultLang, "", "", testAddress.Address())
 		c.Assert(err, qt.ErrorIs, errors.ErrAttemptCoolDownTime)
+
+		var apiErr errors.Error
+		c.Assert(errors.As(err, &apiErr), qt.IsTrue)
+
+		data, ok := apiErr.Data.(map[string]any)
+		c.Assert(ok, qt.IsTrue)
+
+		coolDownTime, ok := data["coolDownTime"]
+		c.Assert(ok, qt.IsTrue)
+
+		switch v := coolDownTime.(type) {
+		case int:
+			c.Assert(v > 0, qt.IsTrue)
+		case int64:
+			c.Assert(v > 0, qt.IsTrue)
+		case float64:
+			c.Assert(v > 0, qt.IsTrue)
+		default:
+			c.Fatalf("coolDownTime should be a positive numeric value in a client-friendly unit, got %T", coolDownTime)
+		}
 	})
 
 	c.Run("auth-only ignores cooldown", func(c *qt.C) {
@@ -206,6 +227,211 @@ func TestVerifyBundleAuthToken(t *testing.T) {
 	})
 }
 
+func TestResendChallenge(t *testing.T) {
+	c := qt.New(t)
+
+	testDB, err := db.New(testMongoURI, test.RandomDatabaseName())
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	csp, err := New(ctx, &Config{
+		DB:                       testDB,
+		MailService:              testMailService,
+		SMSService:               testSMSService,
+		NotificationThrottleTime: time.Second,
+		NotificationCoolDownTime: time.Second * 5,
+		RootKey:                  *testRootKey,
+	})
+	c.Assert(err, qt.IsNil)
+
+	c.Run("empty token", func(c *qt.C) {
+		err := csp.ResendChallenge(
+			nil,
+			testUserEmail,
+			notifications.EmailChallenge,
+			apicommon.DefaultLang,
+			testOrgName,
+			testOrgLogo,
+			testAddress.Address(),
+		)
+		c.Assert(err, qt.ErrorIs, ErrInvalidAuthToken)
+	})
+
+	c.Run("empty destination and type", func(c *qt.C) {
+		err := csp.ResendChallenge(
+			testToken,
+			"",
+			"",
+			apicommon.DefaultLang,
+			testOrgName,
+			testOrgLogo,
+			testAddress.Address(),
+		)
+		c.Assert(err, qt.ErrorIs, errors.ErrInvalidData)
+	})
+
+	c.Run("empty destination", func(c *qt.C) {
+		err := csp.ResendChallenge(
+			testToken,
+			"",
+			notifications.EmailChallenge,
+			apicommon.DefaultLang,
+			testOrgName,
+			testOrgLogo,
+			testAddress.Address(),
+		)
+		c.Assert(err, qt.ErrorIs, errors.ErrInvalidData)
+	})
+
+	c.Run("empty challenge type", func(c *qt.C) {
+		err := csp.ResendChallenge(
+			testToken,
+			testUserEmail,
+			"",
+			apicommon.DefaultLang,
+			testOrgName,
+			testOrgLogo,
+			testAddress.Address(),
+		)
+		c.Assert(err, qt.ErrorIs, errors.ErrInvalidData)
+	})
+
+	c.Run("token not found", func(c *qt.C) {
+		err := csp.ResendChallenge(
+			testToken,
+			testUserEmail,
+			notifications.EmailChallenge,
+			apicommon.DefaultLang,
+			testOrgName,
+			testOrgLogo,
+			testAddress.Address(),
+		)
+		c.Assert(err, qt.ErrorIs, ErrInvalidAuthToken)
+	})
+
+	c.Run("token already verified", func(c *qt.C) {
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		c.Assert(csp.Storage.VerifyCSPAuth(testToken), qt.IsNil)
+
+		err := csp.ResendChallenge(
+			testToken,
+			testUserEmail,
+			notifications.EmailChallenge,
+			apicommon.DefaultLang,
+			testOrgName,
+			testOrgLogo,
+			testAddress.Address(),
+		)
+		c.Assert(err, qt.ErrorIs, errors.ErrUserAlreadyVerified)
+	})
+
+	c.Run("success", func(c *qt.C) {
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+
+		expectedCode, err := csp.regenerateTokenCode(testUserID, testBundleID)
+		c.Assert(err, qt.IsNil)
+
+		err = csp.ResendChallenge(
+			testToken,
+			testUserEmail,
+			notifications.EmailChallenge,
+			apicommon.DefaultLang,
+			testOrgName,
+			testOrgLogo,
+			testAddress.Address(),
+		)
+		c.Assert(err, qt.IsNil)
+
+		time.Sleep(time.Second * 3)
+		mailCode := fetchOTPCodeFromEmail(c, testUserEmail)
+		c.Assert(mailCode, qt.Equals, expectedCode)
+	})
+}
+
+func TestBundleAuthTokenResendAndVerifyFlow(t *testing.T) {
+	c := qt.New(t)
+
+	testDB, err := db.New(testMongoURI, test.RandomDatabaseName())
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	csp, err := New(ctx, &Config{
+		DB:                       testDB,
+		MailService:              testMailService,
+		SMSService:               testSMSService,
+		NotificationThrottleTime: time.Second,
+		NotificationCoolDownTime: time.Second * 5,
+		RootKey:                  *testRootKey,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	token, err := csp.BundleAuthToken(
+		testBundleID,
+		testUserID,
+		testUserEmail,
+		notifications.EmailChallenge,
+		apicommon.DefaultLang,
+		testOrgName,
+		testOrgLogo,
+		testAddress.Address(),
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(token, qt.Not(qt.IsNil))
+
+	expectedFirstCode, err := csp.regenerateTokenCode(testUserID, testBundleID)
+	c.Assert(err, qt.IsNil)
+	firstCode := fetchOTPCodeFromEmail(c, testUserEmail)
+	c.Assert(firstCode, qt.Equals, expectedFirstCode)
+
+	err = csp.ResendChallenge(
+		token,
+		testUserEmail,
+		notifications.EmailChallenge,
+		apicommon.DefaultLang,
+		testOrgName,
+		testOrgLogo,
+		testAddress.Address(),
+	)
+	c.Assert(err, qt.IsNil)
+	resendCode := fetchOTPCodeFromEmail(c, testUserEmail)
+	c.Assert(resendCode, qt.Equals, expectedFirstCode)
+
+	secondBundleID := internal.HexBytes("bundleID-2")
+	secondToken, err := csp.BundleAuthToken(
+		secondBundleID,
+		testUserID,
+		testUserEmail,
+		notifications.EmailChallenge,
+		apicommon.DefaultLang,
+		testOrgName,
+		testOrgLogo,
+		testAddress.Address(),
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(secondToken, qt.Not(qt.IsNil))
+
+	expectedSecondCode, err := csp.regenerateTokenCode(testUserID, secondBundleID)
+	c.Assert(err, qt.IsNil)
+	secondCode := fetchOTPCodeFromEmail(c, testUserEmail)
+	c.Assert(secondCode, qt.Equals, expectedSecondCode)
+	c.Assert(secondCode, qt.Not(qt.Equals), resendCode)
+
+	err = csp.VerifyBundleAuthToken(token, resendCode)
+	c.Assert(err, qt.IsNil)
+	err = csp.VerifyBundleAuthToken(secondToken, secondCode)
+	c.Assert(err, qt.IsNil)
+
+	authTokenResult, err := csp.Storage.CSPAuth(token)
+	c.Assert(err, qt.IsNil)
+	c.Assert(authTokenResult.Verified, qt.IsTrue)
+	authTokenSecondResult, err := csp.Storage.CSPAuth(secondToken)
+	c.Assert(err, qt.IsNil)
+	c.Assert(authTokenSecondResult.Verified, qt.IsTrue)
+}
+
 func TestGenerateToken(t *testing.T) {
 	c := qt.New(t)
 	secret := otpSecret(testUserID, testBundleID)
@@ -237,4 +463,35 @@ func TestOTPSecret(t *testing.T) {
 	encodedSecret := base32.StdEncoding.EncodeToString(expectedSecret[:])
 	secret := otpSecret(testUserID, testBundleID)
 	c.Assert(secret, qt.Equals, encodedSecret)
+}
+
+func fetchOTPCodeFromEmail(c *qt.C, email string) string {
+	var mailBody string
+	var err error
+
+	for range 25 {
+		mailBody, err = testMailService.FindEmail(context.Background(), email)
+		if err == nil {
+			break
+		}
+		if err == io.EOF {
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+		c.Assert(err, qt.IsNil)
+	}
+	c.Assert(err, qt.IsNil)
+
+	seedNotification, err := mailtemplates.VerifyOTPCodeNotification.Localized(apicommon.DefaultLang).
+		ExecPlain(struct {
+			Code             string
+			Organization     string
+			OrganizationLogo string
+		}{`(.{6})`, testOrgName, testOrgLogo})
+	c.Assert(err, qt.IsNil)
+
+	rgxNotification := regexp.MustCompile(seedNotification.PlainBody)
+	mailCode := rgxNotification.FindStringSubmatch(mailBody)
+	c.Assert(mailCode, qt.HasLen, 2)
+	return mailCode[1]
 }

--- a/csp/errors.go
+++ b/csp/errors.go
@@ -16,6 +16,8 @@ var (
 	// ErrTooManyAttempts is returned when no more SMS attempts available for a
 	// user.
 	ErrTooManyAttempts = fmt.Errorf("too many SMS attempts")
+	// ErrTokenExpired is returned when the authentication token has expired.
+	ErrTokenExpired = fmt.Errorf("authentication token has expired")
 	// ErrUserUnknown is returned if the userID is not found in the database.
 	ErrUserUnknown = fmt.Errorf("user is unknown")
 	// ErrUserAlreadyVerified is returned if the user is already verified when

--- a/csp/handlers/handlers.go
+++ b/csp/handlers/handlers.go
@@ -161,6 +161,131 @@ func (c *CSPHandlers) BundleAuthHandler(w http.ResponseWriter, r *http.Request) 
 	c.handleAuthStep(w, r, step, *bundleID, bundle.Census.ID.Hex())
 }
 
+// BundleAuthResendHandler godoc
+//
+//	@Summary		Resend authentication challenge for a process bundle
+//	@Description	Resend the challenge for an existing (non-verified) authentication token.
+//	@Description	The request must include the auth token and a valid contact method for the bundle census type
+//	@Description	(email, phone, or either depending on census configuration).
+//	@Description	The same token is returned if the challenge is queued successfully.
+//	@Tags			process
+//	@Accept			json
+//	@Produce		json
+//	@Param			bundleId	path		string						true	"Bundle ID"
+//	@Param			request		body		handlers.AuthResendRequest	true	"Resend request with auth token and contact data"
+//	@Success		200			{object}	handlers.AuthResponse
+//	@Failure		400			{object}	errors.Error	"Malformed URL/body, missing auth token, invalid contact data, or token already verified"
+//	@Failure		401			{object}	errors.Error	"Unauthorized, invalid/expired token, token not belonging to bundle, or contact mismatch"
+//	@Failure		404			{object}	errors.Error	"Organization not found"
+//	@Failure		500			{object}	errors.Error	"Internal server error (storage/challenge generation/notification failures)"
+//	@Router			/process/bundle/{bundleId}/auth/resend [post]
+func (c *CSPHandlers) BundleAuthResendHandler(w http.ResponseWriter, r *http.Request) {
+	// Parse the bundle ID
+	bundleID, ok := parseBundleID(w, r)
+	if !ok {
+		return
+	}
+
+	// Get the bundle
+	bundle, ok := c.getBundle(w, *bundleID)
+	if !ok {
+		return
+	}
+
+	// Parse the request body for the auth token and contact information
+	var req AuthResendRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		errors.ErrMalformedBody.Write(w)
+		return
+	}
+	if len(req.AuthToken) == 0 {
+		errors.ErrInvalidData.Withf("missing auth token").Write(w)
+		return
+	}
+
+	// Load token data and enforce that the token belongs to the bundle in the path.
+	auth, ok := c.getAuthInfo(w, req.AuthToken)
+	if !ok {
+		return
+	}
+	if !bytes.Equal(*bundleID, auth.BundleID) {
+		errors.ErrUnauthorized.Withf("token does not belong to the bundle").Write(w)
+		return
+	}
+
+	lang := apicommon.DefaultLang
+	if l, ok := r.Context().Value(apicommon.LangMetadataKey).(string); ok && l != "" {
+		lang = l
+	}
+
+	org, err := c.mainDB.Organization(bundle.OrgAddress)
+	if err != nil {
+		if err == db.ErrNotFound {
+			errors.ErrOrganizationNotFound.Write(w)
+			return
+		}
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+
+	oid, err := primitive.ObjectIDFromHex(auth.UserID.String())
+	if err != nil {
+		errors.ErrUnauthorized.WithErr(fmt.Errorf("invalid user ID in token: %w", err)).Write(w)
+		return
+	}
+	member, err := c.mainDB.OrgMember(bundle.OrgAddress, oid.Hex())
+	if err != nil {
+		errors.ErrUserNotFound.WithErr(err).Write(w)
+		return
+	}
+
+	// Determine the contact method and resend the challenge based on the census type
+	// and provided contact information
+	toDestination, challengeType, err := determineContactMethod(
+		&bundle.Census, org,
+		&AuthRequest{Email: req.Email, Phone: req.Phone},
+		member,
+	)
+	if err != nil {
+		if apiErr, ok := err.(errors.Error); ok {
+			apiErr.Write(w)
+		} else {
+			errors.ErrUnauthorized.WithErr(err).Write(w)
+		}
+		return
+	}
+
+	name := DefaultOrgName
+	logo := DefaultOrgLogo
+
+	if n, ok := org.Meta["name"].(string); ok {
+		name = n
+		// if name is found then retrieve the logo as well
+		if l, ok := org.Meta["logo"].(string); ok {
+			logo = l
+		}
+	}
+
+	// Resend the challenge with the same token and new contact information
+	if err := c.csp.ResendChallenge(req.AuthToken, toDestination, challengeType, lang, name, logo, org.Address); err != nil {
+		if apiErr, ok := err.(errors.Error); ok {
+			apiErr.Write(w)
+			return
+		}
+
+		switch err {
+		case csp.ErrInvalidAuthToken, csp.ErrTokenExpired:
+			errors.ErrUnauthorized.WithErr(err).Write(w)
+		case csp.ErrStorageFailure:
+			errors.ErrInternalStorageError.WithErr(err).Write(w)
+		default:
+			errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		}
+		return
+	}
+	apicommon.HTTPWriteJSON(w, &AuthResponse{AuthToken: req.AuthToken})
+}
+
 // parseSignRequest parses the sign request from the request body
 func parseSignRequest(w http.ResponseWriter, r *http.Request) (*SignRequest, bool) {
 	var req SignRequest

--- a/csp/handlers/types.go
+++ b/csp/handlers/types.go
@@ -23,6 +23,13 @@ type AuthRequest struct {
 	Phone        string `json:"phone"`
 }
 
+// AuthResendRequest defines the payload for the 2FA resend request.
+type AuthResendRequest struct {
+	AuthToken internal.HexBytes `json:"authToken" swaggertype:"string" format:"hex" example:"deadbeef"`
+	Email     string            `json:"email"`
+	Phone     string            `json:"phone"`
+}
+
 // AuthResponse defines the payload for the authentication response, including
 // the authToken and the signature. It is used during the authentication
 // process for both steps: the challenge request and the challenge validation.

--- a/db/census.go
+++ b/db/census.go
@@ -104,7 +104,7 @@ func (ms *MongoStorage) PopulateGroupCensus(
 		}
 		return 0, fmt.Errorf("error retrieving organization group: %w", err)
 	}
-	if len(group.MemberIDs) == 0 {
+	if !group.IsAutoGroup && len(group.MemberIDs) == 0 {
 		return 0, fmt.Errorf("group has no members")
 	}
 

--- a/db/errors.go
+++ b/db/errors.go
@@ -20,6 +20,10 @@ var (
 	ErrTokenNotVerified = fmt.Errorf("token not verified")
 	// ErrUpdateWouldCreateDuplicates is returned when trying to update an OrgMember
 	ErrUpdateWouldCreateDuplicates = fmt.Errorf("update would create duplicates")
+	// ErrAutoGroupCannotBeDeleted is returned when trying to delete the auto-generated "All members" group
+	ErrAutoGroupCannotBeDeleted = fmt.Errorf("auto-generated group cannot be deleted")
+	// ErrAutoGroupMembersCannotBeModified is returned when trying to manually add/remove members from the auto group
+	ErrAutoGroupMembersCannotBeModified = fmt.Errorf("auto-generated group membership cannot be manually modified")
 )
 
 // errorsAsStrings converts a slice of errors to a slice of strings

--- a/db/org_members.go
+++ b/db/org_members.go
@@ -51,6 +51,11 @@ func (ms *MongoStorage) SetOrgMember(salt string, orgMember *OrgMember) (string,
 		return "", err
 	}
 
+	// Ensure the auto group exists now that at least one member is present.
+	if err := ms.EnsureAutoMemberGroup(orgMember.OrgAddress); err != nil {
+		log.Warnw("could not ensure auto member group after SetOrgMember", "error", err)
+	}
+
 	return member.ID.Hex(), nil
 }
 
@@ -59,6 +64,17 @@ func (ms *MongoStorage) DelOrgMember(id string) error {
 	objID, err := primitive.ObjectIDFromHex(id)
 	if err != nil {
 		return ErrInvalidData
+	}
+
+	// Fetch the member first so we know which org it belongs to (needed for auto group cleanup).
+	ctxFetch, cancelFetch := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancelFetch()
+	var existing OrgMember
+	if err := ms.orgMembers.FindOne(ctxFetch, bson.M{"_id": objID}).Decode(&existing); err != nil {
+		if err == mongo.ErrNoDocuments {
+			return ErrNotFound
+		}
+		return fmt.Errorf("could not fetch member before deletion: %w", err)
 	}
 
 	ms.keysLock.Lock()
@@ -70,7 +86,15 @@ func (ms *MongoStorage) DelOrgMember(id string) error {
 	// delete the orgMember from the database using the ID
 	filter := bson.M{"_id": objID}
 	_, err = ms.orgMembers.DeleteOne(ctx, filter)
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Clean up the auto group if the org now has no members.
+	if err := ms.DeleteAutoMemberGroupIfEmpty(existing.OrgAddress); err != nil {
+		log.Warnw("could not clean up auto member group after DelOrgMember", "error", err)
+	}
+	return nil
 }
 
 // OrgMember retrieves a orgMember from the DB based on it ID
@@ -313,6 +337,15 @@ func (ms *MongoStorage) addOrgMemberBatches(
 			Errors:   append(job.Errors, errs...),
 		}
 	}
+
+	// Ensure the auto group exists now that members have been added.
+	if job.Added > 0 {
+		ms.keysLock.Lock()
+		defer ms.keysLock.Unlock()
+		if err := ms.EnsureAutoMemberGroup(org.Address); err != nil {
+			log.Warnw("could not ensure auto member group after bulk add", "error", err)
+		}
+	}
 }
 
 // AddBulkOrgMembers adds multiple organization members to the database in batches of 200 entries.
@@ -381,6 +414,11 @@ func (ms *MongoStorage) UpsertOrgMemberAndCensusParticipants(org *Organization, 
 	_, err = ms.orgMembers.UpdateOne(ctx, filter, updateDoc, opts)
 	if err != nil {
 		return primitive.NilObjectID, fmt.Errorf("failed to upsert org member: %w", err)
+	}
+
+	// Ensure the auto group exists now that at least one member is present.
+	if err := ms.EnsureAutoMemberGroup(org.Address); err != nil {
+		log.Warnw("could not ensure auto member group after upsert", "error", err)
 	}
 
 	return preparedMember.ID, nil
@@ -521,6 +559,9 @@ func (ms *MongoStorage) DeleteOrgMembers(orgAddress common.Address, ids []string
 		},
 	}
 
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+
 	result, err := ms.orgMembers.DeleteMany(ctx, filter)
 	if err != nil {
 		return 0, fmt.Errorf("failed to delete orgMembers: %w", err)
@@ -555,6 +596,11 @@ func (ms *MongoStorage) DeleteOrgMembers(orgAddress common.Address, ids []string
 	_, err = ms.orgMemberGroups.UpdateMany(ctx, groupFilter, groupUpdate)
 	if err != nil {
 		return 0, fmt.Errorf("failed to update groups after deleting orgMembers: %w", err)
+	}
+
+	// Clean up the auto group if the org now has no members.
+	if err := ms.DeleteAutoMemberGroupIfEmpty(orgAddress); err != nil {
+		log.Warnw("could not clean up auto member group after DeleteOrgMembers", "error", err)
 	}
 
 	return int(result.DeletedCount), nil
@@ -597,6 +643,11 @@ func (ms *MongoStorage) DeleteAllOrgMembers(orgAddress common.Address) (int, err
 	_, err = ms.orgMemberGroups.UpdateMany(ctx, groupFilter, groupUpdate)
 	if err != nil {
 		return 0, fmt.Errorf("failed to update groups after deleting all orgMembers: %w", err)
+	}
+
+	// All members are gone — remove the auto group too.
+	if err := ms.deleteAutoMemberGroup(orgAddress); err != nil {
+		log.Warnw("could not delete auto member group after DeleteAllOrgMembers", "error", err)
 	}
 
 	return int(result.DeletedCount), nil

--- a/db/org_members_groups.go
+++ b/db/org_members_groups.go
@@ -44,7 +44,8 @@ func (ms *MongoStorage) OrganizationMemberGroup(
 	return group, nil
 }
 
-// OrganizationMemberGroups returns the list of an organization's members groups
+// OrganizationMemberGroups returns the list of an organization's members groups.
+// The auto-generated "All members" group, if it exists, always sorts first.
 func (ms *MongoStorage) OrganizationMemberGroups(
 	orgAddress common.Address,
 	page, limit int64,
@@ -54,8 +55,32 @@ func (ms *MongoStorage) OrganizationMemberGroups(
 	}
 
 	filter := bson.M{"orgAddress": orgAddress}
+	// Sort: auto group first (isAutoGroup DESC), then stable by _id ASC.
+	findOpts := options.Find().SetSort(bson.D{
+		{Key: "isAutoGroup", Value: -1},
+		{Key: "_id", Value: 1},
+	})
+	total, groups, err := paginatedDocuments[*OrganizationMemberGroup](
+		ms.orgMemberGroups, page, limit, filter, findOpts)
+	if err != nil {
+		return 0, nil, err
+	}
 
-	return paginatedDocuments[*OrganizationMemberGroup](ms.orgMemberGroups, page, limit, filter, options.Find())
+	// For any auto group in the results, populate member count dynamically.
+	for _, g := range groups {
+		if !g.IsAutoGroup {
+			continue
+		}
+		memberCount, err := ms.CountOrgMembers(orgAddress)
+		if err != nil {
+			return 0, nil, fmt.Errorf("could not count auto group members: %w", err)
+		}
+		// Use a slice of the right length so callers that rely on len(MemberIDs)
+		// for display get the correct count without fetching all IDs.
+		g.MemberIDs = make([]string, memberCount)
+	}
+
+	return total, groups, nil
 }
 
 // CreateOrganizationMemberGroup Creates an organization member group
@@ -98,8 +123,9 @@ func (ms *MongoStorage) CreateOrganizationMemberGroup(group *OrganizationMemberG
 }
 
 // UpdateOrganizationMemberGroup updates an organization members group by adding
-// and/or removing members. If a member exists in both lists, it will be removed
-// TODO allow to update the rest of the fields as well. Maybe a different function?
+// and/or removing members. If a member exists in both lists, it will be removed.
+// For the auto-generated group, only title and description can be updated;
+// manual membership changes are not allowed and return ErrAutoGroupMembersCannotBeModified.
 func (ms *MongoStorage) UpdateOrganizationMemberGroup(
 	groupID string, orgAddress common.Address,
 	title, description string, addedMembers, removedMembers []string,
@@ -113,6 +139,10 @@ func (ms *MongoStorage) UpdateOrganizationMemberGroup(
 			return ErrInvalidData
 		}
 		return fmt.Errorf("could not retrieve organization members group: %w", err)
+	}
+	// Auto groups do not allow manual member manipulation.
+	if group.IsAutoGroup && (len(addedMembers) > 0 || len(removedMembers) > 0) {
+		return ErrAutoGroupMembersCannotBeModified
 	}
 	// create a context with a timeout
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
@@ -214,10 +244,23 @@ func (ms *MongoStorage) addOrganizationMemberGroupCensus(
 	return err
 }
 
-// DeleteOrganizationMemberGroup deletes an organization member group by its ID
+// DeleteOrganizationMemberGroup deletes an organization member group by its ID.
+// Returns ErrAutoGroupCannotBeDeleted if the group is the auto-generated "All members" group.
 func (ms *MongoStorage) DeleteOrganizationMemberGroup(groupID string, orgAddress common.Address) error {
 	if orgAddress.Cmp(common.Address{}) == 0 {
 		return ErrInvalidData
+	}
+	// Prevent deletion of the auto group.
+	group, err := ms.OrganizationMemberGroup(groupID, orgAddress)
+	if err != nil {
+		if err == ErrNotFound {
+			// Preserve original behaviour: silently succeed when group doesn't exist.
+			return nil
+		}
+		return fmt.Errorf("could not retrieve group: %w", err)
+	}
+	if group.IsAutoGroup {
+		return ErrAutoGroupCannotBeDeleted
 	}
 	// create a context with a timeout
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
@@ -253,7 +296,10 @@ func (ms *MongoStorage) ListOrganizationMemberGroup(
 	if err != nil {
 		return 0, nil, fmt.Errorf("could not retrieve organization members group: %w", err)
 	}
-
+	// For auto groups, all org members are included; query directly without an ID filter.
+	if group.IsAutoGroup {
+		return ms.OrgMembers(orgAddress, page, limit, "")
+	}
 	return ms.orgMembersByIDs(
 		orgAddress,
 		group.MemberIDs,
@@ -330,7 +376,7 @@ func (ms *MongoStorage) CheckGroupMembersFields(
 
 		// if the key is already seen, add to duplicates
 		// and continue to the next member
-		if len(authFields) > 0 {
+		if len(authFields) > 0 || len(twoFaFields) > 0 {
 			key := buildCompositeKey(bm, authFields, twoFaFields)
 			if val, seen := seenKeys[key]; seen {
 				duplicates[m.ID] = struct{}{}
@@ -375,20 +421,24 @@ func (ms *MongoStorage) getGroupMembersFields(
 			}
 			return nil, fmt.Errorf("failed to fetch group %s for organization %s: %w", groupID, orgAddress, err)
 		}
-		// Check if the group has members
-		if len(group.MemberIDs) == 0 {
-			return nil, fmt.Errorf("no members in group %s for organization %s", groupID, orgAddress)
-		}
-		objectIDs := make([]primitive.ObjectID, len(group.MemberIDs))
-		for i, id := range group.MemberIDs {
-			objID, err := primitive.ObjectIDFromHex(id)
-			if err != nil {
-				return nil, fmt.Errorf("invalid member ID %s: %w", id, ErrInvalidData)
+		// Auto groups always contain every member; no extra ID filter is needed.
+		// For regular groups, restrict to the stored member IDs.
+		if !group.IsAutoGroup {
+			// Check if the group has members
+			if len(group.MemberIDs) == 0 {
+				return nil, fmt.Errorf("no members in group %s for organization %s", groupID, orgAddress)
 			}
-			objectIDs[i] = objID
-		}
-		if len(objectIDs) > 0 {
-			filter = append(filter, bson.E{Key: "_id", Value: bson.M{"$in": objectIDs}})
+			objectIDs := make([]primitive.ObjectID, len(group.MemberIDs))
+			for i, id := range group.MemberIDs {
+				objID, err := primitive.ObjectIDFromHex(id)
+				if err != nil {
+					return nil, fmt.Errorf("invalid member ID %s: %w", id, ErrInvalidData)
+				}
+				objectIDs[i] = objID
+			}
+			if len(objectIDs) > 0 {
+				filter = append(filter, bson.E{Key: "_id", Value: bson.M{"$in": objectIDs}})
+			}
 		}
 	}
 
@@ -470,4 +520,71 @@ func buildCompositeKey(bm bson.M, authFields OrgMemberAuthFields, twoFaFields Or
 	}
 
 	return strings.Join(keyParts, "|")
+}
+
+// EnsureAutoMemberGroup creates the auto-generated "All members" group for an organization
+// if it does not already exist. It is idempotent and safe to call after every member addition.
+func (ms *MongoStorage) EnsureAutoMemberGroup(orgAddress common.Address) error {
+	if orgAddress.Cmp(common.Address{}) == 0 {
+		return ErrInvalidData
+	}
+
+	checkCtx, checkCancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer checkCancel()
+
+	var existing OrganizationMemberGroup
+	err := ms.orgMemberGroups.FindOne(checkCtx, bson.M{"orgAddress": orgAddress, "isAutoGroup": true}).Decode(&existing)
+	if err != nil && err != mongo.ErrNoDocuments {
+		return fmt.Errorf("could not check for existing auto group: %w", err)
+	}
+	if err == nil {
+		return nil // already exists
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	group := OrganizationMemberGroup{
+		ID:          primitive.NewObjectID(),
+		OrgAddress:  orgAddress,
+		Title:       AutoGroupTitle,
+		Description: AutoGroupDescription,
+		MemberIDs:   []string{},
+		CensusIDs:   []string{},
+		IsAutoGroup: true,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+
+	if _, err := ms.orgMemberGroups.InsertOne(ctx, group); err != nil {
+		return fmt.Errorf("could not create auto group: %w", err)
+	}
+	return nil
+}
+
+// DeleteAutoMemberGroupIfEmpty deletes the auto-generated "All members" group when the
+// organization has no more members. Should be called after any member deletion.
+func (ms *MongoStorage) DeleteAutoMemberGroupIfEmpty(orgAddress common.Address) error {
+	if orgAddress.Cmp(common.Address{}) == 0 {
+		return ErrInvalidData
+	}
+	count, err := ms.CountOrgMembers(orgAddress)
+	if err != nil {
+		return fmt.Errorf("could not count org members: %w", err)
+	}
+	if count > 0 {
+		return nil // still has members, keep the auto group
+	}
+	return ms.deleteAutoMemberGroup(orgAddress)
+}
+
+// deleteAutoMemberGroup unconditionally removes the auto-generated "All members" group.
+// Used when all members have been deleted at once.
+func (ms *MongoStorage) deleteAutoMemberGroup(orgAddress common.Address) error {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	filter := bson.M{"orgAddress": orgAddress, "isAutoGroup": true}
+	_, err := ms.orgMemberGroups.DeleteOne(ctx, filter)
+	return err
 }

--- a/db/org_members_groups_test.go
+++ b/db/org_members_groups_test.go
@@ -158,11 +158,12 @@ func TestOrganizationMemberGroup(t *testing.T) {
 		_, memberIDs := setupTestOrgMembersGroupPrerequisites(t, "_list")
 
 		t.Run("EmptyList", func(_ *testing.T) {
-			// Test getting groups for organization with no groups
+			// Test getting groups for organization — members were added above so the
+			// auto group is already present.
 			totalItems, groups, err := testDB.OrganizationMemberGroups(testOrgAddress, 1, 10)
 			c.Assert(err, qt.IsNil)
-			c.Assert(groups, qt.HasLen, 0)
-			c.Assert(totalItems, qt.Equals, int64(0))
+			c.Assert(groups, qt.HasLen, 1) // only the auto group
+			c.Assert(totalItems, qt.Equals, int64(1))
 		})
 
 		t.Run("MultipleGroups", func(_ *testing.T) {
@@ -179,10 +180,11 @@ func TestOrganizationMemberGroup(t *testing.T) {
 			}
 
 			// Test getting all groups for the organization
+			// 3 regular groups + 1 auto group = 4 total
 			totalItems, groups, err := testDB.OrganizationMemberGroups(testOrgAddress, 1, 10)
 			c.Assert(err, qt.IsNil)
-			c.Assert(groups, qt.HasLen, 3)
-			c.Assert(totalItems, qt.Equals, int64(3))
+			c.Assert(groups, qt.HasLen, 4)
+			c.Assert(totalItems, qt.Equals, int64(4))
 
 			// Verify each group has the correct organization address
 			for _, group := range groups {
@@ -247,17 +249,19 @@ func TestOrganizationMemberGroup(t *testing.T) {
 			}
 
 			// Test getting groups for original organization
+			// 2 regular groups + 1 auto group = 3 total
 			_, groups1, err := testDB.OrganizationMemberGroups(testOrgAddress, 1, 10)
 			c.Assert(err, qt.IsNil)
-			c.Assert(groups1, qt.HasLen, 2)
+			c.Assert(groups1, qt.HasLen, 3)
 			for _, group := range groups1 {
 				c.Assert(group.OrgAddress, qt.DeepEquals, testOrgAddress)
 			}
 
 			// Test getting groups for different organization
+			// 3 regular groups + 1 auto group = 4 total
 			_, groups2, err := testDB.OrganizationMemberGroups(testAnotherOrgAddress, 1, 10)
 			c.Assert(err, qt.IsNil)
-			c.Assert(groups2, qt.HasLen, 3)
+			c.Assert(groups2, qt.HasLen, 4)
 			for _, group := range groups2 {
 				c.Assert(group.OrgAddress, qt.DeepEquals, testAnotherOrgAddress)
 			}
@@ -1049,6 +1053,93 @@ func TestOrganizationMemberGroup(t *testing.T) {
 		c.Assert(results, qt.Not(qt.IsNil))
 		c.Assert(results.Duplicates, qt.HasLen, 0, qt.Commentf("Should NOT detect duplicates when 2FA fields make members unique"))
 		c.Assert(results.Members, qt.HasLen, 2, qt.Commentf("Should include both members as valid"))
+
+		// Test 13: Regression — duplicate detection must fire when ONLY twoFa
+		// fields are configured (authFields is empty).
+		//
+		// Before the fix the guard was `if len(authFields) > 0`, so the entire
+		// duplicate-detection block was skipped whenever authFields was empty,
+		// even if twoFaFields contained the only meaningful identity fields.
+		// This caused the census participant bulk-write to fail later with
+		// E11000 duplicate-key errors instead of surfacing a clean validation
+		// error here.
+		//
+		// Phone uniqueness is not enforced by the orgMembers unique index
+		// (the index uses the field name "hashedPhone" while data is stored
+		// under "phone"), so two members with the same phone but different
+		// emails can coexist — making phone the ideal field for this test.
+		regPhone1 := &OrgMember{
+			OrgAddress:     testOrgAddress,
+			Email:          "regression_dup1@test.com",
+			PlaintextPhone: "+34611222001", // same phone as regression_dup2
+			MemberNumber:   "reg_dup_001",
+			Name:           "Regression",
+			Surname:        "DupOne",
+			Password:       testPassword,
+		}
+		regPhone1ID, err := testDB.SetOrgMember(testSalt, regPhone1)
+		c.Assert(err, qt.IsNil)
+
+		regPhone2 := &OrgMember{
+			OrgAddress:     testOrgAddress,
+			Email:          "regression_dup2@test.com",
+			PlaintextPhone: "+34611222001", // same phone as regression_dup1
+			MemberNumber:   "reg_dup_002",
+			Name:           "Regression",
+			Surname:        "DupTwo",
+			Password:       testPassword,
+		}
+		regPhone2ID, err := testDB.SetOrgMember(testSalt, regPhone2)
+		c.Assert(err, qt.IsNil)
+
+		regPhoneUnique := &OrgMember{
+			OrgAddress:     testOrgAddress,
+			Email:          "regression_unique@test.com",
+			PlaintextPhone: "+34611222002", // unique phone
+			MemberNumber:   "reg_unique_003",
+			Name:           "Regression",
+			Surname:        "Unique",
+			Password:       testPassword,
+		}
+		regUniqueID, err := testDB.SetOrgMember(testSalt, regPhoneUnique)
+		c.Assert(err, qt.IsNil)
+
+		regGroup := &OrganizationMemberGroup{
+			OrgAddress:  testOrgAddress,
+			Title:       "Regression TwoFa-Only Dup Group",
+			Description: "Group for twoFa-only duplicate detection regression",
+			MemberIDs:   []string{regPhone1ID, regPhone2ID, regUniqueID},
+		}
+		regGroupID, err := testDB.CreateOrganizationMemberGroup(regGroup)
+		c.Assert(err, qt.IsNil)
+
+		// authFields intentionally empty — only twoFa fields provided.
+		results, err = testDB.CheckGroupMembersFields(
+			testOrgAddress,
+			regGroupID,
+			OrgMemberAuthFields{},
+			OrgMemberTwoFaFields{OrgMemberTwoFaFieldPhone},
+		)
+		c.Assert(err, qt.IsNil)
+		c.Assert(results, qt.Not(qt.IsNil))
+		// Both members sharing the same phone must be flagged as duplicates.
+		c.Assert(results.Duplicates, qt.HasLen, 2)
+		dupHex := make([]string, len(results.Duplicates))
+		for i, id := range results.Duplicates {
+			dupHex[i] = id.Hex()
+		}
+		c.Assert(contains(dupHex, regPhone1ID), qt.IsTrue)
+		c.Assert(contains(dupHex, regPhone2ID), qt.IsTrue)
+		// The member with the unique phone must not be flagged as a duplicate.
+		c.Assert(contains(dupHex, regUniqueID), qt.IsFalse)
+		// The second-seen duplicate must not appear in Members at all.
+		memberHex := make([]string, len(results.Members))
+		for i, id := range results.Members {
+			memberHex[i] = id.Hex()
+		}
+		c.Assert(contains(memberHex, regUniqueID), qt.IsTrue)
+		c.Assert(contains(memberHex, regPhone2ID), qt.IsFalse)
+		c.Assert(results.MissingData, qt.HasLen, 0)
 	})
 
 	// Test DeleteOrgMembers with automatic group cleanup

--- a/db/types.go
+++ b/db/types.go
@@ -369,6 +369,13 @@ type OrgMemberAggregationResults struct {
 	MissingData []primitive.ObjectID `json:"missingData" bson:"missingData"`
 }
 
+const (
+	// AutoGroupTitle is the title of the auto-generated group that always contains every member.
+	AutoGroupTitle = "All members"
+	// AutoGroupDescription is the description shown to users for the auto-generated group.
+	AutoGroupDescription = "This group is automatically generated and always contains every member of your member base."
+)
+
 // An Organization members' group is a precursor of a census, and is simply a
 // collection of members that are grouped together for a specific purpose
 type OrganizationMemberGroup struct {
@@ -376,10 +383,15 @@ type OrganizationMemberGroup struct {
 	OrgAddress  common.Address     `json:"orgAddress" bson:"orgAddress"`
 	Title       string             `json:"title" bson:"title"`
 	Description string             `json:"description" bson:"description"`
-	MemberIDs   []string           `json:"memberIds" bson:"memberIds"`
-	CreatedAt   time.Time          `json:"createdAt" bson:"createdAt"`
-	UpdatedAt   time.Time          `json:"updatedAt" bson:"updatedAt"`
-	CensusIDs   []string           `json:"censusIds" bson:"censusIds"`
+	// MemberIDs is intentionally empty for auto groups (IsAutoGroup == true).
+	// Their membership is derived dynamically from the full orgMembers collection.
+	MemberIDs []string  `json:"memberIds" bson:"memberIds"`
+	CreatedAt time.Time `json:"createdAt" bson:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt" bson:"updatedAt"`
+	CensusIDs []string  `json:"censusIds" bson:"censusIds"`
+	// IsAutoGroup marks this group as the auto-generated "All members" group.
+	// Auto groups cannot be deleted and their membership cannot be manually modified.
+	IsAutoGroup bool `json:"isAutoGroup" bson:"isAutoGroup"`
 }
 
 // Relates an OrgMember to a Census

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1270,6 +1270,17 @@ definitions:
       subscription_status:
         type: string
     type: object
+  handlers.AuthResendRequest:
+    properties:
+      authToken:
+        example: deadbeef
+        format: hex
+        type: string
+      email:
+        type: string
+      phone:
+        type: string
+    type: object
   handlers.AuthResponse:
     properties:
       authToken:
@@ -3718,6 +3729,56 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
       summary: Authenticate for a process bundle
+      tags:
+      - process
+  /process/bundle/{bundleId}/auth/resend:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Resend the challenge for an existing (non-verified) authentication token.
+        The request must include the auth token and a valid contact method for the bundle census type
+        (email, phone, or either depending on census configuration).
+        The same token is returned if the challenge is queued successfully.
+      parameters:
+      - description: Bundle ID
+        in: path
+        name: bundleId
+        required: true
+        type: string
+      - description: Resend request with auth token and contact data
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.AuthResendRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.AuthResponse'
+        "400":
+          description: Malformed URL/body, missing auth token, invalid contact data,
+            or token already verified
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "401":
+          description: Unauthorized, invalid/expired token, token not belonging to
+            bundle, or contact mismatch
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "404":
+          description: Organization not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error (storage/challenge generation/notification
+            failures)
+          schema:
+            $ref: '#/definitions/errors.Error'
+      summary: Resend authentication challenge for a process bundle
       tags:
       - process
   /process/bundle/{bundleId}/sign:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -542,6 +542,11 @@ definitions:
       id:
         description: Unique identifier for the group
         type: string
+      isAutoGroup:
+        description: |-
+          IsAutoGroup indicates this is the auto-generated "All members" group.
+          It cannot be deleted and its membership cannot be manually modified.
+        type: boolean
       memberIds:
         description: List of member IDs in the group
         items:

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -92,6 +92,8 @@ var (
 	ErrProcessCensusSizeExceedsSMSAllowance   = Error{Code: 40047, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("process census size exceeds sms allowance")}
 	ErrMaxOrganizationsReached                = Error{Code: 40048, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("user has reached maximum number of organizations")}
 	ErrExceedsOrganizationMembersLimit        = Error{Code: 40145, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("operation would exceed organization members limit")}
+	ErrAutoGroupCannotBeDeleted               = Error{Code: 40150, HTTPstatus: http.StatusForbidden, Err: fmt.Errorf("the \"All members\" group is auto-generated and cannot be deleted")}
+	ErrAutoGroupMembersCannotBeModified       = Error{Code: 40151, HTTPstatus: http.StatusForbidden, Err: fmt.Errorf("membership of the auto-generated \"All members\" group cannot be manually modified")}
 
 	// CSP errors (408)
 	ErrZeroWeightVoter = Error{Code: 40801, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("voter weight cannot be zero")}

--- a/migrations/0011_create_all_members_auto_group.go
+++ b/migrations/0011_create_all_members_auto_group.go
@@ -1,0 +1,101 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func init() {
+	AddMigration(11, "create_all_members_auto_group", upCreateAllMembersAutoGroup, downCreateAllMembersAutoGroup)
+}
+
+// upCreateAllMembersAutoGroup creates the "All members" auto group for every
+// organization that already has at least one member but does not yet have an
+// auto group.  New organizations receive their auto group automatically when
+// the first member is added via the application layer, so this migration only
+// needs to back-fill existing data.
+func upCreateAllMembersAutoGroup(ctx context.Context, database *mongo.Database) error {
+	organizations := database.Collection("organizations")
+	orgMembers := database.Collection("orgMembers")
+	orgMemberGroups := database.Collection("orgMemberGroups")
+
+	// Fetch all org addresses from the organizations collection.
+	// This is more efficient than Distinct on orgMembers for large member bases,
+	// since the organizations collection is far smaller.
+	cursor, err := organizations.Find(ctx, bson.D{}, options.Find().SetProjection(bson.M{"_id": 1}))
+	if err != nil {
+		return fmt.Errorf("failed to list organizations: %w", err)
+	}
+	defer func() {
+		_ = cursor.Close(ctx)
+	}()
+
+	for cursor.Next(ctx) {
+		var org struct {
+			ID any `bson:"_id"`
+		}
+		if err := cursor.Decode(&org); err != nil {
+			return fmt.Errorf("failed to decode organization: %w", err)
+		}
+		addr := org.ID
+
+		// Skip orgs that have no members yet.
+		memberCount, err := orgMembers.CountDocuments(ctx,
+			bson.M{"orgAddress": addr},
+			options.Count().SetLimit(1),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to count members for %v: %w", addr, err)
+		}
+		if memberCount == 0 {
+			continue
+		}
+		// Check whether an auto group already exists for this org (idempotent).
+		count, err := orgMemberGroups.CountDocuments(ctx,
+			bson.M{"orgAddress": addr, "isAutoGroup": true},
+			options.Count().SetLimit(1),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to check existing auto group for %v: %w", addr, err)
+		}
+		if count > 0 {
+			continue // already has an auto group, skip
+		}
+
+		now := time.Now()
+		group := bson.M{
+			"_id":         primitive.NewObjectID(),
+			"orgAddress":  addr,
+			"title":       "All members",
+			"description": "This group is automatically generated and always contains every member of your member base.",
+			"memberIds":   []string{},
+			"censusIds":   []string{},
+			"isAutoGroup": true,
+			"createdAt":   now,
+			"updatedAt":   now,
+		}
+
+		if _, err := orgMemberGroups.InsertOne(ctx, group); err != nil {
+			return fmt.Errorf("failed to insert auto group for %v: %w", addr, err)
+		}
+	}
+
+	return cursor.Err()
+}
+
+// downCreateAllMembersAutoGroup deletes all auto groups created by this migration.
+// It is safe to run multiple times.
+func downCreateAllMembersAutoGroup(ctx context.Context, database *mongo.Database) error {
+	orgMemberGroups := database.Collection("orgMemberGroups")
+	_, err := orgMemberGroups.DeleteMany(ctx, bson.M{"isAutoGroup": true})
+	if err != nil {
+		return fmt.Errorf("failed to delete auto groups: %w", err)
+	}
+	return nil
+}

--- a/subscriptions/subscriptions.go
+++ b/subscriptions/subscriptions.go
@@ -275,12 +275,21 @@ func (p *Subscriptions) OrgCanPublishGroupCensus(census *db.Census, groupID stri
 		return errors.ErrGroupNotFound.WithErr(err)
 	}
 
+	memberCount := len(group.MemberIDs)
+	if group.IsAutoGroup {
+		count, err := p.db.CountOrgMembers(org.Address)
+		if err != nil {
+			return errors.ErrGenericInternalServerError.WithErr(err)
+		}
+		memberCount = int(count)
+	}
+
 	remainingEmails := plan.Features.TwoFaEmail - org.Counters.SentEmails
-	if census.TwoFaFields.Contains(db.OrgMemberTwoFaFieldEmail) && len(group.MemberIDs) > remainingEmails {
+	if census.TwoFaFields.Contains(db.OrgMemberTwoFaFieldEmail) && memberCount > remainingEmails {
 		return errors.ErrProcessCensusSizeExceedsEmailAllowance.Withf("remaining emails: %d", remainingEmails)
 	}
 	remainingSMS := plan.Features.TwoFaSms - org.Counters.SentSMS
-	if census.TwoFaFields.Contains(db.OrgMemberTwoFaFieldPhone) && len(group.MemberIDs) > remainingSMS {
+	if census.TwoFaFields.Contains(db.OrgMemberTwoFaFieldPhone) && memberCount > remainingSMS {
 		return errors.ErrProcessCensusSizeExceedsSMSAllowance.Withf("remaining sms: %d", remainingSMS)
 	}
 


### PR DESCRIPTION
Related PRs 

- [](https://github.com/vocdoni/saas-backend/pull/433)<https://github.com/vocdoni/saas-backend/pull/433> — Adds CSP support to resend existing login challenges during cooldown, including new resend auth flow logic, cooldown metadata handling, and substantial test expansion for resend/verify scenarios.
- [](https://github.com/vocdoni/saas-backend/pull/435)<https://github.com/vocdoni/saas-backend/pull/435> — Implements automatic “All members” group behavior backed by dynamic membership resolution, with protections on modification/deletion, API exposure of `isAutoGroup`, migration backfill, and integration test updates.
