### PR TITLE
feat(api): adds endpoint to search based on memberInfo weather orgMembers belong in the election and have voted

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -264,6 +264,7 @@ func (a *API) initRouter() http.Handler {
 		handle(r, http.MethodDelete, processEndpoint, a.deleteProcessHandler)
 		handle(r, http.MethodPost, processBundleEndpoint, a.createProcessBundleHandler)
 		handle(r, http.MethodPut, processBundleUpdateEndpoint, a.updateProcessBundleHandler)
+		handle(r, http.MethodPost, processBundleParticipantsCheckEndpoint, a.checkProcessBundleVotedParticipantsHandler)
 	})
 
 	// Public routes

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -1110,6 +1110,43 @@ type CreateProcessBundleResponse struct {
 	Root internal.HexBytes `json:"root" swaggertype:"string" format:"hex" example:"deadbeef"`
 }
 
+// CheckBundleParticipantsRequest is the payload for the bundle participant
+// membership check endpoint. fieldName must be one of: "email", "phone",
+// "memberNumber", "nationalId". value is the raw value to look up — for
+// "phone" the caller passes the plaintext number and the backend hashes it
+// server-side before the lookup. processID is the hex ID of the process whose
+// voting status is reported in the response (hasVoted is true when the member
+// has consumed that process).
+// swagger:model CheckBundleParticipantsRequest
+type CheckBundleParticipantsRequest struct {
+	FieldName string            `json:"fieldName"`
+	Value     string            `json:"value"`
+	ProcessID internal.HexBytes `json:"processID" swaggertype:"string" format:"hex" example:"deadbeef"`
+}
+
+// CheckBundleParticipantsResponseEntry describes a single org member that
+// matched the lookup and is a participant of the bundle's census. HasVoted is
+// true when the member has a used CSP process for the request's processID
+// (i.e. has consumed the process to cast a ballot).
+// swagger:model CheckBundleParticipantsResponseEntry
+type CheckBundleParticipantsResponseEntry struct {
+	MemberID     string `json:"memberId"`
+	Name         string `json:"name,omitempty"`
+	Surname      string `json:"surname,omitempty"`
+	Email        string `json:"email,omitempty"`
+	MemberNumber string `json:"memberNumber,omitempty"`
+	HasVoted     bool   `json:"hasVoted"`
+}
+
+// CheckBundleParticipantsResponse is the response for the bundle participant
+// membership check endpoint. The participants slice contains only members that
+// match the lookup AND are participants of the bundle's census. An empty
+// slice means no match.
+// swagger:model CheckBundleParticipantsResponse
+type CheckBundleParticipantsResponse struct {
+	Participants []CheckBundleParticipantsResponseEntry `json:"participants"`
+}
+
 // OAuthLoginRequest defines the payload for register/login through the OAuth service.
 // swagger:model OAuthLoginRequest
 type OAuthLoginRequest struct {

--- a/api/org_members_delete_all_test.go
+++ b/api/org_members_delete_all_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/vocdoni/saas-backend/api/apicommon"
 )
 
