### PR TITLE
test(internal): add table-driven test for RandomHex output length

### DIFF
--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -233,6 +233,25 @@ func TestEncryptDecryptToken(t *testing.T) {
 	})
 }
 
+func TestRandomHexLength(t *testing.T) {
+	c := quicktest.New(t)
+
+	tests := []struct {
+		n int
+	}{
+		{n: 0},
+		{n: 1},
+		{n: 16},
+		{n: 32},
+	}
+
+	for _, tt := range tests {
+		c.Run(fmt.Sprintf("n=%d", tt.n), func(c *quicktest.C) {
+			c.Assert(RandomHex(tt.n), quicktest.HasLen, 2*tt.n)
+		})
+	}
+}
+
 func TestDecryptTokenFromHexErrors(t *testing.T) {
 	c := quicktest.New(t)
 


### PR DESCRIPTION
## Summary

Adds `TestRandomHexLength` to `internal/utils_test.go`, a table-driven test that asserts `RandomHex(n)` returns a hex string of exactly `2*n` characters for `n ∈ {0, 1, 16, 32}`.

## Linked issue

Closes #471

## Changes

- `internal/utils_test.go`: new `TestRandomHexLength` function using `quicktest.HasLen` to assert the output-length invariant across four representative input sizes (empty, single byte, 16-byte, 32-byte).

## Tests run

```
$ go test -v -timeout=60s ./internal/... -run TestRandomHexLength
=== RUN   TestRandomHexLength
=== RUN   TestRandomHexLength/n=0
=== RUN   TestRandomHexLength/n=1
=== RUN   TestRandomHexLength/n=16
=== RUN   TestRandomHexLength/n=32
--- PASS: TestRandomHexLength (0.00s)
    --- PASS: TestRandomHexLength/n=0 (0.00s)
    --- PASS: TestRandomHexLength/n=1 (0.00s)
    --- PASS: TestRandomHexLength/n=16 (0.00s)
    --- PASS: TestRandomHexLength/n=32 (0.00s)
PASS
ok  	github.com/vocdoni/saas-backend/internal	0.004s
```

Full `./internal/...` suite and `./scripts/check-qt-patterns.sh` also passed.

## Risks and review focus

None — test-only addition, no production code changed.

## Notes for maintainers

No action required. The test covers the edge case `n=0` (empty string) and the typical token sizes used elsewhere in the package.