### PR TITLE
fix(api): enforce minimum password length of 12 characters

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -56,7 +56,7 @@ type apiTestCase struct {
 const (
 	testSecret    = "super-secret"
 	testEmail     = "user@test.com"
-	testPass      = "password123"
+	testPass      = "password12345"
 	testFirstName = "test"
 	testLastName  = "user"
 	testHost      = "0.0.0.0"

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -245,7 +245,7 @@ func TestOAuthLinkUnlinkHandler(t *testing.T) {
 	email := fmt.Sprintf("link-test-%d@test.com", internal.RandomInt(10000))
 	userInfo := &apicommon.UserInfo{
 		Email:     email,
-		Password:  "password123",
+		Password:  testPass,
 		FirstName: "Link",
 		LastName:  "Test",
 	}
@@ -297,7 +297,7 @@ func TestOAuthLinkUnlinkHandler(t *testing.T) {
 	email2 := fmt.Sprintf("link-test-2-%d@test.com", internal.RandomInt(10000))
 	userInfo2 := &apicommon.UserInfo{
 		Email:     email2,
-		Password:  "password123",
+		Password:  testPass,
 		FirstName: "Link",
 		LastName:  "Test",
 	}

--- a/api/lang_test.go
+++ b/api/lang_test.go
@@ -71,7 +71,7 @@ func TestLanguageParameterInUserRegistration(t *testing.T) {
 	test := func(lang string) {
 		userInfo := db.User{
 			Email:     fmt.Sprintf("testLang%s@example.com", lang),
-			Password:  "password123",
+			Password:  testPass,
 			FirstName: "María",
 			LastName:  "García",
 		}

--- a/api/users.go
+++ b/api/users.go
@@ -44,7 +44,7 @@ func (a *API) registerHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// check the password is correct format
-	if len(userInfo.Password) < 8 {
+	if len(userInfo.Password) < 12 {
 		errors.ErrPasswordTooShort.Write(w)
 		return
 	}
@@ -527,7 +527,7 @@ func (a *API) updateUserPasswordHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	// check the password is correct format
-	if len(userPasswords.NewPassword) < 8 {
+	if len(userPasswords.NewPassword) < 12 {
 		errors.ErrPasswordTooShort.Write(w)
 		return
 	}
@@ -625,7 +625,7 @@ func (a *API) resetUserPasswordHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// check the password is correct format
-	if len(userPasswords.NewPassword) < 8 {
+	if len(userPasswords.NewPassword) < 12 {
 		errors.ErrPasswordTooShort.Write(w)
 		return
 	}

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -73,7 +73,7 @@ func TestRegisterHandler(t *testing.T) {
 	// Test valid registration
 	userInfo := &apicommon.UserInfo{
 		Email:     "valid@test.com",
-		Password:  "password",
+		Password:  "validpassword1",
 		FirstName: "first",
 		LastName:  "last",
 	}
@@ -114,14 +114,20 @@ func TestRegisterHandler(t *testing.T) {
 	c.Assert(code, qt.Equals, http.StatusBadRequest)
 	c.Assert(string(resp), qt.Contains, "invalid email format")
 
-	// Test short password
+	// Test password below minimum length (11 chars, one less than the required 12)
 	userInfo.Email = "valid2@test.com"
-	userInfo.Password = "short"
+	userInfo.Password = "password12a"
 	resp, code = testRequest(t, http.MethodPost, "", userInfo, usersEndpoint)
 	c.Assert(code, qt.Equals, http.StatusBadRequest)
-	c.Assert(string(resp), qt.Contains, "password must be at least 8 characters")
+	c.Assert(string(resp), qt.Contains, "password must be at least 12 characters")
+
+	// Test password at exactly the minimum length (12 chars) is accepted
+	userInfo.Password = "password12ab"
+	resp, code = testRequest(t, http.MethodPost, "", userInfo, usersEndpoint)
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 
 	// Test empty password
+	userInfo.Email = "valid3@test.com"
 	userInfo.Password = ""
 	_, code = testRequest(t, http.MethodPost, "", userInfo, usersEndpoint)
 	c.Assert(code, qt.Equals, http.StatusBadRequest)
@@ -180,7 +186,7 @@ func TestRecoverAndResetPassword(t *testing.T) {
 	c.Assert(len(passResetMailCode) > 1, qt.IsTrue)
 
 	// Reset the password
-	newPassword := "password2"
+	newPassword := "newpassword123"
 	resetPass := &apicommon.UserPasswordReset{
 		Email:       testEmail,
 		Code:        passResetMailCode[1],
@@ -201,6 +207,22 @@ func TestRecoverAndResetPassword(t *testing.T) {
 	loginInfo.Password = newPassword
 	resp, code = testRequest(t, http.MethodPost, "", loginInfo, authLoginEndpoint)
 	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+}
+
+func TestUpdateUserPasswordHandler(t *testing.T) {
+	c := qt.New(t)
+
+	// Set up a verified, logged-in user
+	jwt := testCreateUser(t, testPass)
+
+	// Test that a new password below the minimum length is rejected
+	updateReq := &apicommon.UserPasswordUpdate{
+		OldPassword: testPass,
+		NewPassword: "short12",
+	}
+	resp, code := testRequest(t, http.MethodPut, jwt, updateReq, usersPasswordEndpoint)
+	c.Assert(code, qt.Equals, http.StatusBadRequest)
+	c.Assert(string(resp), qt.Contains, "password must be at least 12 characters")
 }
 
 func TestUserWithOrganization(t *testing.T) {

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -44,7 +44,7 @@ var (
 
 	// Validation errors (400)
 	ErrEmailMalformed          = Error{Code: 40002, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid email format")}
-	ErrPasswordTooShort        = Error{Code: 40003, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("password must be at least 8 characters")}
+	ErrPasswordTooShort        = Error{Code: 40003, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("password must be at least 12 characters")}
 	ErrMalformedBody           = Error{Code: 40004, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid JSON request body")}
 	ErrInvalidUserData         = Error{Code: 40005, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid user information provided")}
 	ErrMalformedURLParam       = Error{Code: 40010, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid URL parameter")}


### PR DESCRIPTION
## Summary

Raises the minimum password length from 8 to 12 characters in the user signup, password update, and password reset handlers. Updates the `ErrPasswordTooShort` error message to reflect the new limit and keeps test passwords in sync.

## Linked issue

Closes #480

## Changes

- `api/users.go` — change `len(password) < 8` to `len(password) < 12` in three handlers: `registerHandler`, `updateUserPasswordHandler`, `resetUserPasswordHandler`
- `errors/errors_definition.go` — update `ErrPasswordTooShort` message to `"password must be at least 12 characters"` (error code 40003 unchanged)
- `api/users_test.go` — replace loose 5-char password test with explicit boundary tests (11 chars → 400, 12 chars → 200); update assertion text; fix test passwords that were below the new minimum
- `api/api_test.go` / `api/auth_test.go` / `api/lang_test.go` — bump `testPass` constant and inline literals from 9–11 chars to ≥12 chars so CI integration tests continue to pass

## Tests run

Tier 1 (no Docker required) — passed locally:
```
$ go test -v -timeout=60s ./errors/... ./account/... ./notifications/mailtemplates/... ./internal/... ./subscriptions/... ./csp/handlers/... ./csp/signers/... ./cmd/client/...
ok  github.com/vocdoni/saas-backend/errors
ok  github.com/vocdoni/saas-backend/account
ok  github.com/vocdoni/saas-backend/notifications/mailtemplates
ok  github.com/vocdoni/saas-backend/internal
ok  github.com/vocdoni/saas-backend/subscriptions
ok  github.com/vocdoni/saas-backend/csp/handlers
ok  github.com/vocdoni/saas-backend/csp/signers/saltedkey
ok  github.com/vocdoni/saas-backend/cmd/client
```

Tier 2 (Docker — `./api/...`, `./db/...`, `./csp/...`) runs in CI. The relevant integration test is `TestRegisterHandler` in `api/users_test.go`.

Lint:
```
$ golangci-lint run --new-from-rev=main
0 issues.
$ ./scripts/check-qt-patterns.sh
✅ No qt anti-patterns found!
```

## Risks and review focus

- **Existing users are unaffected** — the check applies only at signup and explicit password-change/reset flows; stored password hashes are not touched.
- **No error code change** — `ErrPasswordTooShort` keeps code 40003; only the human-readable message changes. Clients that key on the code number are unaffected.
- The three handler locations are independent and could theoretically drift again. A named constant would prevent that, but the plan intentionally preserved the existing code style (inline literals) to minimise scope.

## Notes for maintainers

No migration or schema change required. The `testPass` constant in `api/api_test.go` was `"password123"` (11 chars); it is now `"password12345"` (13 chars) — this is a test-only change with no production impact.