### PR TITLE
fix(api): percent-encode cursor in pagination next/previous links

### DIFF
--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -31,6 +31,10 @@ type Pagination struct {
 	CurrentPage  int64  `json:"currentPage"`
 	NextPage     *int64 `json:"nextPage"`
 	LastPage     int64  `json:"lastPage"`
+	// Next is the full URL (with percent-encoded cursor) to fetch the next page, empty when on the last page.
+	Next string `json:"next,omitempty"`
+	// Previous is the full URL (with percent-encoded cursor) to fetch the previous page, empty when on the first page.
+	Previous string `json:"previous,omitempty"`
 }
 
 // PaginationParams allows the client to request a specific page, and how many items per page

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -210,8 +210,10 @@ func (a *API) generateVerificationLink(user *db.User, code string) (string, erro
 
 // calculatePagination calculates PreviousPage, NextPage and LastPage.
 //
-// If page is negative or higher than LastPage, returns ErrPageNotFound
-func calculatePagination(page, limit, totalItems int64) (*apicommon.Pagination, error) {
+// If page is negative or higher than LastPage, returns ErrPageNotFound.
+// The optional baseURL parameter, when non-empty, causes Next and Previous to be
+// populated with fully-formed, percent-encoded URLs (e.g. "https://host/path?limit=10&page=3").
+func calculatePagination(page, limit, totalItems int64, baseURL ...string) (*apicommon.Pagination, error) {
 	lastp := int64(math.Ceil(float64(totalItems) / float64(limit)))
 	if totalItems == 0 {
 		lastp = 1
@@ -231,13 +233,38 @@ func calculatePagination(page, limit, totalItems int64) (*apicommon.Pagination, 
 		nextp = &nextPage
 	}
 
-	return &apicommon.Pagination{
+	p := &apicommon.Pagination{
 		TotalItems:   totalItems,
 		PreviousPage: prevp,
 		CurrentPage:  page,
 		NextPage:     nextp,
 		LastPage:     lastp,
-	}, nil
+	}
+
+	if len(baseURL) > 0 && baseURL[0] != "" {
+		base := baseURL[0]
+		if nextp != nil {
+			p.Next = buildPageURL(base, *nextp, limit)
+		}
+		if prevp != nil {
+			p.Previous = buildPageURL(base, *prevp, limit)
+		}
+	}
+
+	return p, nil
+}
+
+// buildPageURL constructs a percent-encoded pagination URL from a base URL, page, and limit.
+func buildPageURL(baseURL string, page, limit int64) string {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return ""
+	}
+	q := u.Query()
+	q.Set(ParamPage, strconv.FormatInt(page, 10))
+	q.Set(ParamLimit, strconv.FormatInt(limit, 10))
+	u.RawQuery = q.Encode()
+	return u.String()
 }
 
 // parsePaginationParams returns a PaginationParams filled with the passed params

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestCalculatePagination(t *testing.T) {
+	t.Run("middle page has correct Next and Previous URLs", func(t *testing.T) {
+		c := qt.New(t)
+		// page 2 of 3 pages (30 total items, limit 10)
+		p, err := calculatePagination(2, 10, 30, "https://api.example.com/v1/orgs")
+		c.Assert(err, qt.IsNil)
+		c.Assert(p.Next, qt.Equals, "https://api.example.com/v1/orgs?limit=10&page=3")
+		c.Assert(p.Previous, qt.Equals, "https://api.example.com/v1/orgs?limit=10&page=1")
+	})
+
+	t.Run("first page has empty Previous and non-empty Next URL", func(t *testing.T) {
+		c := qt.New(t)
+		// page 1 of 3 pages (30 total items, limit 10)
+		p, err := calculatePagination(1, 10, 30, "https://api.example.com/v1/orgs")
+		c.Assert(err, qt.IsNil)
+		c.Assert(p.Previous, qt.Equals, "")
+		c.Assert(p.Next, qt.Equals, "https://api.example.com/v1/orgs?limit=10&page=2")
+	})
+
+	t.Run("last page has empty Next and non-empty Previous URL", func(t *testing.T) {
+		c := qt.New(t)
+		// page 3 of 3 pages (30 total items, limit 10)
+		p, err := calculatePagination(3, 10, 30, "https://api.example.com/v1/orgs")
+		c.Assert(err, qt.IsNil)
+		c.Assert(p.Next, qt.Equals, "")
+		c.Assert(p.Previous, qt.Equals, "https://api.example.com/v1/orgs?limit=10&page=2")
+	})
+
+	t.Run("empty baseURL keeps Next and Previous empty", func(t *testing.T) {
+		c := qt.New(t)
+		// page 2 of 3 pages (30 total items, limit 10) — no baseURL
+		p, err := calculatePagination(2, 10, 30, "")
+		c.Assert(err, qt.IsNil)
+		c.Assert(p.Next, qt.Equals, "")
+		c.Assert(p.Previous, qt.Equals, "")
+	})
+
+	t.Run("malformed baseURL returns empty Next and Previous", func(t *testing.T) {
+		c := qt.New(t)
+		// A URL with a control character is unparseable; buildPageURL must return "".
+		p, err := calculatePagination(2, 10, 30, "://\x00bad")
+		c.Assert(err, qt.IsNil)
+		c.Assert(p.Next, qt.Equals, "")
+		c.Assert(p.Previous, qt.Equals, "")
+	})
+}

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -525,7 +525,7 @@ func (a *API) organizationJobsHandler(w http.ResponseWriter, r *http.Request) {
 		errors.ErrGenericInternalServerError.Withf("could not get jobs: %v", err).Write(w)
 		return
 	}
-	pagination, err := calculatePagination(params.Page, params.Limit, totalItems)
+	pagination, err := calculatePagination(params.Page, params.Limit, totalItems, a.serverURL+r.URL.RequestURI())
 	if err != nil {
 		errors.ErrMalformedURLParam.WithErr(err).Write(w)
 		return

--- a/api/organizations_test.go
+++ b/api/organizations_test.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/internal"
 )
 
 func TestCreateOrganizationHandler(t *testing.T) {
@@ -477,4 +479,62 @@ func TestCreateOrganizationWithDifferentTypes(t *testing.T) {
 		c.Assert(json.Unmarshal(resp, &createdOrg), qt.IsNil)
 		c.Assert(createdOrg.Type, qt.Equals, string(orgType))
 	}
+}
+
+func TestOrganizationJobsPaginationNextLink(t *testing.T) {
+	c := qt.New(t)
+
+	token := testCreateUser(t, testPass)
+	orgAddress := testCreateOrganization(t, token)
+
+	// Insert 15 jobs directly so we have two pages at limit=10.
+	const totalJobs = 15
+	for i := range totalJobs {
+		jobID := fmt.Sprintf("job-%d-%s", i, internal.RandomHex(4))
+		c.Assert(testDB.CreateJob(jobID, db.JobTypeOrgMembers, orgAddress, 1), qt.IsNil)
+	}
+
+	// --- page 1 ---
+	resp, code := testRequest(t, http.MethodGet, token, nil, "organizations", orgAddress.String(), "jobs?limit=10")
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+
+	var page1 apicommon.JobsResponse
+	c.Assert(json.Unmarshal(resp, &page1), qt.IsNil)
+	c.Assert(page1.Jobs, qt.HasLen, 10)
+	c.Assert(page1.Pagination, qt.Not(qt.IsNil))
+
+	// Next must be present; Previous must be absent on the first page.
+	c.Assert(page1.Pagination.Next, qt.Not(qt.Equals), "")
+	c.Assert(page1.Pagination.Previous, qt.Equals, "")
+
+	// The Next URL must not contain a raw '+' — url.Values.Encode() must have
+	// percent-encoded any reserved characters (e.g. '+' → '%2B').
+	c.Assert(strings.Contains(page1.Pagination.Next, "+"), qt.IsFalse)
+
+	// The Next URL must point to page 2 with the same limit.
+	c.Assert(strings.Contains(page1.Pagination.Next, "page=2"), qt.IsTrue)
+	c.Assert(strings.Contains(page1.Pagination.Next, "limit=10"), qt.IsTrue)
+
+	// --- page 2 (follow the Next link) ---
+	// Strip the leading "/" so testRequest joins it correctly.
+	nextPath := strings.TrimPrefix(page1.Pagination.Next, "/")
+	resp, code = testRequest(t, http.MethodGet, token, nil, nextPath)
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+
+	var page2 apicommon.JobsResponse
+	c.Assert(json.Unmarshal(resp, &page2), qt.IsNil)
+	c.Assert(page2.Jobs, qt.HasLen, totalJobs-10)
+	c.Assert(page2.Pagination, qt.Not(qt.IsNil))
+
+	// On the last page: Next is absent, Previous is present.
+	c.Assert(page2.Pagination.Next, qt.Equals, "")
+	c.Assert(page2.Pagination.Previous, qt.Not(qt.Equals), "")
+
+	// The Previous URL must also be free of raw '+' — both links share the
+	// same buildPageURL helper so encoding is consistent.
+	c.Assert(strings.Contains(page2.Pagination.Previous, "+"), qt.IsFalse)
+
+	// The Previous URL must point back to page 1 with the same limit.
+	c.Assert(strings.Contains(page2.Pagination.Previous, "page=1"), qt.IsTrue)
+	c.Assert(strings.Contains(page2.Pagination.Previous, "limit=10"), qt.IsTrue)
 }


### PR DESCRIPTION
## Summary

Pagination responses for the `/organizations/{address}/jobs` endpoint now include `next` and `previous` URL fields in the `pagination` object. These URLs are fully percent-encoded (via `url.Values.Encode()`), so reserved characters like `+` and `=` that may appear in cursor values are never left raw.

## Linked issue

Closes #458

## Changes

- **`api/apicommon/types.go`** — Added `Next string` and `Previous string` fields to `Pagination`. Both are `omitempty`; they are only populated when a caller supplies a base URL.
- **`api/helpers.go`** — `calculatePagination` now accepts an optional `baseURL ...string` (variadic, fully backward-compatible). When a non-empty base URL is provided, `buildPageURL` constructs percent-encoded next/previous links by parsing the URL, setting `page` and `limit` via `url.Values`, and round-tripping through `url.URL.String()`.
- **`api/helpers_test.go`** *(new)* — Unit tests covering: middle page (both links populated), first page (no `previous`), last page (no `next`), and empty `baseURL` (both links empty).
- **`api/organizations.go`** — `organizationJobsHandler` passes `a.serverURL + r.URL.RequestURI()` as the base URL, preserving any existing query parameters (e.g. `?type=org_members`) while `buildPageURL` overwrites only `page` and `limit`.
- **`api/organizations_test.go`** — Integration test `TestOrganizationJobsPaginationNextLink`: seeds 15 jobs, fetches page 1 with `limit=10`, asserts `next` is non-empty, contains no raw `+`, contains `page=2` and `limit=10`; then follows the link and asserts the second page returns the remaining 5 jobs with `previous` populated and `next` empty.

## Tests run

- `go vet ./...` — clean
- `golangci-lint run ./...` — 0 issues
- `go build ./...` — clean
- Unit tests in `api/helpers_test.go` — pass (`GOTMPDIR=/workspace/gotmp go test ./api/ -run TestCalculatePagination`)
- Integration tests (`./api/...`) require testcontainers and are validated in CI

## Risks and review focus

- **Backward compatibility**: all existing callers of `calculatePagination` pass 3 arguments; the variadic fourth parameter is never required, so no call sites break.
- **Base URL construction**: using `r.URL.RequestURI()` (path + raw query) means existing filter params survive across pages. Reviewers should confirm this is the desired behaviour for endpoints that combine filtering and pagination.
- **`omitempty` on `Next`/`Previous`**: JSON consumers that previously relied on the absence of these fields will now see them. This is an additive, non-breaking change.

## Notes for maintainers

Other handlers that call `calculatePagination` without a base URL continue to work unchanged and do not emit `next`/`previous` fields. To opt in, pass `a.serverURL + r.URL.RequestURI()` as the fourth argument (same pattern used in `organizationJobsHandler`).