### PR TITLE
docs: add Quickstart section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,12 @@ This service also allows to the SDK to user it as remote signer, which makes tha
 
 Check out the service [API documentation](./api/docs.md) here.
 
+## Quickstart
+
+**Prerequisites:** Docker 20.10+ (for the `docker compose` plugin)
+
+- `git clone https://github.com/vocdoni/saas-backend.git && cd saas-backend`
+- `cp example.env .env`
+- `docker compose up -d`
+- `curl http://localhost:8080/ping`
+


### PR DESCRIPTION
## Summary

Adds a `## Quickstart` section to README.md with four terse bullet-point commands, placed after the intro and API docs link. No prose — commands only.

## Linked issue

Closes #461

## Changes

- `README.md`: inserted `## Quickstart` section with four command bullets (clone, copy env, compose up, health ping)

## Tests run

Docs-only change; no Go packages affected. Validation suite passes unchanged:

```
go test -v -timeout=60s ./errors/... ./account/... ./notifications/mailtemplates/... ./internal/... ./subscriptions/... ./csp/handlers/... ./csp/signers/... ./cmd/client/...
```

## Risks and review focus

No code changes. The one judgment call: the health endpoint used is `/ping` (the actual endpoint in `api/routes.go`) rather than `/health` as mentioned in the issue — `/health` does not exist in the codebase.

## Notes for maintainers

The `VOCDONI_PORT` defaults to `8080` per `example.env`, so `localhost:8080/ping` is accurate for a default local setup.