+// TestDeleteAllOrganizationMembers tests the endpoint for deleting all members from an organization.
 func TestDeleteAllOrganizationMembers(t *testing.T) {
 	c := qt.New(t)
 

--- a/api/process_bundles.go
+++ b/api/process_bundles.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/hex"
 	"encoding/json"
+	stderrors "errors"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -361,4 +362,159 @@ func (a *API) processBundleParticipantInfoHandler(w http.ResponseWriter, r *http
 	*/
 
 	apicommon.HTTPWriteJSON(w, nil)
+}
+
+// checkProcessBundleVotedParticipantsHandler godoc
+//
+//	@Summary		Check whether an org member belongs to a bundle's census and have voted
+//	@Description	Look up org members by one of the allowed identification fields
+//	@Description	(email, phone, memberNumber, nationalId, name, surname) and return
+//	@Description	The request must also include the processID
+//	@Description	hasVoted is true when the member has used (consumed) that process to
+//	@Description	cast a ballot. Requires Manager/Admin role on the bundle's organization.
+//	@Tags			process
+//	@Accept			json
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			bundleId	path		string										true	"Bundle ID"
+//	@Param			request		body		apicommon.CheckBundleParticipantsRequest	true	"Lookup request"
+//	@Success		200			{object}	apicommon.CheckBundleParticipantsResponse
+//	@Failure		400			{object}	errors.Error	"Invalid input"
+//	@Failure		401			{object}	errors.Error	"Unauthorized"
+//	@Failure		403			{object}	errors.Error	"Forbidden"
+//	@Failure		404			{object}	errors.Error	"Bundle not found"
+//	@Failure		500			{object}	errors.Error	"Internal server error"
+//	@Router			/process/bundle/{bundleId}/participants/check [post]
+func (a *API) checkProcessBundleVotedParticipantsHandler(w http.ResponseWriter, r *http.Request) {
+	bundleIDStr := chi.URLParam(r, "bundleId")
+	if bundleIDStr == "" {
+		errors.ErrMalformedURLParam.Withf("missing bundle ID").Write(w)
+		return
+	}
+	var bundleID internal.HexBytes
+	if err := bundleID.ParseString(bundleIDStr); err != nil {
+		errors.ErrMalformedURLParam.Withf("invalid bundle ID").Write(w)
+		return
+	}
+
+	var req apicommon.CheckBundleParticipantsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		errors.ErrMalformedBody.Write(w)
+		return
+	}
+	field := db.OrgMemberLookupField(req.FieldName)
+	if !field.IsValid() {
+		errors.ErrMalformedBody.Withf(
+			"invalid fieldName: must be one of email, phone, memberNumber, nationalId",
+		).Write(w)
+		return
+	}
+	if req.Value == "" {
+		errors.ErrMalformedBody.Withf("missing value").Write(w)
+		return
+	}
+	if len(req.ProcessID) == 0 {
+		errors.ErrMalformedBody.Withf("missing processID").Write(w)
+		return
+	}
+
+	bundle, err := a.db.ProcessBundle(bundleID)
+	if err != nil {
+		if stderrors.Is(err, db.ErrNotFound) {
+			errors.ErrBundleNotFound.Write(w)
+			return
+		}
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+
+	user, ok := apicommon.UserFromContext(r.Context())
+	if !ok {
+		errors.ErrUnauthorized.Write(w)
+		return
+	}
+	if !user.HasRoleFor(bundle.OrgAddress, db.ManagerRole) &&
+		!user.HasRoleFor(bundle.OrgAddress, db.AdminRole) {
+		errors.ErrForbidden.Withf("user is not admin or manager of organization").Write(w)
+		return
+	}
+
+	// Build the lookup value. Phone is hashed server-side because OrgMember.Phone
+	// is stored as a HashedPhone.
+	var lookupValue any = req.Value
+	if field == db.OrgMemberLookupFieldPhone {
+		org, err := a.db.Organization(bundle.OrgAddress)
+		if err != nil {
+			errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+			return
+		}
+		hashed, err := db.NewHashedPhone(req.Value, org)
+		if err != nil {
+			errors.ErrMalformedBody.Withf("invalid phone: %v", err).Write(w)
+			return
+		}
+		if hashed.IsEmpty() {
+			errors.ErrMalformedBody.Withf("invalid phone").Write(w)
+			return
+		}
+		lookupValue = hashed
+	}
+
+	members, err := a.db.OrgMembersByField(bundle.OrgAddress, field, lookupValue)
+	if err != nil {
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+	if len(members) == 0 {
+		apicommon.HTTPWriteJSON(w, apicommon.CheckBundleParticipantsResponse{
+			Participants: []apicommon.CheckBundleParticipantsResponseEntry{},
+		})
+		return
+	}
+
+	memberIDs := make([]string, 0, len(members))
+	membersByID := make(map[string]*db.OrgMember, len(members))
+	for _, m := range members {
+		id := m.ID.Hex()
+		memberIDs = append(memberIDs, id)
+		membersByID[id] = m
+	}
+
+	censusID := bundle.Census.ID.Hex()
+	participants, err := a.db.CensusParticipantsByMemberIDs(censusID, memberIDs)
+	if err != nil {
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+
+	// Look up vote status for the requested process. A used CSP process for a
+	// member indicates they have consumed the process to cast a ballot.
+	// participantIDs are the member IDs that are included in the census.
+	participantIDs := make([]string, 0, len(participants))
+	for _, p := range participants {
+		participantIDs = append(participantIDs, p.ParticipantID)
+	}
+	votedSet, err := a.db.MembersWithUsedCSPProcess(req.ProcessID, participantIDs)
+	if err != nil {
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+
+	entries := make([]apicommon.CheckBundleParticipantsResponseEntry, 0, len(participants))
+	for _, p := range participants {
+		m, ok := membersByID[p.ParticipantID]
+		if !ok {
+			continue
+		}
+		entries = append(entries, apicommon.CheckBundleParticipantsResponseEntry{
+			MemberID:     m.ID.Hex(),
+			Name:         m.Name,
+			Surname:      m.Surname,
+			Email:        m.Email,
+			MemberNumber: m.MemberNumber,
+			HasVoted:     votedSet[m.ID.Hex()],
+		})
+	}
+
+	apicommon.HTTPWriteJSON(w, apicommon.CheckBundleParticipantsResponse{Participants: entries})
 }

--- a/api/process_bundles_test.go
+++ b/api/process_bundles_test.go
@@ -1,0 +1,267 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/api/apicommon"
+	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/internal"
+	"go.vocdoni.io/dvote/util"
+)
+
+// TestCheckProcessBundleParticipants exercises
+// POST /process/bundle/{bundleId}/participants/check.
+//
+// Setup:
+//   - Admin user creates an org and a census.
+//   - Three org members are added:
+//     Alice  — email "shared@x.com", phone "+34611111111", memberNumber "P001",
+//     nationalId "DNI001"
+//     Bob    — email "bob@x.com",    phone "+34622222222", memberNumber "P002"
+//     Carol  — email "shared@x.com" (duplicate with Alice), phone "+34633333333"
+//   - Alice and Bob are added to the census (and so become bundle participants);
+//     Carol is intentionally NOT added.
+//   - A bundle is created directly via testDB to avoid the full vocdoni setup
+//     path; the handler only needs the bundle row + the census it references.
+//   - A verified CSP auth token is seeded for Alice to assert hasVoted=true.
+//
+// The endpoint must return ONLY members who are participants of the bundle's
+// census. So a lookup by "shared@x.com" returns Alice but not Carol (Carol
+// matches the org-member query but is not in the census).
+func TestCheckProcessBundleParticipants(t *testing.T) {
+	c := qt.New(t)
+
+	adminToken := testCreateUser(t, "checkbundlepass123")
+	orgAddress := testCreateOrganization(t, adminToken)
+
+	// Keep the same census setup used in other stable API tests.
+	censusID := postCensus(t, adminToken, orgAddress,
+		db.OrgMemberAuthFields{db.OrgMemberAuthFieldsMemberNumber},
+		db.OrgMemberTwoFaFields{db.OrgMemberTwoFaFieldEmail})
+
+	// Build three members; Carol shares Alice's email to test multi-match.
+	memberA := apicommon.OrgMember{
+		MemberNumber: "P001",
+		Name:         "Alice",
+		Surname:      "Alpha",
+		Email:        "shared@x.com",
+		Phone:        "+34611111111",
+		NationalID:   "DNI001",
+		Password:     "pwA",
+	}
+	memberB := apicommon.OrgMember{
+		MemberNumber: "P002",
+		Name:         "Bob",
+		Surname:      "Beta",
+		Email:        "bob@x.com",
+		Phone:        "+34622222222",
+		NationalID:   "DNI002",
+		Password:     "pwB",
+	}
+	memberC := apicommon.OrgMember{
+		MemberNumber: "P003",
+		Name:         "Carol",
+		Surname:      "Gamma",
+		Email:        "shared@x.com", // duplicate of Alice
+		Phone:        "+34633333333",
+		NationalID:   "DNI003",
+		Password:     "pwC",
+	}
+
+	posted := postOrgMembers(t, adminToken, orgAddress, memberA, memberB, memberC)
+	c.Assert(posted, qt.HasLen, 3)
+
+	// Alice and Carol share an email; identify them by member number instead.
+	idByNumber := map[string]string{}
+	for _, m := range posted {
+		idByNumber[m.MemberNumber] = m.ID
+	}
+	aliceID := idByNumber["P001"]
+	bobID := idByNumber["P002"]
+	carolID := idByNumber["P003"]
+	c.Assert(aliceID, qt.Not(qt.Equals), "")
+	c.Assert(bobID, qt.Not(qt.Equals), "")
+	c.Assert(carolID, qt.Not(qt.Equals), "")
+
+	// Add Alice and Bob to the census. Carol stays out.
+	postCensusParticipants(t, adminToken, censusID, aliceID, bobID)
+
+	// Create the bundle directly via testDB — the handler under test only needs
+	// the bundle row plus its referenced census.
+	census, err := testDB.Census(censusID)
+	c.Assert(err, qt.IsNil)
+	bundleObjID := testDB.NewBundleID()
+	_, err = testDB.SetProcessBundle(&db.ProcessesBundle{
+		ID:         bundleObjID,
+		OrgAddress: orgAddress,
+		Census:     *census,
+	})
+	c.Assert(err, qt.IsNil)
+	bundleID := bundleObjID.Hex()
+
+	// processID whose voting status the endpoint reports. It does not need to be
+	// a real on-chain process for these tests; the handler only uses it to look
+	// up per-member CSP process status.
+	processID := internal.HexBytes(util.RandomBytes(32))
+
+	// Helper for the canonical successful call path.
+	checkPath := []string{"process", "bundle", bundleID, "participants", "check"}
+
+	t.Run("lookup by email returns only members in the bundle", func(_ *testing.T) {
+		resp := requestAndParse[apicommon.CheckBundleParticipantsResponse](
+			t, http.MethodPost, adminToken,
+			apicommon.CheckBundleParticipantsRequest{FieldName: "email", Value: "shared@x.com", ProcessID: processID},
+			checkPath...,
+		)
+		// Alice matches AND is in the bundle. Carol matches by email but is not.
+		c.Assert(resp.Participants, qt.HasLen, 1)
+		c.Assert(resp.Participants[0].MemberID, qt.Equals, aliceID)
+		c.Assert(resp.Participants[0].Email, qt.Equals, "shared@x.com")
+		c.Assert(resp.Participants[0].MemberNumber, qt.Equals, "P001")
+		c.Assert(resp.Participants[0].HasVoted, qt.IsFalse)
+	})
+
+	t.Run("lookup by memberNumber returns the matching participant", func(_ *testing.T) {
+		resp := requestAndParse[apicommon.CheckBundleParticipantsResponse](
+			t, http.MethodPost, adminToken,
+			apicommon.CheckBundleParticipantsRequest{FieldName: "memberNumber", Value: "P002", ProcessID: processID},
+			checkPath...,
+		)
+		c.Assert(resp.Participants, qt.HasLen, 1)
+		c.Assert(resp.Participants[0].MemberID, qt.Equals, bobID)
+		c.Assert(resp.Participants[0].MemberNumber, qt.Equals, "P002")
+	})
+
+	t.Run("lookup by nationalId returns the matching participant", func(_ *testing.T) {
+		resp := requestAndParse[apicommon.CheckBundleParticipantsResponse](
+			t, http.MethodPost, adminToken,
+			apicommon.CheckBundleParticipantsRequest{FieldName: "nationalId", Value: "DNI001", ProcessID: processID},
+			checkPath...,
+		)
+		c.Assert(resp.Participants, qt.HasLen, 1)
+		c.Assert(resp.Participants[0].MemberID, qt.Equals, aliceID)
+	})
+
+	t.Run("lookup by phone hashes plaintext server-side", func(_ *testing.T) {
+		resp := requestAndParse[apicommon.CheckBundleParticipantsResponse](
+			t, http.MethodPost, adminToken,
+			apicommon.CheckBundleParticipantsRequest{FieldName: "phone", Value: "+34611111111", ProcessID: processID},
+			checkPath...,
+		)
+		c.Assert(resp.Participants, qt.HasLen, 1)
+		c.Assert(resp.Participants[0].MemberID, qt.Equals, aliceID)
+	})
+
+	t.Run("lookup with no match returns empty array", func(_ *testing.T) {
+		resp := requestAndParse[apicommon.CheckBundleParticipantsResponse](
+			t, http.MethodPost, adminToken,
+			apicommon.CheckBundleParticipantsRequest{FieldName: "email", Value: "missing@x.com", ProcessID: processID},
+			checkPath...,
+		)
+		c.Assert(resp.Participants, qt.HasLen, 0)
+	})
+
+	t.Run("member exists but is not in the bundle returns empty", func(_ *testing.T) {
+		// Carol matches the org-member query (her email is "shared@x.com" and
+		// her memberNumber is unique) but she was not added to the census.
+		resp := requestAndParse[apicommon.CheckBundleParticipantsResponse](
+			t, http.MethodPost, adminToken,
+			apicommon.CheckBundleParticipantsRequest{FieldName: "memberNumber", Value: "P003", ProcessID: processID},
+			checkPath...,
+		)
+		c.Assert(resp.Participants, qt.HasLen, 0)
+	})
+
+	t.Run("invalid fieldName returns 400", func(_ *testing.T) {
+		requestAndAssertCode(http.StatusBadRequest, t, http.MethodPost, adminToken,
+			apicommon.CheckBundleParticipantsRequest{FieldName: "invalid-field", Value: "Alice"},
+			checkPath...,
+		)
+	})
+
+	t.Run("empty value returns 400", func(_ *testing.T) {
+		requestAndAssertCode(http.StatusBadRequest, t, http.MethodPost, adminToken,
+			apicommon.CheckBundleParticipantsRequest{FieldName: "email", Value: ""},
+			checkPath...,
+		)
+	})
+
+	t.Run("malformed body returns 400", func(_ *testing.T) {
+		// Send a string instead of an object.
+		requestAndAssertCode(http.StatusBadRequest, t, http.MethodPost, adminToken,
+			"not-a-json-object", checkPath...,
+		)
+	})
+
+	t.Run("invalid bundleId returns 400", func(_ *testing.T) {
+		requestAndAssertCode(http.StatusBadRequest, t, http.MethodPost, adminToken,
+			apicommon.CheckBundleParticipantsRequest{FieldName: "email", Value: "shared@x.com"},
+			"process", "bundle", "not-hex", "participants", "check",
+		)
+	})
+
+	t.Run("unknown bundle returns 404", func(_ *testing.T) {
+		// Valid hex shape but not a stored bundle ID.
+		missing := internal.HexBytes(util.RandomBytes(12)).String()
+		requestAndAssertCode(http.StatusNotFound, t, http.MethodPost, adminToken,
+			apicommon.CheckBundleParticipantsRequest{FieldName: "email", Value: "shared@x.com", ProcessID: processID},
+			"process", "bundle", missing, "participants", "check",
+		)
+	})
+
+	t.Run("missing auth token returns 401", func(_ *testing.T) {
+		requestAndAssertCode(http.StatusUnauthorized, t, http.MethodPost, "",
+			apicommon.CheckBundleParticipantsRequest{FieldName: "email", Value: "shared@x.com", ProcessID: processID},
+			checkPath...,
+		)
+	})
+
+	t.Run("authenticated caller without manager role returns 403", func(_ *testing.T) {
+		otherUserToken := testCreateUser(t, "checkbundlepass456")
+		requestAndAssertCode(http.StatusForbidden, t, http.MethodPost, otherUserToken,
+			apicommon.CheckBundleParticipantsRequest{FieldName: "email", Value: "shared@x.com", ProcessID: processID},
+			checkPath...,
+		)
+	})
+
+	t.Run("missing processID returns 400", func(_ *testing.T) {
+		requestAndAssertCode(http.StatusBadRequest, t, http.MethodPost, adminToken,
+			apicommon.CheckBundleParticipantsRequest{FieldName: "email", Value: "shared@x.com"},
+			checkPath...,
+		)
+	})
+
+	t.Run("hasVoted is true when the member has used the process", func(_ *testing.T) {
+		// Seed a verified CSP auth token for Alice in this bundle and consume the
+		// process with it, so Alice has a used CSP process for processID.
+		bundleIDBytes := internal.HexBytes{}
+		c.Assert(bundleIDBytes.ParseString(bundleID), qt.IsNil)
+		userID := internal.HexBytesFromString(aliceID)
+		token := internal.HexBytes(util.RandomBytes(32))
+		address := internal.HexBytes(util.RandomBytes(20))
+
+		c.Assert(testDB.SetCSPAuth(token, userID, bundleIDBytes), qt.IsNil)
+		c.Assert(testDB.VerifyCSPAuth(token), qt.IsNil)
+		c.Assert(testDB.ConsumeCSPProcess(token, processID, address), qt.IsNil)
+
+		resp := requestAndParse[apicommon.CheckBundleParticipantsResponse](
+			t, http.MethodPost, adminToken,
+			apicommon.CheckBundleParticipantsRequest{FieldName: "memberNumber", Value: "P001", ProcessID: processID},
+			checkPath...,
+		)
+		c.Assert(resp.Participants, qt.HasLen, 1)
+		c.Assert(resp.Participants[0].MemberID, qt.Equals, aliceID)
+		c.Assert(resp.Participants[0].HasVoted, qt.IsTrue)
+
+		// Bob has not consumed the process → hasVoted=false.
+		respBob := requestAndParse[apicommon.CheckBundleParticipantsResponse](
+			t, http.MethodPost, adminToken,
+			apicommon.CheckBundleParticipantsRequest{FieldName: "memberNumber", Value: "P002", ProcessID: processID},
+			checkPath...,
+		)
+		c.Assert(respBob.Participants, qt.HasLen, 1)
+		c.Assert(respBob.Participants[0].HasVoted, qt.IsFalse)
+	})
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -160,6 +160,9 @@ const (
 	processBundleSignEndpoint = "/process/bundle/{bundleId}/sign"
 	// GET /process/bundle/{bundleId}/{participantId} to get the process information
 	processBundleMemberEndpoint = "/process/bundle/{bundleId}/{participantId}"
+	// POST /process/bundle/{bundleId}/participants/check to check whether an org member is a
+	// participant of the bundle's census. Manager/Admin only.
+	processBundleParticipantsCheckEndpoint = "/process/bundle/{bundleId}/participants/check"
 
 	// // census auth routes (currently not implemented)
 	// // POST /process/{processId}/auth/0 to initiate auth

--- a/db/census_participant.go
+++ b/db/census_participant.go
@@ -720,6 +720,45 @@ func (ms *MongoStorage) CensusParticipants(censusID string) ([]CensusParticipant
 	return participants, nil
 }
 
+// CensusParticipantsByMemberIDs retrieves all census participants of the given
+// census whose participantID matches one of the provided memberIDs. Returns an
+// empty slice (not an error) when there is no match.
+func (ms *MongoStorage) CensusParticipantsByMemberIDs(
+	censusID string,
+	memberIDs []string,
+) ([]CensusParticipant, error) {
+	if len(censusID) == 0 {
+		return nil, ErrInvalidData
+	}
+	if len(memberIDs) == 0 {
+		return nil, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	filter := bson.M{
+		"censusId":      censusID,
+		"participantID": bson.M{"$in": memberIDs},
+	}
+
+	cursor, err := ms.censusParticipants.Find(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query census participants by member IDs: %w", err)
+	}
+	defer func() {
+		if err := cursor.Close(ctx); err != nil {
+			log.Warnw("error closing cursor", "error", err)
+		}
+	}()
+
+	var participants []CensusParticipant
+	if err := cursor.All(ctx, &participants); err != nil {
+		return nil, fmt.Errorf("failed to decode census participants: %w", err)
+	}
+	return participants, nil
+}
+
 func calculateParticipantHashesBson(census Census, member OrgMember) bson.M {
 	hashes := bson.M{}
 	hashes["loginHash"] = HashAuthTwoFaFields(member, census.AuthFields, census.TwoFaFields)

--- a/db/census_participant_test.go
+++ b/db/census_participant_test.go
@@ -657,6 +657,143 @@ func TestCensusParticipant(t *testing.T) {
 	})
 }
 
+type censusParticipantsByMemberIDsFixture struct {
+	alice   *OrgMember
+	bob     *OrgMember
+	carol   *OrgMember
+	censusA *Census
+	censusB *Census
+}
+
+func setupCensusParticipantsByMemberIDsFixtureForTrackedTests(t *testing.T) *censusParticipantsByMemberIDsFixture {
+	t.Helper()
+	c := qt.New(t)
+
+	org := &Organization{
+		Address:   testOrgAddress,
+		Active:    true,
+		CreatedAt: time.Now(),
+	}
+	c.Assert(testDB.SetOrganization(org), qt.IsNil)
+
+	mkMember := func(memberNumber, email string) *OrgMember {
+		member := &OrgMember{
+			ID:           primitive.NewObjectID(),
+			OrgAddress:   testOrgAddress,
+			MemberNumber: memberNumber,
+			Email:        email,
+			CreatedAt:    time.Now(),
+			UpdatedAt:    time.Now(),
+		}
+		_, err := testDB.SetOrgMember(testSalt, member)
+		c.Assert(err, qt.IsNil)
+		return member
+	}
+
+	alice := mkMember("tracked-alice", "tracked-alice@example.com")
+	bob := mkMember("tracked-bob", "tracked-bob@example.com")
+	carol := mkMember("tracked-carol", "tracked-carol@example.com")
+
+	censusA := &Census{
+		OrgAddress: testOrgAddress,
+		CreatedAt:  time.Now(),
+	}
+	censusAID, err := testDB.SetCensus(censusA)
+	c.Assert(err, qt.IsNil)
+	censusAObjID, err := primitive.ObjectIDFromHex(censusAID)
+	c.Assert(err, qt.IsNil)
+	censusA.ID = censusAObjID
+
+	censusB := &Census{
+		OrgAddress: testOrgAddress,
+		CreatedAt:  time.Now(),
+	}
+	censusBID, err := testDB.SetCensus(censusB)
+	c.Assert(err, qt.IsNil)
+	censusBObjID, err := primitive.ObjectIDFromHex(censusBID)
+	c.Assert(err, qt.IsNil)
+	censusB.ID = censusBObjID
+
+	c.Assert(testDB.SetCensusParticipant(&CensusParticipant{
+		ParticipantID: alice.ID.Hex(),
+		CensusID:      censusA.ID.Hex(),
+		CreatedAt:     time.Now(),
+	}), qt.IsNil)
+	c.Assert(testDB.SetCensusParticipant(&CensusParticipant{
+		ParticipantID: bob.ID.Hex(),
+		CensusID:      censusA.ID.Hex(),
+		CreatedAt:     time.Now(),
+	}), qt.IsNil)
+	c.Assert(testDB.SetCensusParticipant(&CensusParticipant{
+		ParticipantID: alice.ID.Hex(),
+		CensusID:      censusB.ID.Hex(),
+		CreatedAt:     time.Now(),
+	}), qt.IsNil)
+
+	return &censusParticipantsByMemberIDsFixture{
+		alice:   alice,
+		bob:     bob,
+		carol:   carol,
+		censusA: censusA,
+		censusB: censusB,
+	}
+}
+
+func TestCensusParticipantsByMemberIDsTrackedSuite(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	t.Run("empty census ID is rejected", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		fixture := setupCensusParticipantsByMemberIDsFixtureForTrackedTests(t)
+
+		_, err := testDB.CensusParticipantsByMemberIDs("", []string{fixture.alice.ID.Hex()})
+		c.Assert(err, qt.Equals, ErrInvalidData)
+	})
+
+	t.Run("empty member IDs returns an empty slice without error", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		fixture := setupCensusParticipantsByMemberIDsFixtureForTrackedTests(t)
+
+		got, err := testDB.CensusParticipantsByMemberIDs(fixture.censusA.ID.Hex(), nil)
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 0)
+	})
+
+	t.Run("returns only participants that belong to the requested census", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		fixture := setupCensusParticipantsByMemberIDsFixtureForTrackedTests(t)
+
+		got, err := testDB.CensusParticipantsByMemberIDs(
+			fixture.censusA.ID.Hex(),
+			[]string{fixture.alice.ID.Hex(), fixture.bob.ID.Hex(), fixture.carol.ID.Hex()},
+		)
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 2)
+
+		gotIDs := map[string]bool{}
+		for _, participant := range got {
+			gotIDs[participant.ParticipantID] = true
+		}
+		c.Assert(gotIDs[fixture.alice.ID.Hex()], qt.IsTrue)
+		c.Assert(gotIDs[fixture.bob.ID.Hex()], qt.IsTrue)
+		c.Assert(gotIDs[fixture.carol.ID.Hex()], qt.IsFalse)
+	})
+
+	t.Run("results stay scoped to the requested census ID", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		fixture := setupCensusParticipantsByMemberIDsFixtureForTrackedTests(t)
+
+		got, err := testDB.CensusParticipantsByMemberIDs(
+			fixture.censusB.ID.Hex(),
+			[]string{fixture.alice.ID.Hex(), fixture.bob.ID.Hex()},
+		)
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].ParticipantID, qt.Equals, fixture.alice.ID.Hex())
+	})
+}
+
 // TestCreateCensusParticipantBulkOperationsFiltering specifically tests the filtering functionality
 // in the createCensusParticipantBulkOperations function, focusing on ensuring
 // that "participantID": orgMember.ID.Hex() works correctly for upserts

