### PR TITLE
test(db): add regression test for verification code expiration boundary

### DIFF
--- a/db/verifications_test.go
+++ b/db/verifications_test.go
@@ -95,4 +95,42 @@ func TestVerifications(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 		c.Assert(code.Attempts, qt.Equals, 2)
 	})
+
+	t.Run("TestSetVerificationCodeExpirationBoundary", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		userID, err := testDB.SetUser(&User{
+			Email:     testUserEmail + "4",
+			Password:  testUserPass,
+			FirstName: testUserFirstName,
+			LastName:  testUserLastName,
+		})
+		c.Assert(err, qt.IsNil)
+
+		sealedCode1, err := internal.SealToken("oldCode", testUserEmail, "mock-app-secret")
+		c.Assert(err, qt.IsNil)
+		// Set a code that expires almost immediately, simulating the expiration boundary.
+		oldExp := time.Now().Add(time.Millisecond)
+		c.Assert(testDB.SetVerificationCode(&User{ID: userID}, sealedCode1, CodeTypeVerifyAccount, oldExp), qt.IsNil)
+
+		// Wait past the old code's expiration boundary.
+		time.Sleep(2 * time.Millisecond)
+
+		// Set a new code at (or just after) the old code's expiration boundary.
+		sealedCode2, err := internal.SealToken("newCode", testUserEmail, "mock-app-secret")
+		c.Assert(err, qt.IsNil)
+		newExp := time.Now().Add(time.Hour)
+		c.Assert(testDB.SetVerificationCode(&User{ID: userID}, sealedCode2, CodeTypeVerifyAccount, newExp), qt.IsNil)
+
+		// The new code must win: UserVerificationCode must return the new sealed code and a future expiration.
+		//
+		// Why no race occurs on current main: UserVerificationCode does not filter by expiration —
+		// the verifications collection has no MongoDB TTL index and the application does not enforce
+		// expiry at query time. SetVerificationCode uses ReplaceOne (upsert), which atomically
+		// overwrites the whole document. Once that call returns, any subsequent read is guaranteed
+		// to see the new code; the old (expired) document can never reappear.
+		code, err := testDB.UserVerificationCode(&User{ID: userID}, CodeTypeVerifyAccount)
+		c.Assert(err, qt.IsNil)
+		c.Assert(code.SealedCode, qt.DeepEquals, sealedCode2)
+		c.Assert(code.Expiration.After(time.Now()), qt.IsTrue)
+	})
 }

--- a/db/verifications_test.go
+++ b/db/verifications_test.go
@@ -97,6 +97,15 @@ func TestVerifications(t *testing.T) {
 	})
 
 	t.Run("TestSetVerificationCodeExpirationBoundary", func(_ *testing.T) {
+		// Documenting current behavior: no prior commit has been identified where this
+		// assertion would fail. SetVerificationCode has always used ReplaceOne (upsert),
+		// which atomically overwrites the document, and there is no MongoDB TTL index nor
+		// application-level expiration check at query time. This test guards against
+		// future regressions if either of those invariants changes.
+		t.Log("documenting current behavior (not a regression for a fixed bug): " +
+			"SetVerificationCode atomically replaces the document via ReplaceOne; " +
+			"no TTL index exists and expiration is not enforced at query time, " +
+			"so the new code always wins with no observable race on current main")
 		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
 		userID, err := testDB.SetUser(&User{
 			Email:     testUserEmail + "4",
@@ -122,12 +131,6 @@ func TestVerifications(t *testing.T) {
 		c.Assert(testDB.SetVerificationCode(&User{ID: userID}, sealedCode2, CodeTypeVerifyAccount, newExp), qt.IsNil)
 
 		// The new code must win: UserVerificationCode must return the new sealed code and a future expiration.
-		//
-		// Why no race occurs on current main: UserVerificationCode does not filter by expiration —
-		// the verifications collection has no MongoDB TTL index and the application does not enforce
-		// expiry at query time. SetVerificationCode uses ReplaceOne (upsert), which atomically
-		// overwrites the whole document. Once that call returns, any subsequent read is guaranteed
-		// to see the new code; the old (expired) document can never reappear.
 		code, err := testDB.UserVerificationCode(&User{ID: userID}, CodeTypeVerifyAccount)
 		c.Assert(err, qt.IsNil)
 		c.Assert(code.SealedCode, qt.DeepEquals, sealedCode2)


### PR DESCRIPTION
## Summary

Adds `TestSetVerificationCodeExpirationBoundary` to `db/verifications_test.go` to exercise the boundary case between verification-code expiration and `SetVerificationCode`. The test confirms the new code always wins after a `SetVerificationCode` call, even when the call lands at or after the previous code's expiration time.

The test does not fail on current `main`. An inline comment documents why: `UserVerificationCode` does not filter by expiration (no MongoDB TTL index on the collection, no application-level expiry check at query time), and `SetVerificationCode` uses an atomic `ReplaceOne` (upsert) that completely overwrites the existing document — so once the call returns, any subsequent read is guaranteed to see the new code.

## Linked issue

Closes #481

## Changes

- `db/verifications_test.go`: new subtest `TestSetVerificationCodeExpirationBoundary` inside `TestVerifications`
  - Creates a user, sets a verification code expiring in 1 ms
  - Waits 2 ms past that boundary
  - Calls `SetVerificationCode` with a new code and a 1-hour TTL
  - Asserts `UserVerificationCode` returns the new sealed code with a future expiration
  - Comment in test explains why no race is observable on current `main`

No production code was modified.

## Tests run

```
$ golangci-lint run --new-from-rev=main ./db/...
0 issues.

$ ./scripts/check-qt-patterns.sh
✅ No qt anti-patterns found!
```

The full `db/...` suite (including the new test) requires Docker/testcontainers and runs in CI.

## Risks and review focus

- The test uses `time.Sleep(2 * time.Millisecond)` for boundary timing. On heavily loaded CI runners this is unlikely to be flaky, but worth keeping in mind if the test shows intermittent failures in future.
- No production paths touched; risk is confined to test infrastructure.

## Notes for maintainers

As documented in the test comment, expiration on `UserVerification` documents is currently unenforced at query time and there is no MongoDB TTL index on the `verifications` collection (unlike `organizationInvites`, which does have one). If enforcement of expired codes is ever desired, a TTL index or an application-level filter in `UserVerificationCode` would be needed — that is a separate issue.