### PR TITLE
test(internal): add BenchmarkHashPassword benchmark

### DIFF
--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -312,3 +312,12 @@ func TestDecryptTokenFromHexErrors(t *testing.T) {
 		c.Assert(err.Error(), quicktest.Contains, "failed to decrypt token")
 	})
 }
+
+func BenchmarkHashPassword(b *testing.B) {
+	salt := "1234567890abcdef"                     // 16 bytes
+	password := "abcdefghijklmnopqrstuvwxyz123456" // 32 chars
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		HashPassword(salt, password)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a single Go benchmark `BenchmarkHashPassword` to `internal/utils_test.go` to measure the performance of the argon2-based password hashing function.

## Linked issue

Closes #487

## Changes

- `internal/utils_test.go`: appended `BenchmarkHashPassword(b *testing.B)` — uses a 16-byte salt and 32-character password, calls `b.ResetTimer()` before the loop.

## Tests run

```
$ go test -v -timeout=60s ./internal/...
...
PASS
ok  	github.com/vocdoni/saas-backend/internal	0.415s

$ go test -bench=BenchmarkHashPassword -benchmem ./internal/...
goos: linux
goarch: amd64
pkg: github.com/vocdoni/saas-backend/internal
cpu: AMD Ryzen 9 9950X3D 16-Core Processor
BenchmarkHashPassword-8   	      73	  16500663 ns/op	67122505 B/op	     166 allocs/op
PASS
ok  	github.com/vocdoni/saas-backend/internal	2.589s
```

The ~16.5 ms/op and ~64 MB/op figures are expected: `argon2.IDKey` is configured with `memory=64 MiB`, `time=4`, `threads=8`.

## Risks and review focus

None — purely additive change to a test file; no production code touched.

## Notes for maintainers

Running the benchmark in CI with the default `-benchtime` will take several seconds per iteration due to argon2 parameters. Consider passing `-benchtime=1x` in CI if you add benchmark runs there to keep it fast.