--- a/db/csp.go
+++ b/db/csp.go
@@ -368,3 +368,37 @@ func (ms *MongoStorage) GetOrgMembersByProcess(orgAddress common.Address, proces
 	}
 	return orgMembers, nil
 }
+
+// MembersWithUsedCSPProcess returns the subset of the given memberIDs (each the
+// hex of an OrgMember ObjectID) that have already cast a ballot in the given
+// process. The returned map is keyed by the memberID hex string and only
+// contains entries set to true; members without a CSP process for the given
+// process, or with one that has not been used, are simply absent from the map.
+//
+// A member is considered to have voted when a CSPProcess exists for
+// (memberID, processID) and its Used field is true — i.e. the member consumed
+// the process to cast a ballot.
+func (ms *MongoStorage) MembersWithUsedCSPProcess(
+	processID internal.HexBytes,
+	memberIDs []string,
+) (map[string]bool, error) {
+	if processID == nil {
+		return nil, ErrBadInputs
+	}
+
+	result := make(map[string]bool, len(memberIDs))
+	for _, id := range memberIDs {
+		userID := internal.HexBytesFromString(id)
+		proc, err := ms.CSPProcessByUserAndProcess(userID, processID)
+		if err != nil {
+			if errors.Is(err, ErrTokenNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to query CSP process status: %w", err)
+		}
+		if proc.Used {
+			result[id] = true
+		}
+	}
+	return result, nil
+}

--- a/db/org_members.go
+++ b/db/org_members.go
@@ -796,3 +796,105 @@ func (ms *MongoStorage) orgMembersByIDs(
 
 	return paginatedDocuments[*OrgMember](ms.orgMembers, page, limit, filter, options.Find())
 }
+
+// OrgMemberLookupField identifies an OrgMember column that can be used as a
+// unique-ish lookup key. Only the values declared as constants below are valid;
+// any other value should be rejected by callers before reaching the DB layer.
+type OrgMemberLookupField string
+
+const (
+	OrgMemberLookupFieldEmail        OrgMemberLookupField = "email"
+	OrgMemberLookupFieldPhone        OrgMemberLookupField = "phone"
+	OrgMemberLookupFieldMemberNumber OrgMemberLookupField = "memberNumber"
+	OrgMemberLookupFieldNationalID   OrgMemberLookupField = "nationalId"
+	OrgMemberLookupFieldName         OrgMemberLookupField = "name"
+	OrgMemberLookupFieldSurname      OrgMemberLookupField = "surname"
+)
+
+// IsValid reports whether the field is one of the supported lookup fields.
+func (f OrgMemberLookupField) IsValid() bool {
+	switch f {
+	case OrgMemberLookupFieldEmail,
+		OrgMemberLookupFieldPhone,
+		OrgMemberLookupFieldMemberNumber,
+		OrgMemberLookupFieldNationalID,
+		OrgMemberLookupFieldName,
+		OrgMemberLookupFieldSurname:
+		return true
+	}
+	return false
+}
+
+// bsonField returns the BSON field name corresponding to the lookup field.
+func (f OrgMemberLookupField) bsonField() string {
+	switch f {
+	case OrgMemberLookupFieldEmail:
+		return "email"
+	case OrgMemberLookupFieldPhone:
+		return "phone"
+	case OrgMemberLookupFieldMemberNumber:
+		return "memberNumber"
+	case OrgMemberLookupFieldNationalID:
+		return "nationalId"
+	case OrgMemberLookupFieldName:
+		return "name"
+	case OrgMemberLookupFieldSurname:
+		return "surname"
+	}
+	return ""
+}
+
+// OrgMembersByField retrieves all organization members for the given org whose
+// `field` column equals `value`. The field must be one of the OrgMemberLookupField
+// constants — invalid fields return ErrInvalidData.
+//
+// For OrgMemberLookupFieldPhone, the caller must pass an already-hashed value
+// (HashedPhone bytes); for the other fields the value is matched verbatim as a
+// string. Returns an empty slice (not an error) when there is no match.
+func (ms *MongoStorage) OrgMembersByField(
+	orgAddress common.Address,
+	field OrgMemberLookupField,
+	value any,
+) ([]*OrgMember, error) {
+	if !field.IsValid() {
+		return nil, ErrInvalidData
+	}
+	switch v := value.(type) {
+	case string:
+		if v == "" {
+			return nil, ErrInvalidData
+		}
+	case HashedPhone:
+		if v.IsEmpty() {
+			return nil, ErrInvalidData
+		}
+	case []byte:
+		if len(v) == 0 {
+			return nil, ErrInvalidData
+		}
+	case nil:
+		return nil, ErrInvalidData
+	default:
+		return nil, ErrInvalidData
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	filter := bson.M{
+		"orgAddress":      orgAddress,
+		field.bsonField(): value,
+	}
+
+	cur, err := ms.orgMembers.Find(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query org members by %s: %w", field, err)
+	}
+	defer func() { _ = cur.Close(ctx) }()
+
+	var members []*OrgMember
+	if err := cur.All(ctx, &members); err != nil {
+		return nil, fmt.Errorf("failed to decode org members by %s: %w", field, err)
+	}
+	return members, nil
+}

--- a/db/org_members_test.go
+++ b/db/org_members_test.go
@@ -299,3 +299,127 @@ func TestOrgMembers(t *testing.T) {
 		c.Assert(err, qt.Equals, ErrInvalidData)
 	})
 }
