### PR TITLE
chore(api): log org_id in createOrganizationHandler success path

### DIFF
--- a/api/organizations.go
+++ b/api/organizations.go
@@ -148,6 +148,7 @@ func (a *API) createOrganizationHandler(w http.ResponseWriter, r *http.Request) 
 		errors.ErrGenericInternalServerError.Write(w)
 		return
 	}
+	log.Infow("organization created", "org_id", dbOrg.Address.Hex())
 	// send the organization back to the user
 	apicommon.HTTPWriteJSON(w, apicommon.OrganizationFromDB(dbOrg, dbParentOrg))
 }


### PR DESCRIPTION
## Summary

Adds a structured log entry on the success path of the create-organization handler so the new organization's address can be correlated with downstream events in log aggregation tooling.

## Linked issue

Closes #456

## Changes

- `api/organizations.go`: Add `log.Infow("organization created", "org_id", dbOrg.Address.Hex())` immediately after `SetOrganization` succeeds in `createOrganizationHandler`. No behavior or response change.

## Tests run

Tier 1 (local, no Docker):

```
ok  github.com/vocdoni/saas-backend/errors
ok  github.com/vocdoni/saas-backend/account
ok  github.com/vocdoni/saas-backend/notifications/mailtemplates
ok  github.com/vocdoni/saas-backend/internal
ok  github.com/vocdoni/saas-backend/subscriptions
ok  github.com/vocdoni/saas-backend/csp/handlers
ok  github.com/vocdoni/saas-backend/csp/signers/saltedkey
ok  github.com/vocdoni/saas-backend/cmd/client
```

Lint: `golangci-lint run --new-from-rev=main ./api/...` — 0 issues.

Tier 2 (`api/` integration tests) require Docker and run in CI.

## Risks and review focus

None. Pure log enrichment; HTTP response and data writes are unchanged.

## Notes for maintainers

Field name `org_id` matches the naming suggested in the issue. The value is the Ethereum hex address that also serves as the organization's unique identifier in the DB.