### PR TITLE
feat(api): add request-id middleware with zerolog context binding

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -169,6 +169,7 @@ func (a *API) initRouter() http.Handler {
 		AllowCredentials: true,
 		MaxAge:           300, // Maximum value not ignored by any of major browsers
 	}).Handler)
+	r.Use(requestID)
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Throttle(100))

--- a/api/middlewares.go
+++ b/api/middlewares.go
@@ -6,10 +6,12 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/jwtauth/v5"
+	"github.com/google/uuid"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
+	"go.vocdoni.io/dvote/log"
 )
 
 // authenticator is a middleware that authenticates the user and returns a JWT
@@ -75,6 +77,18 @@ func (*API) setLang(next http.Handler) http.Handler {
 			ctx = context.WithValue(r.Context(), apicommon.LangMetadataKey, lang)
 		}
 		// add lang to the context
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// requestID is a middleware that generates a UUID for each request, sets it on
+// the X-Request-ID response header, and binds a zerolog context-logger carrying
+// the request_id field so handlers can retrieve it via zerolog.Ctx(r.Context()).
+func requestID(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := uuid.New().String()
+		w.Header().Set("X-Request-ID", id)
+		ctx := log.Logger().With().Str("request_id", id).Logger().WithContext(r.Context())
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/api/middlewares_test.go
+++ b/api/middlewares_test.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/google/uuid"
+)
+
+func TestRequestIDMiddleware(t *testing.T) {
+	c := qt.New(t)
+
+	handler := requestID(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	id := rec.Header().Get("X-Request-ID")
+	c.Assert(id, qt.Not(qt.Equals), "")
+	_, err := uuid.Parse(id)
+	c.Assert(err, qt.IsNil)
+}


### PR DESCRIPTION
## Summary

Adds a per-request UUID middleware to the `api/` package. Every response now carries an `X-Request-ID` header, and a zerolog context-logger annotated with the `request_id` field is stored on the request context so handlers can retrieve it via `zerolog.Ctx(r.Context())`.

## Linked issue

Closes #476

## Changes

- **`api/middlewares.go`** — new `requestID` middleware: generates a UUID via `github.com/google/uuid` (already a dependency), sets `X-Request-ID` on the response header, and binds a zerolog logger carrying the `request_id` field to the request context using `log.Logger().With().Str("request_id", id).Logger().WithContext(ctx)`.
- **`api/api.go`** — wires `r.Use(requestID)` into `initRouter()` immediately after CORS and before chi's `Logger`/`Recoverer` middleware, so the ID is available to all downstream handlers and log lines.
- **`api/middlewares_test.go`** (new) — `TestRequestIDMiddleware` wraps a no-op handler in the middleware using `httptest`, asserts `X-Request-ID` is non-empty, and validates the value parses as a UUID.

## Tests run

```
# Tier 1 (no Docker required)
golangci-lint run --new-from-rev=main ./...   → 0 issues
./scripts/check-qt-patterns.sh                → no anti-patterns found
go test -v -timeout=60s ./errors/... ./account/... ./notifications/mailtemplates/... \
  ./internal/... ./subscriptions/... ./csp/handlers/... ./csp/signers/... ./cmd/client/...

ok  github.com/vocdoni/saas-backend/errors
ok  github.com/vocdoni/saas-backend/account
ok  github.com/vocdoni/saas-backend/notifications/mailtemplates
ok  github.com/vocdoni/saas-backend/internal
ok  github.com/vocdoni/saas-backend/subscriptions
ok  github.com/vocdoni/saas-backend/csp/handlers
ok  github.com/vocdoni/saas-backend/csp/signers/saltedkey
ok  github.com/vocdoni/saas-backend/cmd/client

# Tier 2 (api package — requires Docker, runs in CI)
go test -v -run TestRequestIDMiddleware ./api/...  → will run in CI
```

## Risks and review focus

- **Additive only** — no existing handler or middleware is modified; the new `r.Use` call is inserted before existing middleware so the header is set on every response path including error responses.
- **No new dependencies** — `github.com/google/uuid` and `go.vocdoni.io/dvote/log` are already direct dependencies.
- The client-provided `X-Request-ID` is not echoed back (always a fresh UUID); if echo behaviour is wanted later it can be layered on top.

## Notes for maintainers

Handlers can now access the request-scoped logger with:
```go
logger := zerolog.Ctx(r.Context())
logger.Info().Msg("handler called")  // automatically includes request_id field
```
This requires importing `github.com/rs/zerolog` directly in the handler file (it is an indirect dependency today).