### PR TITLE
feat(csp): add token-only census membership check endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -299,6 +299,7 @@ func (a *API) initRouter() http.Handler {
 		handle(r, http.MethodPost, processBundleAuthEndpoint, cspHandlers.BundleAuthHandler)
 		handle(r, http.MethodPost, processBundleAuthResendEndpoint, cspHandlers.BundleAuthResendHandler)
 		handle(r, http.MethodPost, processBundleSignEndpoint, cspHandlers.BundleSignHandler)
+		handle(r, http.MethodPost, processBundleCheckEndpoint, cspHandlers.BundleCheckHandler)
 		handle(r, http.MethodGet, processBundleMemberEndpoint, a.processBundleParticipantInfoHandler)
 	})
 	a.router = r

--- a/api/csp_voting_test.go
+++ b/api/csp_voting_test.go
@@ -357,6 +357,104 @@ func TestCSPVoting(t *testing.T) {
 				// Create a bundle with the census and process
 				bundleID, _ := postProcessBundle(t, token, censusID, processID)
 
+				// Check census membership via the CSP token alone (the only voter
+				// data the client stores), mirroring client.isInCensus() for CSP.
+				t.Run("Check census membership", func(t *testing.T) {
+					c := qt.New(t)
+
+					// Grace (P009) is a verified participant of this bundle's census.
+					grace := members[8]
+					authToken := testCSPAuthenticateWithFields(t, bundleID, &handlers.AuthRequest{
+						Name:         grace.Name,
+						Surname:      grace.Surname,
+						MemberNumber: grace.MemberNumber,
+						Email:        grace.Email,
+					})
+
+					checkReq := &handlers.CheckMembershipRequest{
+						AuthToken: authToken,
+						ProcessID: processID,
+					}
+
+					// A verified token for this bundle whose user is in the census is eligible.
+					resp := requestAndParse[handlers.CheckMembershipResponse](t, http.MethodPost, "", checkReq,
+						"process", "bundle", bundleID, "check")
+					c.Assert(resp.Belongs, qt.IsTrue)
+					c.Assert(resp.HasVoted, qt.IsFalse)
+					c.Assert(bytes.Equal(resp.Weight, big.NewInt(1).Bytes()), qt.IsTrue,
+						qt.Commentf("unexpected weight %x", resp.Weight))
+
+					// Once the member consumes the process, hasVoted flips to true.
+					voter := ethereum.SignKeys{}
+					c.Assert(voter.Generate(), qt.IsNil)
+					c.Assert(testDB.ConsumeCSPProcess(authToken, processID,
+						internal.HexBytes(voter.Address().Bytes())), qt.IsNil)
+
+					resp = requestAndParse[handlers.CheckMembershipResponse](t, http.MethodPost, "", checkReq,
+						"process", "bundle", bundleID, "check")
+					c.Assert(resp.Belongs, qt.IsTrue)
+					c.Assert(resp.HasVoted, qt.IsTrue)
+
+					// An unknown token is reported as not eligible with HTTP 200, not an error.
+					unknown := requestAndParse[handlers.CheckMembershipResponse](t, http.MethodPost, "",
+						&handlers.CheckMembershipRequest{AuthToken: internal.HexBytes{0xde, 0xad, 0xbe, 0xef}},
+						"process", "bundle", bundleID, "check")
+					c.Assert(unknown.Belongs, qt.IsFalse)
+
+					// A token issued for a different bundle is rejected even though the user
+					// is in the (shared) census: this closes the cross-bundle leak.
+					otherBundleID, _ := postProcessBundle(t, token, censusID, processID)
+					otherResp := requestAndParse[handlers.CheckMembershipResponse](t, http.MethodPost, "", checkReq,
+						"process", "bundle", otherBundleID, "check")
+					c.Assert(otherResp.Belongs, qt.IsFalse)
+
+					// The normal auth flow cannot mint a verified token for a non-participant
+					// or a zero-weight voter (auth rejects both), so seed tokens directly to
+					// exercise the handler's remaining negative gates.
+					bundleHex := internal.HexBytesFromString(bundleID)
+					seedVerifiedToken := func(memberID string) internal.HexBytes {
+						tok := internal.HexBytes(internal.RandomBytes(16))
+						c.Assert(testDB.SetCSPAuth(tok, internal.HexBytesFromString(memberID), bundleHex), qt.IsNil)
+						c.Assert(testDB.VerifyCSPAuth(tok), qt.IsNil)
+						return tok
+					}
+					checkBelongs := func(tok internal.HexBytes) bool {
+						r := requestAndParse[handlers.CheckMembershipResponse](t, http.MethodPost, "",
+							&handlers.CheckMembershipRequest{AuthToken: tok, ProcessID: processID},
+							"process", "bundle", bundleID, "check")
+						return r.Belongs
+					}
+
+					// A verified token for this bundle whose user is NOT in the census
+					// (an org member outside the published group) is not eligible.
+					allMembers := postOrgMembers(t, token, orgAddress, apicommon.OrgMember{
+						Name: "Out", Surname: "Sider", MemberNumber: "P999", NationalID: "OUTSIDER99",
+						Email: "outsider@example.com", Phone: "+34612399999", Weight: "1",
+					})
+					var outsiderID string
+					for _, m := range allMembers {
+						if m.NationalID == "OUTSIDER99" {
+							outsiderID = m.ID
+						}
+					}
+					c.Assert(outsiderID, qt.Not(qt.Equals), "")
+					c.Assert(checkBelongs(seedVerifiedToken(outsiderID)), qt.IsFalse)
+
+					// A verified token for a zero-weight member of a weighted census is not eligible.
+					c.Assert(members[9].Weight, qt.Equals, "0") // Hannah
+					c.Assert(checkBelongs(seedVerifiedToken(members[9].ID)), qt.IsFalse)
+
+					// An unverified token (issued but never verified) is not eligible,
+					// even for a genuine census participant.
+					unverifiedTok := internal.HexBytes(internal.RandomBytes(16))
+					c.Assert(testDB.SetCSPAuth(unverifiedTok, internal.HexBytesFromString(grace.ID), bundleHex), qt.IsNil)
+					c.Assert(checkBelongs(unverifiedTok), qt.IsFalse)
+
+					// A missing auth token is a client error, not a membership answer.
+					requestAndAssertError(errors.ErrInvalidData, t, http.MethodPost, "",
+						&handlers.CheckMembershipRequest{}, "process", "bundle", bundleID, "check")
+				})
+
 				t.Run("Authenticate with Email and Vote", func(t *testing.T) {
 					orgBefore := getOrganization(t, orgAddress)
 

--- a/api/routes.go
+++ b/api/routes.go
@@ -158,6 +158,8 @@ const (
 	processBundleWeightEndpoint = "/process/bundle/{bundleId}/weight"
 	// POST /process/bundle/{bundleId}/sign to sign with two-factor authentication
 	processBundleSignEndpoint = "/process/bundle/{bundleId}/sign"
+	// POST /process/bundle/{bundleId}/check to check census membership for a CSP auth token
+	processBundleCheckEndpoint = "/process/bundle/{bundleId}/check"
 	// GET /process/bundle/{bundleId}/{participantId} to get the process information
 	processBundleMemberEndpoint = "/process/bundle/{bundleId}/{participantId}"
 	// POST /process/bundle/{bundleId}/participants/check to check whether an org member is a

--- a/csp/handlers/handlers.go
+++ b/csp/handlers/handlers.go
@@ -512,6 +512,122 @@ func (c *CSPHandlers) UserWeightHandler(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
+// BundleCheckHandler godoc
+//
+//	@Summary		Check census membership for a bundle
+//	@Description	Check whether the user behind a CSP auth token is an eligible participant of the bundle's census.
+//	@Description	The user is identified solely by the auth token (the only voter data the client stores). The token
+//	@Description	must be verified and issued for this same bundle, and the user must be a participant of the bundle's
+//	@Description	census. When electionId is provided, the response also reports whether the user already voted in that
+//	@Description	process. Ineligibility (unknown/unverified token, token from another bundle, not in census, zero weight
+//	@Description	on a weighted census) is reported as belongs=false with HTTP 200, not as an error.
+//	@Tags			process
+//	@Accept			json
+//	@Produce		json
+//	@Param			bundleId	path		string							true	"Bundle ID"
+//	@Param			request		body		handlers.CheckMembershipRequest	true	"Request with auth token and optional election ID"
+//	@Success		200			{object}	handlers.CheckMembershipResponse
+//	@Failure		400			{object}	errors.Error	"Malformed URL/body or missing auth token"
+//	@Failure		404			{object}	errors.Error	"Bundle not found or census not found"
+//	@Failure		500			{object}	errors.Error	"Internal server error"
+//	@Router			/process/bundle/{bundleId}/check [post]
+func (c *CSPHandlers) BundleCheckHandler(w http.ResponseWriter, r *http.Request) {
+	// Parse the bundle ID and load the bundle
+	bundleID, ok := parseBundleID(w, r)
+	if !ok {
+		return
+	}
+	bundle, ok := c.getBundle(w, *bundleID)
+	if !ok {
+		return
+	}
+
+	// Parse the request body
+	var req CheckMembershipRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		errors.ErrMalformedBody.Write(w)
+		return
+	}
+	if len(req.AuthToken) == 0 {
+		errors.ErrInvalidData.Withf("missing auth token").Write(w)
+		return
+	}
+
+	// notEligible writes a successful negative response: the token's user is
+	// simply not allowed to vote in this bundle, which is not an error.
+	notEligible := func() {
+		apicommon.HTTPWriteJSON(w, &CheckMembershipResponse{Belongs: false})
+	}
+
+	// Load the token. An unknown or expired token means "not eligible".
+	auth, err := c.csp.Storage.CSPAuth(req.AuthToken)
+	if err != nil {
+		notEligible()
+		return
+	}
+	// The token must be verified and issued for this very bundle. A token from a
+	// different bundle (or an unverified one) does not grant access here.
+	if !auth.Verified || !bytes.Equal(*bundleID, auth.BundleID) {
+		notEligible()
+		return
+	}
+
+	// Resolve the org member referenced by the token.
+	oid, err := primitive.ObjectIDFromHex(auth.UserID.String())
+	if err != nil {
+		notEligible()
+		return
+	}
+	member, err := c.mainDB.OrgMember(bundle.OrgAddress, oid.Hex())
+	if err != nil {
+		notEligible()
+		return
+	}
+
+	census, err := c.mainDB.Census(bundle.Census.ID.Hex())
+	if err != nil {
+		errors.ErrCensusNotFound.WithErr(err).Write(w)
+		return
+	}
+
+	// The token's user must be a participant of the bundle's census.
+	if _, err := c.mainDB.CensusParticipant(bundle.Census.ID.Hex(), auth.UserID.String()); err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			notEligible()
+			return
+		}
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+
+	// Compute the voter weight (1 unless the census is weighted). A zero weight
+	// on a weighted census means the user cannot vote.
+	weight := uint64(1)
+	if census.Weighted {
+		weight = member.Weight
+		if weight == 0 {
+			notEligible()
+			return
+		}
+	}
+
+	// Optionally report whether the user already voted in the requested process.
+	hasVoted := false
+	if len(req.ProcessID) > 0 {
+		if processID, found := findProcessInBundle(bundle, req.ProcessID); found {
+			if proc, err := c.mainDB.CSPProcessByUserAndProcess(auth.UserID, processID); err == nil {
+				hasVoted = proc.Used
+			}
+		}
+	}
+
+	apicommon.HTTPWriteJSON(w, &CheckMembershipResponse{
+		Belongs:  true,
+		Weight:   internal.HexBytes(big.NewInt(int64(weight)).Bytes()),
+		HasVoted: hasVoted,
+	})
+}
+
 // ConsumedAddressHandler godoc
 //
 //	@Summary		Get the address used to sign a process

--- a/csp/handlers/types.go
+++ b/csp/handlers/types.go
@@ -71,6 +71,26 @@ type UserWeightResponse struct {
 	Weight internal.HexBytes `json:"weight,omitempty" swaggertype:"string" format:"hex" example:"2a"`
 }
 
+// CheckMembershipRequest defines the payload for the request to check whether
+// the user behind a CSP auth token belongs to a bundle's census. The user is
+// identified solely by the authToken; the optional electionId (process ID)
+// scopes the hasVoted result to that process.
+type CheckMembershipRequest struct {
+	AuthToken internal.HexBytes `json:"authToken" swaggertype:"string" format:"hex" example:"deadbeef"`
+	ProcessID internal.HexBytes `json:"electionId,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`
+}
+
+// CheckMembershipResponse defines the payload for the response to the census
+// membership check. Belongs reports whether the token's user is an eligible
+// participant of the bundle's census, Weight is the voter weight (1 unless the
+// census is weighted) and HasVoted reports whether the user already cast a
+// ballot in the requested process (only meaningful when electionId is provided).
+type CheckMembershipResponse struct {
+	Belongs  bool              `json:"belongs"`
+	Weight   internal.HexBytes `json:"weight,omitempty" swaggertype:"string" format:"hex" example:"2a"`
+	HasVoted bool              `json:"hasVoted"`
+}
+
 // ConsumedAddressRequest defines the payload for the request to get the
 // if a token was used and which address was used. It includes the
 // authToken to query the information.

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1334,6 +1334,28 @@ definitions:
         format: hex
         type: string
     type: object
+  handlers.CheckMembershipRequest:
+    properties:
+      authToken:
+        example: deadbeef
+        format: hex
+        type: string
+      electionId:
+        example: deadbeef
+        format: hex
+        type: string
+    type: object
+  handlers.CheckMembershipResponse:
+    properties:
+      belongs:
+        type: boolean
+      hasVoted:
+        type: boolean
+      weight:
+        example: 2a
+        format: hex
+        type: string
+    type: object
   handlers.ConsumedAddressRequest:
     properties:
       authToken:
@@ -3817,6 +3839,51 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
       summary: Resend authentication challenge for a process bundle
+      tags:
+      - process
+  /process/bundle/{bundleId}/check:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Check whether the user behind a CSP auth token is an eligible participant of the bundle's census.
+        The user is identified solely by the auth token (the only voter data the client stores). The token
+        must be verified and issued for this same bundle, and the user must be a participant of the bundle's
+        census. When electionId is provided, the response also reports whether the user already voted in that
+        process. Ineligibility (unknown/unverified token, token from another bundle, not in census, zero weight
+        on a weighted census) is reported as belongs=false with HTTP 200, not as an error.
+      parameters:
+      - description: Bundle ID
+        in: path
+        name: bundleId
+        required: true
+        type: string
+      - description: Request with auth token and optional election ID
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.CheckMembershipRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.CheckMembershipResponse'
+        "400":
+          description: Malformed URL/body or missing auth token
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "404":
+          description: Bundle not found or census not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+      summary: Check census membership for a bundle
       tags:
       - process
   /process/bundle/{bundleId}/participants/check:


### PR DESCRIPTION
Add POST /process/bundle/{bundleId}/check so the UI can verify, using only the stored CSP auth token, whether a voter belongs to a bundle's census — mirroring client.isInCensus() for non-CSP censuses. Previously the CSP vote button was gated on mere token presence, so it was wrongly shown when the stored token belonged to a different bundle than the election being viewed.

The endpoint returns {belongs, weight, hasVoted}. belongs is true only for a verified token issued for this same bundle whose user is a participant of the bundle's census (and non-zero weight on weighted censuses). Ineligibility is reported as belongs:false with HTTP 200, not as an error, so the UI can consume it the same way it consumes isInCensus.

Composes existing DB methods (CSPAuth, OrgMember, Census, CensusParticipant, CSPProcessByUserAndProcess); no new query logic.

Required by https://github.com/vocdoni/vocdoni-app/issues/1675