+
+type orgMembersByFieldFixture struct {
+	org   *Organization
+	alice *OrgMember
+	bob   *OrgMember
+	carol *OrgMember
+	other *OrgMember
+}
+
+func setupOrgMembersByFieldFixtureForTrackedTests(t *testing.T) *orgMembersByFieldFixture {
+	t.Helper()
+	c := qt.New(t)
+
+	org := &Organization{
+		Address: testOrgAddress,
+		Country: "ES",
+	}
+	otherOrg := &Organization{
+		Address: testAnotherOrgAddress,
+		Country: "ES",
+	}
+	c.Assert(testDB.SetOrganization(org), qt.IsNil)
+	c.Assert(testDB.SetOrganization(otherOrg), qt.IsNil)
+
+	mkMember := func(orgAddress common.Address, memberNumber, email, phone, nationalID string) *OrgMember {
+		member := &OrgMember{
+			OrgAddress:     orgAddress,
+			MemberNumber:   memberNumber,
+			Email:          email,
+			PlaintextPhone: phone,
+			NationalID:     nationalID,
+			Name:           memberNumber,
+		}
+		memberID, err := testDB.SetOrgMember(testSalt, member)
+		c.Assert(err, qt.IsNil)
+
+		stored, err := testDB.OrgMember(orgAddress, memberID)
+		c.Assert(err, qt.IsNil)
+		return stored
+	}
+
+	alice := mkMember(testOrgAddress, "P001", "shared@x.com", "+34611111111", "DNI001")
+	bob := mkMember(testOrgAddress, "P002", "bob@x.com", "+34622222222", "DNI002")
+	carol := mkMember(testOrgAddress, "P003", "shared@x.com", "+34633333333", "DNI003")
+	other := mkMember(testAnotherOrgAddress, "P004", "shared@x.com", "+34611111111", "DNI004")
+
+	return &orgMembersByFieldFixture{
+		org:   org,
+		alice: alice,
+		bob:   bob,
+		carol: carol,
+		other: other,
+	}
+}
+
+func TestOrgMembersByFieldTrackedSuite(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	t.Run("validation rejects invalid field and empty values", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		_ = setupOrgMembersByFieldFixtureForTrackedTests(t)
+
+		_, err := testDB.OrgMembersByField(testOrgAddress, OrgMemberLookupField("invalid-field"), "Alice")
+		c.Assert(err, qt.Equals, ErrInvalidData)
+
+		_, err = testDB.OrgMembersByField(testOrgAddress, OrgMemberLookupFieldEmail, "")
+		c.Assert(err, qt.Equals, ErrInvalidData)
+	})
+
+	t.Run("lookup by email returns all matches within the organization", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		fixture := setupOrgMembersByFieldFixtureForTrackedTests(t)
+
+		got, err := testDB.OrgMembersByField(testOrgAddress, OrgMemberLookupFieldEmail, "shared@x.com")
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 2)
+
+		gotIDs := map[string]bool{}
+		for _, member := range got {
+			gotIDs[member.ID.Hex()] = true
+		}
+		c.Assert(gotIDs[fixture.alice.ID.Hex()], qt.IsTrue)
+		c.Assert(gotIDs[fixture.carol.ID.Hex()], qt.IsTrue)
+	})
+
+	t.Run("lookup by member number and national ID returns the unique match", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		fixture := setupOrgMembersByFieldFixtureForTrackedTests(t)
+
+		gotByNumber, err := testDB.OrgMembersByField(testOrgAddress, OrgMemberLookupFieldMemberNumber, "P002")
+		c.Assert(err, qt.IsNil)
+		c.Assert(gotByNumber, qt.HasLen, 1)
+		c.Assert(gotByNumber[0].ID.Hex(), qt.Equals, fixture.bob.ID.Hex())
+
+		gotByNationalID, err := testDB.OrgMembersByField(testOrgAddress, OrgMemberLookupFieldNationalID, "DNI001")
+		c.Assert(err, qt.IsNil)
+		c.Assert(gotByNationalID, qt.HasLen, 1)
+		c.Assert(gotByNationalID[0].ID.Hex(), qt.Equals, fixture.alice.ID.Hex())
+	})
+
+	t.Run("lookup by phone uses the hashed value and remains org-scoped", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		fixture := setupOrgMembersByFieldFixtureForTrackedTests(t)
+
+		hashedPhone, err := NewHashedPhone("+34611111111", fixture.org)
+		c.Assert(err, qt.IsNil)
+
+		got, err := testDB.OrgMembersByField(testOrgAddress, OrgMemberLookupFieldPhone, hashedPhone)
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].ID.Hex(), qt.Equals, fixture.alice.ID.Hex())
+		c.Assert(got[0].ID.Hex(), qt.Not(qt.Equals), fixture.other.ID.Hex())
+	})
+
+	t.Run("no matches return an empty slice without error", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		_ = setupOrgMembersByFieldFixtureForTrackedTests(t)
+
+		got, err := testDB.OrgMembersByField(testOrgAddress, OrgMemberLookupFieldEmail, "missing@x.com")
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 0)
+	})
+}

