### PR TITLE
docs(internal): add package-level godoc comment to internal/utils.go

### DIFF
--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,3 +1,5 @@
+// Package internal provides shared utility functions for email and phone number validation,
+// cryptographically secure random data generation, password hashing, and AES-GCM token encryption.
 package internal
 
 import (


### PR DESCRIPTION
## Summary

Adds a package-level godoc comment to `internal/utils.go` so that `go doc` and IDEs surface a description of the package.

## Linked issue

Closes #442

## Changes

- Added a two-line `// Package internal ...` comment immediately above the `package internal` declaration in `internal/utils.go`. The comment describes the package's four areas of functionality derived from its exported symbols: email/phone validation, random data generation, password hashing, and AES-GCM token encryption.
- No other files modified.

## Tests run

```
$ golangci-lint run --new-from-rev=HEAD~1
0 issues.

$ go test -v -timeout=60s ./internal/...
ok  github.com/vocdoni/saas-backend/internal  0.374s

$ go build ./...
# exit 0
```

## Risks and review focus

None. Change is additive (comment only); no executable code is touched.

## Notes for maintainers

The comment text was derived from the actual exported identifiers in the file (`ValidEmail`, `SanitizeAndVerifyPhoneNumber`, `RandomBytes`/`RandomHex`/`RandomInt`, `HashPassword`/`HexHashPassword`/`HashOrgData`, `SealToken`/`OpenToken`) — nothing fabricated.