### PR TITLE
refactor(api): consolidate error wrapping via wrapErr helper

### DIFF
--- a/api/helpers.go
+++ b/api/helpers.go
@@ -314,3 +314,8 @@ func parseLimit(s string) (int64, error) {
 	}
 	return limit, nil
 }
+
+// wrapErr wraps err with a context message using fmt.Errorf("%s: %w", msg, err).
+func wrapErr(msg string, err error) error {
+	return fmt.Errorf("%s: %w", msg, err)
+}

--- a/api/stripe_handlers.go
+++ b/api/stripe_handlers.go
@@ -236,13 +236,13 @@ func (a *API) InitializeStripeService() error {
 	// Load plans from Stripe and populate the database
 	plans, err := service.GetPlansFromStripe()
 	if err != nil {
-		return fmt.Errorf("failed to load plans from Stripe: %w", err)
+		return wrapErr("failed to load plans from Stripe", err)
 	}
 
 	// Store plans in database
 	for _, plan := range plans {
 		if _, err := a.db.SetPlan(plan); err != nil {
-			return fmt.Errorf("failed to store plan %s: %w", plan.Name, err)
+			return wrapErr(fmt.Sprintf("failed to store plan %s", plan.Name), err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Introduces a small unexported `wrapErr(msg string, err error) error` helper in `api/helpers.go` and replaces the two inline `fmt.Errorf("...: %w", err)` call sites in `InitializeStripeService` with it. Error messages and `errors.Unwrap` behaviour are unchanged.

## Linked issue

Closes #445

## Changes

- **`api/helpers.go`** — added `wrapErr` at the end of the file (5 lines including GoDoc comment). Uses `fmt.Errorf("%s: %w", msg, err)` internally; no new imports.
- **`api/stripe_handlers.go`** — replaced two call sites in `InitializeStripeService`:
  - `fmt.Errorf("failed to load plans from Stripe: %w", err)` → `wrapErr("failed to load plans from Stripe", err)`
  - `fmt.Errorf("failed to store plan %s: %w", plan.Name, err)` → `wrapErr(fmt.Sprintf("failed to store plan %s", plan.Name), err)`

## Tests run

```
go test -v -timeout=60s ./errors/... ./account/... ./notifications/mailtemplates/... \
  ./internal/... ./subscriptions/... ./csp/handlers/... ./csp/signers/... ./cmd/client/...

ok  github.com/vocdoni/saas-backend/errors                        0.007s
ok  github.com/vocdoni/saas-backend/account                       0.037s
ok  github.com/vocdoni/saas-backend/notifications/mailtemplates   0.059s
ok  github.com/vocdoni/saas-backend/internal                      0.631s
ok  github.com/vocdoni/saas-backend/subscriptions                 0.056s
ok  github.com/vocdoni/saas-backend/csp/handlers                  0.314s
ok  github.com/vocdoni/saas-backend/csp/signers/saltedkey         0.022s
ok  github.com/vocdoni/saas-backend/cmd/client                    0.185s
```

`golangci-lint run --new-from-rev=main`: 0 issues.

The `api/...` integration tests (which call `InitializeStripeService` indirectly) require Docker and run in CI.

## Risks and review focus

Pure mechanical refactor; no logic change. The only risk is a subtle message-format difference — verified by running both the old and new call patterns through the same `fmt.Errorf`/`errors.Unwrap` checks and confirming identical output.

## Notes for maintainers

The issue referenced `api/handlers.go`, which does not exist as a single file; handlers are split across several files in `api/`. Only the two `fmt.Errorf` call sites in the package outside test files were present, both in `stripe_handlers.go`.