### PR TITLE
refactor(db): wrap SetUser errors with fmt.Errorf("set user: %w", err)

### DIFF
--- a/db/users.go
+++ b/db/users.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"go.mongodb.org/mongo-driver/bson"
@@ -129,7 +130,7 @@ func (ms *MongoStorage) SetUser(user *User) (uint64, error) {
 	// get the next available user ID
 	nextID, err := ms.nextUserID(ctx)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("set user: %w", err)
 	}
 	// if the user provided doesn't have organizations, create an empty slice
 	if user.Organizations == nil {
@@ -143,11 +144,11 @@ func (ms *MongoStorage) SetUser(user *User) (uint64, error) {
 		// if the user exists, update it with the new data
 		updateDoc, err := dynamicUpdateDocument(user, nil)
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("set user: %w", err)
 		}
 		_, err = ms.users.UpdateOne(ctx, bson.M{"_id": user.ID}, updateDoc)
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("set user: %w", err)
 		}
 	} else {
 		// if the user doesn't exist, create it setting the ID first
@@ -156,7 +157,7 @@ func (ms *MongoStorage) SetUser(user *User) (uint64, error) {
 			if mongo.IsDuplicateKeyError(err) {
 				return 0, ErrAlreadyExists
 			}
-			return 0, err
+			return 0, fmt.Errorf("set user: %w", err)
 		}
 	}
 	return user.ID, nil


### PR DESCRIPTION
## Summary

All four error-return paths in `db.SetUser` previously returned raw MongoDB errors with no context. This wraps each with `fmt.Errorf("set user: %w", err)`, adding a consistent prefix while preserving sentinel unwrapping via `errors.Is`/`errors.As`. Sentinel values returned directly (`ErrInvalidData`, `ErrAlreadyExists`) are left unwrapped — they signal specific conditions, not unexpected failures.

## Linked issue

Closes #470

## Changes

- `db/users.go`: add `fmt` import; wrap errors from `nextUserID`, `dynamicUpdateDocument`, `UpdateOne`, and the non-duplicate-key `InsertOne` path with `fmt.Errorf("set user: %w", err)`.

No call-site changes required — `api/auth.go` only checks `if err != nil`, and test assertions use sentinel comparisons (`ErrInvalidData`, `ErrAlreadyExists`) or `qt.IsNotNil`, all of which continue to work through `%w` wrapping.

## Tests run

Local (non-Docker) test suite — all pass:

```
$ golangci-lint run --new-from-rev=main ./db/...
0 issues.

$ go test -timeout=60s ./errors/... ./account/... ./notifications/mailtemplates/... ./internal/... ./subscriptions/... ./csp/handlers/... ./csp/signers/... ./cmd/client/...
ok  	github.com/vocdoni/saas-backend/errors
ok  	github.com/vocdoni/saas-backend/account
ok  	github.com/vocdoni/saas-backend/notifications/mailtemplates
ok  	github.com/vocdoni/saas-backend/internal
ok  	github.com/vocdoni/saas-backend/subscriptions
ok  	github.com/vocdoni/saas-backend/csp/handlers
ok  	github.com/vocdoni/saas-backend/csp/signers/saltedkey
ok  	github.com/vocdoni/saas-backend/cmd/client
```

The `db` package tests (`TestUsers`, `TestOrganizations`, etc.) require a live MongoDB via testcontainers-go and run only in CI.

## Risks and review focus

Low risk. The change is additive — `%w` preserves the underlying error for `errors.Is`/`errors.As`, so no existing sentinel-based error handling is broken. The only observable difference is the added `"set user: "` prefix in error messages surfaced to log aggregators or HTTP error responses.

## Notes for maintainers

No migration, no dependency change, no API surface change.