--- a/db/process_bundles.go
+++ b/db/process_bundles.go
@@ -3,12 +3,14 @@ package db
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -98,6 +100,9 @@ func (ms *MongoStorage) ProcessBundle(hbBundleID internal.HexBytes) (*ProcessesB
 
 	bundle := &ProcessesBundle{}
 	if err := ms.processBundles.FindOne(ctx, bson.M{"_id": bundleID}).Decode(bundle); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, ErrNotFound
+		}
 		return nil, fmt.Errorf("failed to get process bundle: %w", err)
 	}
 

--- a/db/process_bundles_check_test.go
+++ b/db/process_bundles_check_test.go
@@ -1,0 +1,331 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/internal"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// setupCheckBundleFixture seeds an organization, three org members, a census
+// with two of them as participants, and a process bundle pointing at that
+// census. It is the fixture for all bundle-participants-check helper tests.
+//
+// Members:
+//
+//	Alice (P001, email "shared@x.com",   phone +34611111111, nationalId DNI001) — in census
+//	Bob   (P002, email "bob@x.com",      phone +34622222222, nationalId DNI002) — in census
+//	Carol (P003, email "shared@x.com",   phone +34633333333, nationalId DNI003) — NOT in census
+func setupCheckBundleFixture(t *testing.T) *checkBundleFixture {
+	t.Helper()
+	c := qt.New(t)
+
+	org := &Organization{
+		Address:   testOrgAddress,
+		Country:   "ES",
+		Active:    true,
+		CreatedAt: time.Now(),
+	}
+	c.Assert(testDB.SetOrganization(org), qt.IsNil)
+
+	mkMember := func(num, name, surname, email, phone, nationalID string) *OrgMember {
+		m := &OrgMember{
+			OrgAddress:     testOrgAddress,
+			MemberNumber:   num,
+			Name:           name,
+			Surname:        surname,
+			Email:          email,
+			PlaintextPhone: phone,
+			NationalID:     nationalID,
+		}
+		id, err := testDB.SetOrgMember(testSalt, m)
+		c.Assert(err, qt.IsNil)
+		stored, err := testDB.OrgMember(testOrgAddress, id)
+		c.Assert(err, qt.IsNil)
+		return stored
+	}
+
+	alice := mkMember("P001", "Alice", "Alpha", "shared@x.com", "+34611111111", "DNI001")
+	bob := mkMember("P002", "Bob", "Beta", "bob@x.com", "+34622222222", "DNI002")
+	carol := mkMember("P003", "Carol", "Gamma", "shared@x.com", "+34633333333", "DNI003")
+
+	census := &Census{
+		OrgAddress: testOrgAddress,
+		AuthFields: OrgMemberAuthFields{},
+		CreatedAt:  time.Now(),
+	}
+	censusIDStr, err := testDB.SetCensus(census)
+	c.Assert(err, qt.IsNil)
+	oid, err := primitive.ObjectIDFromHex(censusIDStr)
+	c.Assert(err, qt.IsNil)
+	census.ID = oid
+
+	// Alice and Bob become participants; Carol stays out.
+	for _, m := range []*OrgMember{alice, bob} {
+		c.Assert(testDB.SetCensusParticipant(&CensusParticipant{
+			ParticipantID: m.ID.Hex(),
+			CensusID:      censusIDStr,
+			CreatedAt:     time.Now(),
+		}), qt.IsNil)
+	}
+
+	bundleObjID := testDB.NewBundleID()
+	_, err = testDB.SetProcessBundle(&ProcessesBundle{
+		ID:         bundleObjID,
+		OrgAddress: testOrgAddress,
+		Census:     *census,
+	})
+	c.Assert(err, qt.IsNil)
+	bundleID := internal.HexBytesFromString(bundleObjID.Hex())
+
+	return &checkBundleFixture{
+		org:      org,
+		alice:    alice,
+		bob:      bob,
+		carol:    carol,
+		census:   census,
+		bundleID: bundleID,
+	}
+}
+
+type checkBundleFixture struct {
+	org      *Organization
+	alice    *OrgMember
+	bob      *OrgMember
+	carol    *OrgMember
+	census   *Census
+	bundleID internal.HexBytes
+}
+
+func TestOrgMembersByField(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	t.Run("invalid field returns ErrInvalidData", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		_ = setupCheckBundleFixture(t)
+
+		_, err := testDB.OrgMembersByField(testOrgAddress, OrgMemberLookupField("invalid-field"), "Alice")
+		c.Assert(err, qt.Equals, ErrInvalidData)
+	})
+
+	t.Run("empty value returns ErrInvalidData", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		_ = setupCheckBundleFixture(t)
+
+		_, err := testDB.OrgMembersByField(testOrgAddress, OrgMemberLookupFieldEmail, "")
+		c.Assert(err, qt.Equals, ErrInvalidData)
+	})
+
+	t.Run("lookup by email returns every matching member", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		fixture := setupCheckBundleFixture(t)
+
+		got, err := testDB.OrgMembersByField(testOrgAddress, OrgMemberLookupFieldEmail, "shared@x.com")
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 2)
+
+		ids := map[string]bool{}
+		for _, m := range got {
+			ids[m.ID.Hex()] = true
+		}
+		c.Assert(ids[fixture.alice.ID.Hex()], qt.IsTrue)
+		c.Assert(ids[fixture.carol.ID.Hex()], qt.IsTrue)
+	})
+
+	t.Run("lookup by memberNumber returns the unique member", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		fixture := setupCheckBundleFixture(t)
+
+		got, err := testDB.OrgMembersByField(testOrgAddress, OrgMemberLookupFieldMemberNumber, "P002")
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].ID.Hex(), qt.Equals, fixture.bob.ID.Hex())
+	})
+
+	t.Run("lookup by nationalId returns the unique member", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		fixture := setupCheckBundleFixture(t)
+
+		got, err := testDB.OrgMembersByField(testOrgAddress, OrgMemberLookupFieldNationalID, "DNI001")
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].ID.Hex(), qt.Equals, fixture.alice.ID.Hex())
+	})
+
+	t.Run("lookup by phone matches against the hashed value", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		fixture := setupCheckBundleFixture(t)
+
+		hashed, err := NewHashedPhone("+34611111111", fixture.org)
+		c.Assert(err, qt.IsNil)
+
+		got, err := testDB.OrgMembersByField(testOrgAddress, OrgMemberLookupFieldPhone, hashed)
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].ID.Hex(), qt.Equals, fixture.alice.ID.Hex())
+	})
+
+	t.Run("no match returns empty slice without error", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		_ = setupCheckBundleFixture(t)
+
+		got, err := testDB.OrgMembersByField(testOrgAddress, OrgMemberLookupFieldEmail, "missing@x.com")
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 0)
+	})
+
+	t.Run("results are scoped to the requested org", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		_ = setupCheckBundleFixture(t)
+
+		got, err := testDB.OrgMembersByField(testAnotherOrgAddress, OrgMemberLookupFieldEmail, "shared@x.com")
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 0)
+	})
+}
+
+func TestCensusParticipantsByMemberIDs(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	t.Run("empty censusID returns ErrInvalidData", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		fixture := setupCheckBundleFixture(t)
+
+		_, err := testDB.CensusParticipantsByMemberIDs("", []string{fixture.alice.ID.Hex()})
+		c.Assert(err, qt.Equals, ErrInvalidData)
+	})
+
+	t.Run("empty memberIDs returns empty slice without error", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		fixture := setupCheckBundleFixture(t)
+
+		got, err := testDB.CensusParticipantsByMemberIDs(fixture.census.ID.Hex(), nil)
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 0)
+	})
+
+	t.Run("returns only IDs that are participants of the census", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		fixture := setupCheckBundleFixture(t)
+
+		got, err := testDB.CensusParticipantsByMemberIDs(
+			fixture.census.ID.Hex(),
+			[]string{fixture.alice.ID.Hex(), fixture.bob.ID.Hex(), fixture.carol.ID.Hex()},
+		)
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 2)
+
+		gotIDs := map[string]bool{}
+		for _, p := range got {
+			gotIDs[p.ParticipantID] = true
+		}
+		c.Assert(gotIDs[fixture.alice.ID.Hex()], qt.IsTrue)
+		c.Assert(gotIDs[fixture.bob.ID.Hex()], qt.IsTrue)
+		c.Assert(gotIDs[fixture.carol.ID.Hex()], qt.IsFalse)
+	})
+
+	t.Run("results are scoped to the requested census", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		fixture := setupCheckBundleFixture(t)
+
+		// Different census ID; same memberID must not be returned.
+		other := &Census{OrgAddress: testOrgAddress, CreatedAt: time.Now()}
+		otherID, err := testDB.SetCensus(other)
+		c.Assert(err, qt.IsNil)
+
+		got, err := testDB.CensusParticipantsByMemberIDs(otherID, []string{fixture.alice.ID.Hex()})
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 0)
+	})
+}
+
+// seedUsedCSPProcess seeds a verified CSP auth token for the given member/bundle
+// and consumes the given process with it, so that CSPProcessByUserAndProcess
+// reports a used process for (memberID, processID).
+func seedUsedCSPProcess(t *testing.T, memberID string, bundleID, processID internal.HexBytes) {
+	t.Helper()
+	c := qt.New(t)
+	token := internal.HexBytes(append([]byte{0xC5, 0x90}, processID...))
+	userID := internal.HexBytesFromString(memberID)
+	address := internal.HexBytes{0x11, 0x22, 0x33}
+	c.Assert(testDB.SetCSPAuth(token, userID, bundleID), qt.IsNil)
+	c.Assert(testDB.VerifyCSPAuth(token), qt.IsNil)
+	c.Assert(testDB.ConsumeCSPProcess(token, processID, address), qt.IsNil)
+}
+
+func TestMembersWithUsedCSPProcess(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	processID := internal.HexBytes{0xAA, 0xBB, 0xCC, 0xDD}
+
+	t.Run("nil processID returns ErrBadInputs", func(_ *testing.T) {
+		_, err := testDB.MembersWithUsedCSPProcess(nil, []string{"deadbeef"})
+		c.Assert(err, qt.Equals, ErrBadInputs)
+	})
+
+	t.Run("empty memberIDs returns empty map without error", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		_ = setupCheckBundleFixture(t)
+
+		got, err := testDB.MembersWithUsedCSPProcess(processID, nil)
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 0)
+	})
+
+	t.Run("no CSP processes at all returns empty map", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		fixture := setupCheckBundleFixture(t)
+
+		got, err := testDB.MembersWithUsedCSPProcess(
+			processID, []string{fixture.alice.ID.Hex(), fixture.bob.ID.Hex()},
+		)
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 0)
+	})
+
+	t.Run("a verified auth token without a consumed process does not count", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		fixture := setupCheckBundleFixture(t)
+
+		// Verified auth exists, but the process was never consumed → no CSPProcess.
+		token := internal.HexBytes{0x01, 0x02, 0x03}
+		userID := internal.HexBytesFromString(fixture.alice.ID.Hex())
+		c.Assert(testDB.SetCSPAuth(token, userID, fixture.bundleID), qt.IsNil)
+		c.Assert(testDB.VerifyCSPAuth(token), qt.IsNil)
+
+		got, err := testDB.MembersWithUsedCSPProcess(processID, []string{fixture.alice.ID.Hex()})
+		c.Assert(err, qt.IsNil)
+		c.Assert(got[fixture.alice.ID.Hex()], qt.IsFalse)
+	})
+
+	t.Run("a used CSP process flips the member's flag to true", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		fixture := setupCheckBundleFixture(t)
+
+		seedUsedCSPProcess(t, fixture.alice.ID.Hex(), fixture.bundleID, processID)
+
+		got, err := testDB.MembersWithUsedCSPProcess(
+			processID, []string{fixture.alice.ID.Hex(), fixture.bob.ID.Hex()},
+		)
+		c.Assert(err, qt.IsNil)
+		c.Assert(got[fixture.alice.ID.Hex()], qt.IsTrue)
+		c.Assert(got[fixture.bob.ID.Hex()], qt.IsFalse)
+	})
+
+	t.Run("a used CSP process for a different process is ignored", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		fixture := setupCheckBundleFixture(t)
+
+		otherProcess := internal.HexBytes{0xDE, 0xAD, 0xBE, 0xEF}
+		seedUsedCSPProcess(t, fixture.alice.ID.Hex(), fixture.bundleID, otherProcess)
+
+		got, err := testDB.MembersWithUsedCSPProcess(processID, []string{fixture.alice.ID.Hex()})
+		c.Assert(err, qt.IsNil)
+		c.Assert(got[fixture.alice.ID.Hex()], qt.IsFalse)
+	})
+}

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -78,6 +78,39 @@ definitions:
           type: string
         type: array
     type: object
