### PR TITLE
feat(csp): blind signatures for voter anonymity

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -299,6 +299,7 @@ func (a *API) initRouter() http.Handler {
 		handle(r, http.MethodPost, processBundleAuthEndpoint, cspHandlers.BundleAuthHandler)
 		handle(r, http.MethodPost, processBundleAuthResendEndpoint, cspHandlers.BundleAuthResendHandler)
 		handle(r, http.MethodPost, processBundleSignEndpoint, cspHandlers.BundleSignHandler)
+		handle(r, http.MethodPost, processBundleSignREndpoint, cspHandlers.BundleSignRHandler)
 		handle(r, http.MethodPost, processBundleCheckEndpoint, cspHandlers.BundleCheckHandler)
 		handle(r, http.MethodGet, processBundleMemberEndpoint, a.processBundleParticipantInfoHandler)
 	})

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	blind "github.com/arnaucube/go-blindsecp256k1"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	qt "github.com/frankban/quicktest"
@@ -877,6 +878,113 @@ func testGenerateVoteProof(processID, voterAddr, signature internal.HexBytes, we
 			},
 		},
 	}
+}
+
+// testCSPSignBlind implements the two-step blind signing protocol with the CSP.
+// Step 1 calls /sign-r to get the ephemeral R point and weight, then blinds the
+// CAbundle hash. Step 2 sends the blinded message to /sign and unblinds the response.
+// Returns the 96-byte uncompressed blind signature and the voter weight from the CSP.
+func testCSPSignBlind(t *testing.T, bundleID string, authToken, processID internal.HexBytes, voterAddr []byte) (
+	internal.HexBytes, uint64,
+) {
+	t.Helper()
+	c := qt.New(t)
+
+	// Step 1: get R point and weight from sign-r
+	signRResp := requestAndParse[handlers.SignRResponse](t, http.MethodPost, "", &handlers.SignRRequest{
+		AuthToken: authToken,
+		ProcessID: processID,
+	}, "process", "bundle", bundleID, "sign-r")
+	c.Assert(signRResp.TokenR, qt.Not(qt.HasLen), 0, qt.Commentf("tokenR is empty"))
+
+	r, err := blind.NewPointFromBytes(signRResp.TokenR)
+	c.Assert(err, qt.IsNil)
+
+	weightBytes := signRResp.Weight
+	weight := new(big.Int).SetBytes(weightBytes).Uint64()
+
+	// Build the CAbundle exactly as vochain will verify it
+	bundle := &models.CAbundle{
+		ProcessId:  processID,
+		Address:    voterAddr,
+		VoteWeight: weightBytes,
+	}
+	cspBundle, err := proto.Marshal(bundle)
+	c.Assert(err, qt.IsNil)
+
+	// Blind the keccak256 hash of the bundle
+	msgHash := ethereum.HashRaw(cspBundle)
+	msgBlinded, userSecretData, err := blind.Blind(new(big.Int).SetBytes(msgHash), r)
+	c.Assert(err, qt.IsNil)
+
+	// Step 2: send blinded message to sign. TokenR must be non-empty so the
+	// handler dispatches to the blind path instead of the plain ECDSA path.
+	signResp := requestAndParse[handlers.AuthResponse](t, http.MethodPost, "", &handlers.SignRequest{
+		TokenR:    signRResp.TokenR,
+		AuthToken: authToken,
+		ProcessID: processID,
+		Payload:   hex.EncodeToString(msgBlinded.Bytes()),
+	}, "process", "bundle", bundleID, "sign")
+	c.Assert(signResp.Signature, qt.Not(qt.HasLen), 0, qt.Commentf("signature is empty"))
+
+	// Unblind the S scalar to get the full *Signature{S, F}
+	sig := blind.Unblind(new(big.Int).SetBytes(signResp.Signature), userSecretData)
+	t.Logf("Blind signature obtained (%d bytes uncompressed)", len(sig.BytesUncompressed()))
+	return sig.BytesUncompressed(), weight
+}
+
+// testGenerateBlindVoteProof generates a vote proof using the blind signature proof type.
+func testGenerateBlindVoteProof(processID, voterAddr, signature internal.HexBytes, weight uint64) *models.Proof {
+	return &models.Proof{
+		Payload: &models.Proof_Ca{
+			Ca: &models.ProofCA{
+				Type:      models.ProofCA_ECDSA_BLIND_PIDSALTED,
+				Signature: signature,
+				Bundle: &models.CAbundle{
+					ProcessId:  processID,
+					Address:    voterAddr,
+					VoteWeight: big.NewInt(int64(weight)).Bytes(),
+				},
+			},
+		},
+	}
+}
+
+// testAuthenthicateAndVoteBlind is identical to testAuthenthicateAndVote but
+// uses the two-step blind signing protocol and ECDSA_BLIND_PIDSALTED proof type.
+func testAuthenthicateAndVoteBlind(t *testing.T, vocdoniClient *apiclient.HTTPclient,
+	bundleID string, processID internal.HexBytes, expectedWeight string, authRequest *handlers.AuthRequest,
+) {
+	t.Helper()
+	c := qt.New(t)
+
+	votesBefore, err := vocdoniClient.ElectionVoteCount(processID.Bytes())
+	c.Assert(err, qt.IsNil)
+
+	user1 := ethereum.SignKeys{}
+	err = user1.Generate()
+	c.Assert(err, qt.IsNil)
+	user1Addr := user1.Address().Bytes()
+
+	authToken := testCSPAuthenticateWithFields(t, bundleID, authRequest)
+
+	expectedWeightInt, ok := math.ParseUint64(expectedWeight)
+	c.Assert(ok, qt.IsTrue)
+
+	// Weight comes from the sign-r step; verify it matches
+	signature, signedWeight := testCSPSignBlind(t, bundleID, authToken, processID, user1Addr)
+	c.Assert(signedWeight, qt.Equals, expectedWeightInt,
+		qt.Commentf("CSP weight %d != expected %d", signedWeight, expectedWeightInt))
+
+	proof := testGenerateBlindVoteProof(processID, user1Addr, signature, signedWeight)
+
+	votePackage := []byte("[\"1\"]")
+	nullifier := testCastVote(t, vocdoniClient, &user1, processID, proof, votePackage)
+	t.Logf("Blind vote cast successfully with nullifier: %x", nullifier)
+
+	votesAfter, err := vocdoniClient.ElectionVoteCount(processID.Bytes())
+	c.Assert(err, qt.IsNil)
+	c.Assert(votesAfter, qt.Equals, votesBefore+1, qt.Commentf("expected 1 more vote, got %d", votesAfter))
 }
 
 // testCastVote casts a vote with the given proof and process ID.

