### PR TITLE
feat(api): add GET /api/info endpoint returning runtime info

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -49,6 +49,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"runtime"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -56,6 +57,7 @@ import (
 	"github.com/go-chi/cors"
 	"github.com/go-chi/jwtauth/v5"
 	"github.com/vocdoni/saas-backend/account"
+	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/csp"
 	"github.com/vocdoni/saas-backend/csp/handlers"
 	"github.com/vocdoni/saas-backend/db"
@@ -70,6 +72,9 @@ const (
 	jwtExpiration = 360 * time.Hour // 15 days
 	passwordSalt  = "vocdoni365"    // salt for password hashing
 )
+
+// startTime records when the API package was loaded, used to compute uptime.
+var startTime = time.Now()
 
 type Config struct {
 	Host        string
@@ -209,6 +214,7 @@ func (a *API) initRouter() http.Handler {
 		// handle valid JWT tokens
 		r.Use(a.authenticator)
 
+		handle(r, http.MethodGet, infoEndpoint, a.infoHandler)
 		handle(r, http.MethodPost, authRefresTokenEndpoint, a.refreshTokenHandler)
 		handle(r, http.MethodGet, authAddressesEndpoint, a.organizationAddressesHandler)
 		handle(r, http.MethodPost, oauthLinkEndpoint, a.oauthLinkHandler)
@@ -302,4 +308,20 @@ func (a *API) initRouter() http.Handler {
 	})
 	a.router = r
 	return r
+}
+
+// infoHandler godoc
+//
+//	@Summary		Get server runtime information
+//	@Description	Returns the Go version and server uptime in seconds
+//	@Tags			info
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Success		200	{object}	apicommon.InfoResponse
+//	@Router			/api/info [get]
+func (*API) infoHandler(w http.ResponseWriter, _ *http.Request) {
+	apicommon.HTTPWriteJSON(w, apicommon.InfoResponse{
+		GoVersion:     runtime.Version(),
+		UptimeSeconds: int64(time.Since(startTime).Seconds()),
+	})
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -966,6 +967,19 @@ func requestAndExpectError(t *testing.T, method, jwt string, jsonBody any, urlPa
 
 func randomProcessID() []byte {
 	return internal.RandomBytes(32)
+}
+
+func TestInfoHandler(t *testing.T) {
+	c := qt.New(t)
+
+	// Unauthenticated request must be rejected
+	requestAndAssertCode(http.StatusUnauthorized, t, http.MethodGet, "", nil, infoEndpoint)
+
+	// Authenticated request must return runtime info
+	token := testCreateUser(t, testPass)
+	info := requestAndParse[apicommon.InfoResponse](t, http.MethodGet, token, nil, infoEndpoint)
+	c.Assert(info.GoVersion, qt.Equals, runtime.Version())
+	c.Assert(info.UptimeSeconds >= 0, qt.IsTrue)
 }
 
 // memberIDs returns a slice of all orgMembers[n].ID

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -1207,6 +1207,16 @@ type JobsResponse struct {
 	Jobs []JobInfo `json:"jobs"`
 }
 
+// InfoResponse represents the runtime information of the server.
+// swagger:model InfoResponse
+type InfoResponse struct {
+	// Go version of the running server
+	GoVersion string `json:"go_version"`
+
+	// Number of seconds the server has been running
+	UptimeSeconds int64 `json:"uptime_seconds"`
+}
+
 // JobFromDB converts a db.Job to a JobInfo.
 func JobFromDB(job *db.Job) JobInfo {
 	if job == nil {

--- a/api/routes.go
+++ b/api/routes.go
@@ -4,6 +4,8 @@ const (
 	// ping route
 	// GET /ping to check the server status
 	pingEndpoint = "/ping"
+	// GET /api/info to get the runtime information of the server
+	infoEndpoint = "/api/info"
 
 	// auth routes
 


### PR DESCRIPTION
## Summary

- Adds a `GET /api/info` authenticated endpoint that returns the Go runtime version and server uptime in seconds.
- Route is protected by the existing JWT middleware (unauthenticated requests receive 401).
- Uptime is computed from a package-level `startTime` variable initialised at process start.

## Linked issue

Closes #462

## Changes

- `api/routes.go` — adds `infoEndpoint = "/api/info"` constant alongside the existing `pingEndpoint`.
- `api/apicommon/types.go` — adds `InfoResponse` struct (`go_version string`, `uptime_seconds int64`) with swagger annotation.
- `api/api.go` — adds `var startTime = time.Now()` at package scope; implements `(*API).infoHandler` using `runtime.Version()` and `time.Since(startTime)`; registers the route in the protected group at the top of `initRouter()`.
- `api/api_test.go` — adds `TestInfoHandler` covering the 401 unauthenticated path and the 200 authenticated path (asserts `go_version == runtime.Version()` and `uptime_seconds >= 0`).

## Tests run

Tier-1 suite (no Docker required) — all pass:

```
go test -v -timeout=60s ./errors/... ./account/... ./notifications/mailtemplates/... ./internal/... ./subscriptions/... ./csp/handlers/... ./csp/signers/... ./cmd/client/...
ok  github.com/vocdoni/saas-backend/errors
ok  github.com/vocdoni/saas-backend/account
ok  github.com/vocdoni/saas-backend/notifications/mailtemplates
ok  github.com/vocdoni/saas-backend/internal
ok  github.com/vocdoni/saas-backend/subscriptions
ok  github.com/vocdoni/saas-backend/csp/handlers
ok  github.com/vocdoni/saas-backend/csp/signers/saltedkey
ok  github.com/vocdoni/saas-backend/cmd/client
```

`TestInfoHandler` lives in `api/api_test.go` and will run as part of the full Docker-backed CI suite (`./api/...`).

Lint: `golangci-lint run --new-from-rev=main ./api/...` — 0 issues.
Qt pattern check: `./scripts/check-qt-patterns.sh` — no anti-patterns found.

## Risks and review focus

- **Low risk**: read-only endpoint, no DB access, no new dependencies.
- `startTime` is set once at package init; it reflects process start time, not `API.Start()` call time. Acceptable for an uptime approximation.
- The endpoint is inside the JWT-authenticated group — it cannot be reached without a valid token.

## Notes for maintainers

- No new dependencies introduced.
- Swagger docs can be regenerated with `./scripts/generate-swagger.sh` if desired; the handler carries the standard godoc annotation block.