+  apicommon.CheckBundleParticipantsRequest:
+    properties:
+      fieldName:
+        type: string
+      processID:
+        example: deadbeef
+        format: hex
+        type: string
+      value:
+        type: string
+    type: object
+  apicommon.CheckBundleParticipantsResponse:
+    properties:
+      participants:
+        items:
+          $ref: '#/definitions/apicommon.CheckBundleParticipantsResponseEntry'
+        type: array
+    type: object
+  apicommon.CheckBundleParticipantsResponseEntry:
+    properties:
+      email:
+        type: string
+      hasVoted:
+        type: boolean
+      memberId:
+        type: string
+      memberNumber:
+        type: string
+      name:
+        type: string
+      surname:
+        type: string
+    type: object
   apicommon.CreateCensusRequest:
     properties:
       authFields:
@@ -3784,6 +3817,60 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
       summary: Resend authentication challenge for a process bundle
+      tags:
+      - process
+  /process/bundle/{bundleId}/participants/check:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Look up org members by one of the allowed identification fields
+        (email, phone, memberNumber, nationalId, name, surname) and return
+        The request must also include the processID
+        hasVoted is true when the member has used (consumed) that process to
+        cast a ballot. Requires Manager/Admin role on the bundle's organization.
+      parameters:
+      - description: Bundle ID
+        in: path
+        name: bundleId
+        required: true
+        type: string
+      - description: Lookup request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/apicommon.CheckBundleParticipantsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apicommon.CheckBundleParticipantsResponse'
+        "400":
+          description: Invalid input
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "404":
+          description: Bundle not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+      security:
+      - BearerAuth: []
+      summary: Check whether an org member belongs to a bundle's census and have voted
       tags:
       - process
   /process/bundle/{bundleId}/sign:

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -74,6 +74,7 @@ var (
 	ErrCensusParticipantNotFound = Error{Code: 40029, HTTPstatus: http.StatusNotFound, Err: fmt.Errorf("census participant not found")}
 	ErrProcessNotFound           = Error{Code: 40038, HTTPstatus: http.StatusNotFound, Err: fmt.Errorf("process not found")}
 	ErrGroupNotFound             = Error{Code: 40057, HTTPstatus: http.StatusNotFound, Err: fmt.Errorf("group not found")}
+	ErrBundleNotFound            = Error{Code: 40058, HTTPstatus: http.StatusNotFound, Err: fmt.Errorf("bundle not found")}
 
 	// Conflict errors (409)
 	ErrDuplicateConflict           = Error{Code: 40901, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("resource already exists")}
@@ -94,6 +95,7 @@ var (
 	ErrExceedsOrganizationMembersLimit        = Error{Code: 40145, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("operation would exceed organization members limit")}
 	ErrAutoGroupCannotBeDeleted               = Error{Code: 40150, HTTPstatus: http.StatusForbidden, Err: fmt.Errorf("the \"All members\" group is auto-generated and cannot be deleted")}
 	ErrAutoGroupMembersCannotBeModified       = Error{Code: 40151, HTTPstatus: http.StatusForbidden, Err: fmt.Errorf("membership of the auto-generated \"All members\" group cannot be manually modified")}
+	ErrForbidden                              = Error{Code: 40152, HTTPstatus: http.StatusForbidden, Err: fmt.Errorf("forbidden"), LogLevel: "info"}
 
 	// CSP errors (408)
 	ErrZeroWeightVoter = Error{Code: 40801, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("voter weight cannot be zero")}


### PR DESCRIPTION
## Summary

  Implements `POST /process/bundle/{bundleId}/participants/check` so organization
  managers/admins can verify whether one or more org members belong to a bundle's
  census — looked up by `email`, `phone`, `memberNumber`, or `nationalId` — and
  whether each of them has already voted in a specific process of the bundle.
  
  ## What changed

  - Added the new protected process-bundle endpoint and its request/response API types.
  - Added an allowlisted org-member lookup field type to avoid arbitrary field queries.
  - Reused the existing phone hashing flow so plaintext phone input is hashed
    server-side before lookup.
  - The request carries a required `processID`; the response's `hasVoted` reflects
    whether the member has voted in **that** process.
  - `hasVoted` is derived from CSP **process consumption**: a member counts as
    voted when a `CSPProcess` exists for `(memberID, processID)` and its `used`
    field is `true`. This replaces the earlier approach of inferring votes from
    verified CSP auth tokens in the `cspTokens` table, which only proved a member
    completed the auth challenge — not that they actually cast a ballot.
  - Added DB helpers to:
    - find org members by field within an organization
    - find census participants by member IDs within a census
    - `MembersWithUsedCSPProcess(processID, memberIDs)` — return the subset of
      members with a used CSP process for the given process, built on the existing
      `CSPProcessByUserAndProcess` helper in `db/csp.go`
  - Returned only members that both match the lookup and are participants of the
    bundle's census.
  - Aligned handler responses with the issue contract:
    - `400` for malformed input, including a missing/empty `processID`
    - `401` for unauthenticated callers
    - `403` for authenticated callers without Manager/Admin role
    - `404` when the bundle does not exist
  
  ## API

  `POST /process/bundle/{bundleId}/participants/check`
  
  Request:
  ```json
  {
    "fieldName": "email",
    "value": "alice@x.org",
    "processID": "deadbeef..."
  }
  ```
  
  Response (200 OK):
```json
  {
    "participants": [
      {
        "memberId": "65f...",
        "name": "Alice",
        "surname": "Bolet",
        "email": "alice@x.org",
        "memberNumber": "P001",
        "hasVoted": false
      }
    ]
  }
  ```

  Testing
  
  - db package: table-driven tests for the org-member field lookup, census
  participant lookup, and MembersWithUsedCSPProcess (nil process → ErrBadInputs,
  empty input, no process, verified-but-unconsumed auth → false, used process →
  true, used process for a different process ID ignored).
  - api package: covers each allowed fieldName, invalid fieldName, missing
  processID, plaintext phone hashing, no match, multi-match dedup against the
  census, member-exists-but-not-in-bundle, hasVoted true/false, and the
  401/403/404 paths.

  Closes #495