--- a/api/csp_voting_test.go
+++ b/api/csp_voting_test.go
@@ -539,6 +539,53 @@ func TestCSPVoting(t *testing.T) {
 						})
 				})
 
+				// Verify ConsumedAddressHandler omits address/nullifier for blind processes
+				// but includes them for ECDSA processes.
+				t.Run("Sign-info endpoint", func(t *testing.T) {
+					c := qt.New(t)
+
+					t.Run("returns only timestamp for blind-signed process", func(t *testing.T) {
+						// John Doe (P001) has not yet voted on blindBundleID; consume it now
+						// via the blind path so we can check sign-info without casting a vote.
+						authToken := testCSPAuthenticateWithFields(t, blindBundleID, &handlers.AuthRequest{
+							Name:         "John",
+							Surname:      "Doe",
+							MemberNumber: "P001",
+							Email:        "john.doe@example.com",
+						})
+						voter := ethereum.SignKeys{}
+						c.Assert(voter.Generate(), qt.IsNil)
+						testCSPSignBlind(t, blindBundleID, authToken, internal.HexBytes(blindProcessID), voter.Address().Bytes())
+
+						resp := requestAndParse[handlers.ConsumedAddressResponse](t, http.MethodPost, "",
+							&handlers.ConsumedAddressRequest{AuthToken: authToken},
+							"process", hex.EncodeToString(blindProcessID), "sign-info")
+						c.Assert(resp.At.IsZero(), qt.IsFalse, qt.Commentf("expected At to be set"))
+						c.Assert(resp.Address, qt.HasLen, 0, qt.Commentf("expected no address for blind process"))
+						c.Assert(resp.Nullifier, qt.HasLen, 0, qt.Commentf("expected no nullifier for blind process"))
+					})
+
+					t.Run("returns address and nullifier for ECDSA-signed process", func(t *testing.T) {
+						// Frank Lopez (P008) has not yet signed on bundleID; consume it now.
+						authToken := testCSPAuthenticateWithFields(t, bundleID, &handlers.AuthRequest{
+							Name:         "Frank",
+							Surname:      "Lopez",
+							MemberNumber: "P008",
+							Email:        "frank.lopez@example.com",
+						})
+						voter := ethereum.SignKeys{}
+						c.Assert(voter.Generate(), qt.IsNil)
+						testCSPSign(t, bundleID, authToken, processID, voter.Address().Bytes())
+
+						resp := requestAndParse[handlers.ConsumedAddressResponse](t, http.MethodPost, "",
+							&handlers.ConsumedAddressRequest{AuthToken: authToken},
+							"process", hex.EncodeToString(processID), "sign-info")
+						c.Assert(resp.At.IsZero(), qt.IsFalse, qt.Commentf("expected At to be set"))
+						c.Assert(resp.Address, qt.Not(qt.HasLen), 0, qt.Commentf("expected address for ECDSA process"))
+						c.Assert(resp.Nullifier, qt.Not(qt.HasLen), 0, qt.Commentf("expected nullifier for ECDSA process"))
+					})
+				})
+
 				// Create a voting key for the member
 				t.Run("Update user weight", func(_ *testing.T) {
 					// Create the voting address for the first user

--- a/api/csp_voting_test.go
+++ b/api/csp_voting_test.go
@@ -357,6 +357,41 @@ func TestCSPVoting(t *testing.T) {
 				// Create a bundle with the census and process
 				bundleID, _ := postProcessBundle(t, token, censusID, processID)
 
+				// Create a second process registered with the blind public key and
+				// a separate bundle so the blind signing path can be tested end-to-end.
+				blindNonce := fetchVocdoniAccountNonce(t, vocdoniClient, orgAddress)
+				blindProcessTx := models.Tx{
+					Payload: &models.Tx_NewProcess{
+						NewProcess: &models.NewProcessTx{
+							Txtype: models.TxType_NEW_PROCESS,
+							Nonce:  blindNonce,
+							Process: &models.Process{
+								EntityId:      orgAddress.Bytes(),
+								Duration:      120,
+								Status:        models.ProcessStatus_READY,
+								CensusOrigin:  models.CensusOrigin_OFF_CHAIN_CA,
+								CensusRoot:    testCSP.BlindPubKey(),
+								MaxCensusSize: 10,
+								EnvelopeType: &models.EnvelopeType{
+									Anonymous:      false,
+									CostFromWeight: false,
+								},
+								VoteOptions: &models.ProcessVoteOptions{
+									MaxCount: 1,
+									MaxValue: 5,
+								},
+								Mode: &models.ProcessMode{
+									AutoStart:     true,
+									Interruptible: true,
+								},
+							},
+						},
+					},
+				}
+				blindProcessID := signRemoteSignerAndSendVocdoniTx(t, &blindProcessTx, token, vocdoniClient, orgAddress)
+				t.Logf("Created blind process with ID: %x", blindProcessID)
+				blindBundleID, _ := postProcessBundle(t, token, censusID, blindProcessID)
+
 				// Check census membership via the CSP token alone (the only voter
 				// data the client stores), mirroring client.isInCensus() for CSP.
 				t.Run("Check census membership", func(t *testing.T) {
@@ -487,6 +522,21 @@ func TestCSPVoting(t *testing.T) {
 					orgAfter := getOrganization(t, orgAddress)
 					qt.Assert(t, orgAfter.Counters.SentEmails, qt.Equals, orgBefore.Counters.SentEmails)
 					qt.Assert(t, orgAfter.Counters.SentSMS, qt.Equals, orgBefore.Counters.SentSMS+1)
+				})
+
+				t.Run("Authenticate with Email and Vote (Blind)", func(t *testing.T) {
+					// Uses the blind process (ECDSA_BLIND_PIDSALTED) and blindBundleID.
+					// This exercises the two-step /sign-r → /sign blind protocol and
+					// verifies that BlindPubKey() is in the standard secp256k1 compressed
+					// format that vochain can decompress.
+					testAuthenthicateAndVoteBlind(t, vocdoniClient, blindBundleID,
+						internal.HexBytes(blindProcessID), members[1].Weight,
+						&handlers.AuthRequest{
+							Name:         "Jane",
+							Surname:      "Smith",
+							MemberNumber: "P002",
+							Email:        "jane.smith@example.com",
+						})
 				})
 
 				// Create a voting key for the member

--- a/api/routes.go
+++ b/api/routes.go
@@ -158,6 +158,8 @@ const (
 	processBundleWeightEndpoint = "/process/bundle/{bundleId}/weight"
 	// POST /process/bundle/{bundleId}/sign to sign with two-factor authentication
 	processBundleSignEndpoint = "/process/bundle/{bundleId}/sign"
+	// POST /process/bundle/{bundleId}/sign-r to begin a blind signing session
+	processBundleSignREndpoint = "/process/bundle/{bundleId}/sign-r"
 	// POST /process/bundle/{bundleId}/check to check census membership for a CSP auth token
 	processBundleCheckEndpoint = "/process/bundle/{bundleId}/check"
 	// GET /process/bundle/{bundleId}/{participantId} to get the process information

--- a/csp/csp.go
+++ b/csp/csp.go
@@ -55,6 +55,7 @@ type CSP struct {
 	Signer       *saltedkey.SaltedKey
 	Storage      *db.MongoStorage
 	signerLock   sync.Map
+	blindKStore  sync.Map // ephemeral secretK values for in-flight blind signing sessions
 	notifyQueue  *notifications.Queue
 
 	notificationCoolDownTime time.Duration
@@ -118,11 +119,16 @@ func New(ctx context.Context, config *Config) (*CSP, error) {
 	}, nil
 }
 
-// PubKey method returns the root public key of the CSP.
+// PubKey method returns the root ECDSA public key of the CSP.
 func (c *CSP) PubKey() (internal.HexBytes, error) {
 	pub, err := c.Signer.ECDSAPubKey()
 	if err != nil {
 		return nil, err
 	}
 	return ethcrypto.CompressPubkey(pub), nil
+}
+
+// BlindPubKey returns the root blind (secp256k1) public key of the CSP.
+func (c *CSP) BlindPubKey() internal.HexBytes {
+	return c.Signer.BlindPubKey().Bytes()
 }

--- a/csp/csp.go
+++ b/csp/csp.go
@@ -2,6 +2,7 @@ package csp
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"sync"
 	"time"
 
@@ -128,7 +129,18 @@ func (c *CSP) PubKey() (internal.HexBytes, error) {
 	return ethcrypto.CompressPubkey(pub), nil
 }
 
-// BlindPubKey returns the root blind (secp256k1) public key of the CSP.
+// BlindPubKey returns the root blind public key in standard secp256k1 compressed
+// format (0x02/0x03 prefix + 32-byte X), compatible with vochain's
+// ethereum.DecompressPubKey / btcec.ParsePubKey.
+//
+// go-blindsecp256k1's own Bytes() uses a non-standard layout (32-byte X
+// little-endian + parity byte at the end) which btcec cannot parse.
 func (c *CSP) BlindPubKey() internal.HexBytes {
-	return c.Signer.BlindPubKey().Bytes()
+	pk := c.Signer.BlindPubKey()
+	ecPub := &ecdsa.PublicKey{
+		Curve: ethcrypto.S256(),
+		X:     pk.X,
+		Y:     pk.Y,
+	}
+	return ethcrypto.CompressPubkey(ecPub)
 }

--- a/csp/errors.go
+++ b/csp/errors.go
@@ -64,4 +64,9 @@ var (
 	ErrUserIsNotAlreadySigning = fmt.Errorf("the user is not signing")
 	// ErrInvalidSalt is returned when the salt is invalid.
 	ErrInvalidSalt = fmt.Errorf("invalid salt, length must be %d bytes", saltedkey.SaltSize)
+	// ErrBlindRNotFound is returned when no pending blind signing session exists
+	// for the given auth token and process ID.
+	ErrBlindRNotFound = fmt.Errorf("blind signing session not found or expired")
+	// ErrWeightAttestation is returned when the weight attestation signing fails.
+	ErrWeightAttestation = fmt.Errorf("failed to sign weight attestation")
 )

--- a/csp/handlers/handlers.go
+++ b/csp/handlers/handlers.go
@@ -286,6 +286,104 @@ func (c *CSPHandlers) BundleAuthResendHandler(w http.ResponseWriter, r *http.Req
 	apicommon.HTTPWriteJSON(w, &AuthResponse{AuthToken: req.AuthToken})
 }
 
+// BundleSignRHandler godoc
+//
+//	@Summary		Get blind signing R point for a bundle process
+//	@Description	Begin a blind signing session. Returns the R point the voter needs to blind their
+//	@Description	ballot address, together with the voter's weight and a non-blind weight attestation
+//	@Description	(ECDSA signature over {processID, weight}) for weighted censuses.
+//	@Description	The R point is valid for one sign call; it is discarded after use or on the next
+//	@Description	call to this endpoint for the same (token, process) pair.
+//	@Tags			process
+//	@Accept			json
+//	@Produce		json
+//	@Param			bundleId	path		string					true	"Bundle ID"
+//	@Param			request		body		handlers.SignRRequest	true	"Auth token and process ID"
+//	@Success		200			{object}	handlers.SignRResponse
+//	@Failure		400			{object}	errors.Error	"Invalid input data"
+//	@Failure		401			{object}	errors.Error	"Unauthorized or token not verified"
+//	@Failure		404			{object}	errors.Error	"Bundle not found or process not in bundle"
+//	@Failure		500			{object}	errors.Error	"Internal server error"
+//	@Router			/process/bundle/{bundleId}/sign-r [post]
+func (c *CSPHandlers) BundleSignRHandler(w http.ResponseWriter, r *http.Request) {
+	bundleID, ok := parseBundleID(w, r)
+	if !ok {
+		return
+	}
+	bundle, ok := c.getBundle(w, *bundleID)
+	if !ok {
+		return
+	}
+
+	var req SignRRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		errors.ErrMalformedBody.Write(w)
+		return
+	}
+	if len(req.AuthToken) == 0 {
+		errors.ErrUnauthorized.Withf("missing auth token").Write(w)
+		return
+	}
+	if len(req.ProcessID) == 0 {
+		errors.ErrInvalidData.Withf("missing process ID").Write(w)
+		return
+	}
+
+	auth, ok := c.getAuthInfo(w, req.AuthToken)
+	if !ok {
+		return
+	}
+	if !auth.Verified {
+		errors.ErrUnauthorized.WithErr(csp.ErrAuthTokenNotVerified).Write(w)
+		return
+	}
+
+	processID, found := findProcessInBundle(bundle, req.ProcessID)
+	if !found {
+		errors.ErrUnauthorized.Withf("process not found in bundle").Write(w)
+		return
+	}
+
+	oid, err := primitive.ObjectIDFromHex(auth.UserID.String())
+	if err != nil {
+		errors.ErrUnauthorized.WithErr(fmt.Errorf("invalid user ID in token: %w", err)).Write(w)
+		return
+	}
+	member, err := c.mainDB.OrgMember(bundle.OrgAddress, oid.Hex())
+	if err != nil {
+		errors.ErrUserNotFound.WithErr(err).Write(w)
+		return
+	}
+	census, err := c.mainDB.Census(bundle.Census.ID.Hex())
+	if err != nil {
+		errors.ErrCensusNotFound.WithErr(err).Write(w)
+		return
+	}
+
+	weight := uint64(1)
+	if census.Weighted {
+		weight = member.Weight
+	}
+
+	tokenR, weightCert, err := c.csp.GetBlindR(req.AuthToken, processID, weight)
+	if err != nil {
+		switch err {
+		case csp.ErrAuthTokenNotVerified,
+			csp.ErrProcessAlreadyConsumed:
+			errors.ErrUnauthorized.WithErr(err).Write(w)
+		default:
+			errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		}
+		return
+	}
+
+	apicommon.HTTPWriteJSON(w, &SignRResponse{
+		TokenR:     tokenR,
+		Weight:     big.NewInt(int64(weight)).Bytes(),
+		WeightCert: weightCert,
+	})
+}
+
 // parseSignRequest parses the sign request from the request body
 func parseSignRequest(w http.ResponseWriter, r *http.Request) (*SignRequest, bool) {
 	var req SignRequest
@@ -333,7 +431,7 @@ func parseAddress(w http.ResponseWriter, payload string) (*internal.HexBytes, bo
 	return address, true
 }
 
-// signAndRespond signs the request and sends the response
+// signAndRespond signs with ECDSA (plain) and sends the response.
 func (c *CSPHandlers) signAndRespond(w http.ResponseWriter, authToken, address, processID, weight internal.HexBytes) {
 	log.Debugw("new CSP sign request", "address", address, "procId", processID, "weight", weight)
 
@@ -344,6 +442,26 @@ func (c *CSPHandlers) signAndRespond(w http.ResponseWriter, authToken, address, 
 	}
 
 	apicommon.HTTPWriteJSON(w, &AuthResponse{Signature: signature, Weight: weight})
+}
+
+// signBlindAndRespond performs the blind signing step and sends the response.
+// blindedMsg is the blinded ballot produced client-side using the R point from
+// BundleSignRHandler. The returned signature must be unblinded client-side.
+func (c *CSPHandlers) signBlindAndRespond(w http.ResponseWriter, authToken, blindedMsg, processID internal.HexBytes) {
+	log.Debugw("new CSP blind sign request", "procId", processID)
+
+	signature, err := c.csp.SignBlindMsg(authToken, processID, blindedMsg)
+	if err != nil {
+		switch err {
+		case csp.ErrAuthTokenNotVerified, csp.ErrBlindRNotFound, csp.ErrProcessAlreadyConsumed:
+			errors.ErrUnauthorized.WithErr(err).Write(w)
+		default:
+			errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		}
+		return
+	}
+
+	apicommon.HTTPWriteJSON(w, &AuthResponse{Signature: signature})
 }
 
 // BundleSignHandler godoc
@@ -428,12 +546,22 @@ func (c *CSPHandlers) BundleSignHandler(w http.ResponseWriter, r *http.Request) 
 	// 	return
 	// }
 
-	// Parse the address from the payload
+	// Blind signing mode: TokenR is set, Payload is the blinded message.
+	if len(req.TokenR) > 0 {
+		blindedMsg := new(internal.HexBytes)
+		if err := blindedMsg.ParseString(req.Payload); err != nil {
+			errors.ErrMalformedBody.WithErr(err).Write(w)
+			return
+		}
+		c.signBlindAndRespond(w, req.AuthToken, *blindedMsg, processID)
+		return
+	}
+
+	// Plain ECDSA mode: Payload is the voter's Ethereum address.
 	address, ok := parseAddress(w, req.Payload)
 	if !ok {
 		return
 	}
-	// Sign the request and send the response
 	c.signAndRespond(w, req.AuthToken, *address, processID, big.NewInt(int64(weight)).Bytes())
 }
 
@@ -684,12 +812,14 @@ func (c *CSPHandlers) ConsumedAddressHandler(w http.ResponseWriter, r *http.Requ
 		errors.ErrUserNoVoted.Write(w)
 		return
 	}
-	// return the address used to sign the process and the nullifier
-	apicommon.HTTPWriteJSON(w, &ConsumedAddressResponse{
-		Address:   cspProcess.UsedAddress,
-		Nullifier: state.GenerateNullifier(common.BytesToAddress(cspProcess.UsedAddress), *processID),
-		At:        cspProcess.UsedAt,
-	})
+	resp := ConsumedAddressResponse{At: cspProcess.UsedAt}
+	// for blind-signed processes the CSP never learns the address, so both
+	// Address and Nullifier remain nil.
+	if len(cspProcess.UsedAddress) > 0 {
+		resp.Address = cspProcess.UsedAddress
+		resp.Nullifier = state.GenerateNullifier(common.BytesToAddress(cspProcess.UsedAddress), *processID)
+	}
+	apicommon.HTTPWriteJSON(w, &resp)
 }
 
 // validateContactInfo checks if at least one contact method is provided

--- a/csp/handlers/types.go
+++ b/csp/handlers/types.go
@@ -101,9 +101,28 @@ type ConsumedAddressRequest struct {
 // ConsumedAddressResponse defines the payload for the response to the
 // request to get the if a token was used and which address was used.
 // It includes the address, the nullifier, and the timestamp of the
-// usage.
+// usage. For blind-signed processes Address and Nullifier are nil.
 type ConsumedAddressResponse struct {
-	Address   internal.HexBytes `json:"authToken" swaggertype:"string" format:"hex" example:"deadbeef"`
-	Nullifier internal.HexBytes `json:"nullifier" swaggertype:"string" format:"hex" example:"deadbeef"`
+	Address   internal.HexBytes `json:"authToken,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`
+	Nullifier internal.HexBytes `json:"nullifier,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`
 	At        time.Time         `json:"at"`
+}
+
+// SignRRequest defines the payload for requesting the blind signing R point.
+// The client submits its verified auth token and the process ID it intends to
+// vote in. The server returns the R point and a weight attestation.
+type SignRRequest struct {
+	AuthToken internal.HexBytes `json:"authToken" swaggertype:"string" format:"hex" example:"deadbeef"`
+	ProcessID internal.HexBytes `json:"electionId" swaggertype:"string" format:"hex" example:"deadbeef"`
+}
+
+// SignRResponse defines the payload returned by the sign-r endpoint.
+// TokenR is the R point (33 bytes, compressed secp256k1) the client uses to
+// blind its ballot address. Weight is the voter's weight for this process.
+// WeightCert is a non-blind ECDSA signature over {processID, weight} that the
+// chain can verify independently from the anonymous blind credential.
+type SignRResponse struct {
+	TokenR     internal.HexBytes `json:"tokenR" swaggertype:"string" format:"hex" example:"deadbeef"`
+	Weight     internal.HexBytes `json:"weight,omitempty" swaggertype:"string" format:"hex" example:"2a"`
+	WeightCert internal.HexBytes `json:"weightCert,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`
 }

--- a/csp/sign.go
+++ b/csp/sign.go
@@ -4,7 +4,9 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"math/big"
 
+	blind "github.com/arnaucube/go-blindsecp256k1"
 	"github.com/vocdoni/saas-backend/csp/signers"
 	"github.com/vocdoni/saas-backend/csp/signers/saltedkey"
 	"github.com/vocdoni/saas-backend/db"
@@ -144,4 +146,133 @@ func (c *CSP) isLocked(userID, processID internal.HexBytes) bool {
 func (c *CSP) unlock(userID, processID internal.HexBytes) {
 	id := sha256.Sum256(append(userID, processID...))
 	c.signerLock.Delete(id)
+}
+
+// blindKKey returns the sync.Map key used to store the ephemeral secretK for a
+// blind signing session keyed by (userID, processID).
+func blindKKey(userID, processID internal.HexBytes) [32]byte {
+	return sha256.Sum256(append(userID, processID...))
+}
+
+// GetBlindR begins a blind signing session for the authenticated voter. It
+// validates the auth token, checks the process is not yet consumed, generates
+// a fresh blind-signing keypair (secretK, R), stores secretK ephemerally, and
+// returns:
+//   - tokenR: the R point (33 bytes, compressed) the voter needs to blind their ballot.
+//   - weight: the voter's weight for this process (1 for non-weighted censuses).
+//   - weightCert: a non-blind ECDSA signature over {processID, weight}, allowing
+//     the chain to verify the weight independently of the anonymous blind credential.
+func (c *CSP) GetBlindR(
+	token, processID internal.HexBytes,
+	memberWeight uint64,
+) (tokenR internal.HexBytes, weightCert internal.HexBytes, err error) {
+	authTokenData, err := c.Storage.CSPAuth(token)
+	if err != nil {
+		return nil, nil, ErrInvalidAuthToken
+	}
+	if !authTokenData.Verified {
+		return nil, nil, ErrAuthTokenNotVerified
+	}
+	if consumed, err := c.Storage.IsCSPProcessConsumed(authTokenData.UserID, processID); err != nil {
+		switch err {
+		case db.ErrTokenNotVerified:
+			return nil, nil, ErrAuthTokenNotVerified
+		default:
+			return nil, nil, ErrSign
+		}
+	} else if consumed {
+		return nil, nil, ErrProcessAlreadyConsumed
+	}
+
+	// generate ephemeral blind signing parameters
+	k, r, err := blind.NewRequestParameters()
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: %w", ErrSign, err)
+	}
+
+	// store k keyed by (userID, processID) for retrieval during the sign step
+	key := blindKKey(authTokenData.UserID, processID)
+	c.blindKStore.Store(key, k)
+
+	// build weight attestation: ECDSA-sign {processID, weight_big_endian} with
+	// the process salt so the signature is deterministic per (process, weight).
+	weightBytes := new(big.Int).SetUint64(memberWeight).Bytes()
+	weightMsg, err := proto.Marshal(&models.CAbundle{
+		ProcessId:  processID,
+		VoteWeight: weightBytes,
+	})
+	if err != nil {
+		c.blindKStore.Delete(key)
+		return nil, nil, fmt.Errorf("%w: marshal weight bundle: %w", ErrWeightAttestation, err)
+	}
+	salt := [saltedkey.SaltSize]byte{}
+	if len(processID) < saltedkey.SaltSize {
+		c.blindKStore.Delete(key)
+		return nil, nil, ErrInvalidSalt
+	}
+	copy(salt[:], processID[:saltedkey.SaltSize])
+	cert, err := c.Signer.SignECDSA(salt, weightMsg)
+	if err != nil {
+		c.blindKStore.Delete(key)
+		return nil, nil, fmt.Errorf("%w: %w", ErrWeightAttestation, err)
+	}
+
+	return r.Bytes(), cert, nil
+}
+
+// SignBlindMsg completes a blind signing session. It retrieves the stored
+// secretK for the (authToken, processID) pair, performs the blind signature on
+// blindedMsg, cleans up the ephemeral state, and marks the process as consumed.
+// The returned bytes are the raw blind signature that the voter must unblind
+// client-side using their UserSecretData.
+func (c *CSP) SignBlindMsg(
+	token, processID, blindedMsg internal.HexBytes,
+) (internal.HexBytes, error) {
+	authTokenData, err := c.Storage.CSPAuth(token)
+	if err != nil {
+		return nil, ErrInvalidAuthToken
+	}
+	if !authTokenData.Verified {
+		return nil, ErrAuthTokenNotVerified
+	}
+
+	key := blindKKey(authTokenData.UserID, processID)
+	kVal, ok := c.blindKStore.Load(key)
+	if !ok {
+		return nil, ErrBlindRNotFound
+	}
+	k, ok := kVal.(*big.Int)
+	if !ok {
+		return nil, ErrBlindRNotFound
+	}
+	// always clean up the ephemeral k regardless of outcome
+	defer c.blindKStore.Delete(key)
+
+	if consumed, err := c.Storage.IsCSPProcessConsumed(authTokenData.UserID, processID); err != nil {
+		switch err {
+		case db.ErrTokenNotVerified:
+			return nil, ErrAuthTokenNotVerified
+		default:
+			return nil, ErrSign
+		}
+	} else if consumed {
+		return nil, ErrProcessAlreadyConsumed
+	}
+
+	salt := [saltedkey.SaltSize]byte{}
+	if len(processID) < saltedkey.SaltSize {
+		return nil, ErrInvalidSalt
+	}
+	copy(salt[:], processID[:saltedkey.SaltSize])
+
+	sig, err := c.Signer.SignBlind(salt, blindedMsg, k)
+	if err != nil {
+		return nil, errors.Join(ErrSign, err)
+	}
+
+	if err := c.Storage.ConsumeCSPProcessBlind(token, processID); err != nil {
+		log.Warn(err)
+		return nil, ErrSign
+	}
+	return sig, nil
 }

--- a/csp/sign_test.go
+++ b/csp/sign_test.go
@@ -2,9 +2,12 @@ package csp
 
 import (
 	"context"
+	"crypto/sha256"
+	"math/big"
 	"testing"
 	"time"
 
+	blind "github.com/arnaucube/go-blindsecp256k1"
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/saas-backend/csp/signers"
 	"github.com/vocdoni/saas-backend/csp/signers/saltedkey"
@@ -15,6 +18,27 @@ import (
 	"go.vocdoni.io/proto/build/go/models"
 	"google.golang.org/protobuf/proto"
 )
+
+func newTestCSP(t *testing.T) (*CSP, *db.MongoStorage) {
+	t.Helper()
+	testDB, err := db.New(testMongoURI, test.RandomDatabaseName())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	c, err := New(ctx, &Config{
+		DB:                       testDB,
+		MailService:              testMailService,
+		SMSService:               testSMSService,
+		NotificationThrottleTime: time.Second,
+		NotificationCoolDownTime: time.Second * 5,
+		RootKey:                  *testRootKey,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c, testDB
+}
 
 func TestSign(t *testing.T) {
 	c := qt.New(t)
@@ -223,5 +247,134 @@ func TestFinishSaltedKeySigner(t *testing.T) {
 		c.Assert(status.UsedAt.IsZero(), qt.IsFalse)
 		c.Assert(status.UsedAt.After(time.Now().Add(-time.Second)), qt.IsTrue)
 		c.Assert(status.TimesVoted, qt.Equals, 1)
+	})
+}
+
+func TestGetBlindR(t *testing.T) {
+	c := qt.New(t)
+
+	csp, testDB := newTestCSP(t)
+
+	c.Run("invalid auth token", func(c *qt.C) {
+		_, _, err := csp.GetBlindR(testToken, testPID, 1)
+		c.Assert(err, qt.ErrorIs, ErrInvalidAuthToken)
+	})
+
+	c.Run("token not verified", func(c *qt.C) {
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		_, _, err := csp.GetBlindR(testToken, testPID, 1)
+		c.Assert(err, qt.ErrorIs, ErrAuthTokenNotVerified)
+	})
+
+	c.Run("process already consumed", func(c *qt.C) {
+		pid := internal.HexBytes(util.RandomBytes(32))
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		c.Assert(csp.Storage.VerifyCSPAuth(testToken), qt.IsNil)
+		for i := 0; i <= 10; i++ {
+			c.Assert(csp.Storage.ConsumeCSPProcessBlind(testToken, pid), qt.IsNil)
+		}
+		_, _, err := csp.GetBlindR(testToken, pid, 1)
+		c.Assert(err, qt.ErrorIs, ErrProcessAlreadyConsumed)
+	})
+
+	c.Run("invalid salt (pid too short)", func(c *qt.C) {
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		c.Assert(csp.Storage.VerifyCSPAuth(testToken), qt.IsNil)
+		_, _, err := csp.GetBlindR(testToken, util.RandomBytes(saltedkey.SaltSize-1), 1)
+		c.Assert(err, qt.ErrorIs, ErrInvalidSalt)
+	})
+
+	c.Run("success", func(c *qt.C) {
+		pid := internal.HexBytes(util.RandomBytes(32))
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		c.Assert(csp.Storage.VerifyCSPAuth(testToken), qt.IsNil)
+		tokenR, weightCert, err := csp.GetBlindR(testToken, pid, testUserWeight)
+		c.Assert(err, qt.IsNil)
+		c.Assert(tokenR, qt.Not(qt.IsNil))
+		c.Assert(tokenR, qt.HasLen, 33) // compressed secp256k1 point
+		c.Assert(weightCert, qt.Not(qt.IsNil))
+		c.Assert(weightCert, qt.Not(qt.HasLen), 0)
+	})
+}
+
+func TestSignBlindMsg(t *testing.T) {
+	c := qt.New(t)
+
+	csp, testDB := newTestCSP(t)
+
+	c.Run("invalid auth token", func(c *qt.C) {
+		_, err := csp.SignBlindMsg(testToken, testPID, []byte("blinded"))
+		c.Assert(err, qt.ErrorIs, ErrInvalidAuthToken)
+	})
+
+	c.Run("token not verified", func(c *qt.C) {
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		_, err := csp.SignBlindMsg(testToken, testPID, []byte("blinded"))
+		c.Assert(err, qt.ErrorIs, ErrAuthTokenNotVerified)
+	})
+
+	c.Run("no pending blind session", func(c *qt.C) {
+		pid := internal.HexBytes(util.RandomBytes(32))
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		c.Assert(csp.Storage.VerifyCSPAuth(testToken), qt.IsNil)
+		_, err := csp.SignBlindMsg(testToken, pid, []byte("blinded"))
+		c.Assert(err, qt.ErrorIs, ErrBlindRNotFound)
+	})
+
+	c.Run("process already consumed", func(c *qt.C) {
+		pid := internal.HexBytes(util.RandomBytes(32))
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		c.Assert(csp.Storage.VerifyCSPAuth(testToken), qt.IsNil)
+		_, _, err := csp.GetBlindR(testToken, pid, 1)
+		c.Assert(err, qt.IsNil)
+		for i := 0; i <= 10; i++ {
+			c.Assert(csp.Storage.ConsumeCSPProcessBlind(testToken, pid), qt.IsNil)
+		}
+		_, err = csp.SignBlindMsg(testToken, pid, []byte("blinded"))
+		c.Assert(err, qt.ErrorIs, ErrProcessAlreadyConsumed)
+	})
+
+	c.Run("full round-trip", func(c *qt.C) {
+		pid := internal.HexBytes(util.RandomBytes(32))
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		c.Assert(csp.Storage.VerifyCSPAuth(testToken), qt.IsNil)
+
+		// step 1: server returns R
+		tokenR, _, err := csp.GetBlindR(testToken, pid, testUserWeight)
+		c.Assert(err, qt.IsNil)
+
+		// client: decompress R, blind the message
+		r, err := blind.NewPointFromBytes(tokenR)
+		c.Assert(err, qt.IsNil)
+		msgHash := sha256.Sum256(testAddress)
+		msgBlinded, userSecretData, err := blind.Blind(new(big.Int).SetBytes(msgHash[:]), r)
+		c.Assert(err, qt.IsNil)
+
+		// step 2: server blind-signs
+		blindSig, err := csp.SignBlindMsg(testToken, pid, msgBlinded.Bytes())
+		c.Assert(err, qt.IsNil)
+		c.Assert(blindSig, qt.Not(qt.IsNil))
+
+		// client: unblind the signature
+		sig := blind.Unblind(new(big.Int).SetBytes(blindSig), userSecretData)
+
+		// verify against the salted pub key
+		salt := [saltedkey.SaltSize]byte{}
+		copy(salt[:], pid[:saltedkey.SaltSize])
+		saltedPub, err := saltedkey.SaltBlindPubKey(csp.Signer.BlindPubKey(), salt)
+		c.Assert(err, qt.IsNil)
+		c.Assert(blind.Verify(new(big.Int).SetBytes(msgHash[:]), sig, saltedPub), qt.IsTrue)
+
+		// process is consumed; a second sign attempt must fail
+		_, err = csp.SignBlindMsg(testToken, pid, msgBlinded.Bytes())
+		c.Assert(err, qt.ErrorIs, ErrBlindRNotFound)
 	})
 }

--- a/db/csp.go
+++ b/db/csp.go
@@ -234,6 +234,53 @@ func (ms *MongoStorage) ConsumeCSPProcess(token, processID, address internal.Hex
 	return nil
 }
 
+// ConsumeCSPProcessBlind marks a CSP process as consumed without recording an
+// address. It is used for blind-signature flows where the CSP never learns the
+// voter's Ethereum address.
+func (ms *MongoStorage) ConsumeCSPProcessBlind(token, processID internal.HexBytes) error {
+	if token == nil || processID == nil {
+		return ErrBadInputs
+	}
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	tokenData, err := ms.fetchCSPAuthFromDB(ctx, token)
+	if err != nil {
+		return err
+	}
+	tokenStatus, err := ms.fetchCSPProcessFromDB(ctx, tokenData.UserID, processID)
+	if err != nil && !errors.Is(err, ErrTokenNotFound) {
+		return err
+	}
+	if tokenStatus != nil && tokenStatus.TimesVoted > MaxVoteOverwritesPerProcess {
+		return ErrProcessAlreadyConsumed
+	}
+	timesVoted := 1
+	if tokenStatus != nil {
+		timesVoted = tokenStatus.TimesVoted + 1
+	}
+	id := cspAuthTokenStatusID(tokenData.UserID, processID)
+	updateDoc, err := dynamicUpdateDocument(CSPProcess{
+		ID:         id,
+		UserID:     tokenData.UserID,
+		ProcessID:  processID,
+		Used:       true,
+		UsedAt:     time.Now(),
+		UsedToken:  token,
+		TimesVoted: timesVoted,
+	}, nil)
+	if err != nil {
+		return errors.Join(ErrPrepareDocument, err)
+	}
+	filter := bson.M{"_id": id}
+	opts := options.Update().SetUpsert(true)
+	if _, err = ms.cspTokensStatus.UpdateOne(ctx, filter, updateDoc, opts); err != nil {
+		return errors.Join(ErrStoreToken, err)
+	}
+	return nil
+}
+
 func (ms *MongoStorage) fetchCSPAuthFromDB(ctx context.Context, token internal.HexBytes) (*CSPAuth, error) {
 	tokenData := new(CSPAuth)
 	if err := ms.cspTokens.FindOne(ctx, bson.M{"_id": token}).Decode(tokenData); err != nil {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1376,6 +1376,32 @@ definitions:
         format: hex
         type: string
     type: object
+  handlers.SignRRequest:
+    properties:
+      authToken:
+        example: deadbeef
+        format: hex
+        type: string
+      electionId:
+        example: deadbeef
+        format: hex
+        type: string
+    type: object
+  handlers.SignRResponse:
+    properties:
+      tokenR:
+        example: deadbeef
+        format: hex
+        type: string
+      weight:
+        example: 2a
+        format: hex
+        type: string
+      weightCert:
+        example: deadbeef
+        format: hex
+        type: string
+    type: object
   handlers.SignRequest:
     properties:
       authToken:
@@ -3985,6 +4011,54 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
       summary: Sign a process in a bundle
+      tags:
+      - process
+  /process/bundle/{bundleId}/sign-r:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Begin a blind signing session. Returns the R point the voter needs to blind their
+        ballot address, together with the voter's weight and a non-blind weight attestation
+        (ECDSA signature over {processID, weight}) for weighted censuses.
+        The R point is valid for one sign call; it is discarded after use or on the next
+        call to this endpoint for the same (token, process) pair.
+      parameters:
+      - description: Bundle ID
+        in: path
+        name: bundleId
+        required: true
+        type: string
+      - description: Auth token and process ID
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.SignRRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.SignRResponse'
+        "400":
+          description: Invalid input data
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "401":
+          description: Unauthorized or token not verified
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "404":
+          description: Bundle not found or process not in bundle
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+      summary: Get blind signing R point for a bundle process
       tags:
       - process
   /process/bundle/{bundleId}/weight:


### PR DESCRIPTION
## Summary

- The CSP was signing voter addresses with plain ECDSA
- Switch to secp256k1 blind signatures (already implemented in `saltedkey` but never wired up) so the CSP authorises a voter without ever seeing the Ethereum address they cast with
- For weighted censuses, a separate non-blind ECDSA weight attestation over `{processId, weight}` is issued at the R-point step, so the chain can verify weight independently of the anonymous credential

## New API flow

```
POST /process/bundle/{bundleId}/sign-r
  in:  { authToken, electionId }
  out: { tokenR (33-byte R point), weight, weightCert (ECDSA sig over {processId, weight}) }

  → client: blindedMsg, userSecretData = blind(bundle{processId, address}, tokenR)

POST /process/bundle/{bundleId}/sign   (TokenR field set)
  in:  { authToken, tokenR, payload: hex(blindedMsg), electionId }
  out: { signature: blindSig }

  → client: validSig = unblind(blindSig, userSecretData)
```

The plain ECDSA path is preserved when `TokenR` is absent, keeping all existing integrations working.

## Changes

- `csp/csp.go` — `blindKStore sync.Map` for ephemeral secretK; `BlindPubKey()` method
- `csp/errors.go` — `ErrBlindRNotFound`, `ErrWeightAttestation`
- `csp/sign.go` — `GetBlindR()`, `SignBlindMsg()`, `blindKKey()`
- `db/csp.go` — `ConsumeCSPProcessBlind()` (marks consumed without storing address)
- `csp/handlers/types.go` — `SignRRequest`, `SignRResponse`; `ConsumedAddressResponse` address/nullifier now `omitempty`
- `csp/handlers/handlers.go` — `BundleSignRHandler`, `signBlindAndRespond()`; `BundleSignHandler` dispatches on `TokenR != nil`; `ConsumedAddressHandler` handles nil address gracefully
- `api/routes.go` + `api/api.go` — register `POST /process/bundle/{bundleId}/sign-r`

## Test plan

- [x] Run `make test` — existing CSP auth and sign tests must pass unchanged
- [ ] Unit test `GetBlindR` / `SignBlindMsg` round-trip (mirrors `TestBlindsaltedKey` in `saltedkey_test.go`)
- [ ] Verify `ConsumedAddressHandler` returns `{at: ...}` with no address/nullifier for a blind-signed process
- [x] Verify the plain ECDSA path still works when `TokenR` is omitted from the sign request
- [x] Run `make swagger` to regenerate `docs/swagger.yaml`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)