### PR TITLE
fix(members): normalize emails for case-insensitive CSP login

### DIFF
--- a/csp/handlers/handlers.go
+++ b/csp/handlers/handlers.go
@@ -889,7 +889,9 @@ func (c *CSPHandlers) authFirstStep(
 		return nil, errors.ErrInvalidData.WithErr(err)
 	}
 
-	// create an empty member and assign the input data where applicable
+	// create an empty member and assign the input data where applicable.
+	// The email is normalized to lowercase so the recomputed login hash matches
+	// the (also normalized) email stored at member-creation time.
 	inputMember := &db.OrgMember{
 		OrgAddress:   census.OrgAddress,
 		Name:         req.Name,
@@ -897,7 +899,7 @@ func (c *CSPHandlers) authFirstStep(
 		MemberNumber: req.MemberNumber,
 		NationalID:   req.NationalID,
 		BirthDate:    req.BirthDate,
-		Email:        req.Email,
+		Email:        internal.NormalizeEmail(req.Email),
 		Phone:        phone,
 	}
 

--- a/db/migration_normalize_emails_test.go
+++ b/db/migration_normalize_emails_test.go
@@ -11,11 +11,11 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-// runNormalizeEmailsMigration invokes migration 0012's Up function directly
+// runNormalizeEmailsMigration invokes migration 0015's Up function directly
 // against the current test database state.
 func runNormalizeEmailsMigration(t *testing.T) {
 	t.Helper()
-	mig, ok := migrations.AsMap()[12]
+	mig, ok := migrations.AsMap()[15]
 	qt.Assert(t, ok, qt.IsTrue)
 	err := mig.Up(context.Background(), testDB.DBClient.Database(testDB.database))
 	qt.Assert(t, err, qt.IsNil)

--- a/db/migration_normalize_emails_test.go
+++ b/db/migration_normalize_emails_test.go
@@ -1,0 +1,150 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/migrations"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// runNormalizeEmailsMigration invokes migration 0012's Up function directly
+// against the current test database state.
+func runNormalizeEmailsMigration(t *testing.T) {
+	t.Helper()
+	mig, ok := migrations.AsMap()[12]
+	qt.Assert(t, ok, qt.IsTrue)
+	err := mig.Up(context.Background(), testDB.DBClient.Database(testDB.database))
+	qt.Assert(t, err, qt.IsNil)
+}
+
+func TestNormalizeMemberEmailsMigration(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	org := &Organization{Address: testOrgAddress, Active: true, CreatedAt: time.Now()}
+	c.Assert(testDB.SetOrganization(org), qt.IsNil)
+
+	t.Run("normalizes email and recomputes login hashes", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		c.Assert(testDB.SetOrganization(org), qt.IsNil)
+
+		// A mail census whose login hash includes the email.
+		census := &Census{
+			OrgAddress:  testOrgAddress,
+			AuthFields:  OrgMemberAuthFields{OrgMemberAuthFieldsMemberNumber},
+			TwoFaFields: OrgMemberTwoFaFields{OrgMemberTwoFaFieldEmail},
+			CreatedAt:   time.Now(),
+		}
+		censusID, err := testDB.SetCensus(census)
+		c.Assert(err, qt.IsNil)
+
+		// Seed a member with an uppercase email directly, bypassing the write
+		// chokepoint that would normalize it (simulating pre-existing data).
+		member := &OrgMember{
+			ID:           primitive.NewObjectID(),
+			OrgAddress:   testOrgAddress,
+			MemberNumber: "M-1",
+			Email:        "User@Example.COM",
+			CreatedAt:    time.Now(),
+		}
+		ctx := context.Background()
+		_, err = testDB.orgMembers.InsertOne(ctx, member)
+		c.Assert(err, qt.IsNil)
+
+		// Seed the participant with the uppercase-derived login hash.
+		upperHash := HashAuthTwoFaFields(*member, census.AuthFields, census.TwoFaFields)
+		participant := &CensusParticipant{
+			ParticipantID: member.ID.Hex(),
+			CensusID:      censusID,
+			LoginHash:     upperHash,
+			CreatedAt:     time.Now(),
+		}
+		_, err = testDB.censusParticipants.InsertOne(ctx, participant)
+		c.Assert(err, qt.IsNil)
+
+		runNormalizeEmailsMigration(t)
+
+		// Email is now lowercase.
+		var got OrgMember
+		c.Assert(testDB.orgMembers.FindOne(ctx, bson.M{"_id": member.ID}).Decode(&got), qt.IsNil)
+		c.Assert(got.Email, qt.Equals, "user@example.com")
+
+		// Login hash matches the canonical hash of the lowercased member.
+		lowered := *member
+		lowered.Email = "user@example.com"
+		expected := HashAuthTwoFaFields(lowered, census.AuthFields, census.TwoFaFields)
+		var gotParticipant CensusParticipant
+		c.Assert(testDB.censusParticipants.FindOne(ctx,
+			bson.M{"participantID": member.ID.Hex(), "censusId": censusID}).Decode(&gotParticipant), qt.IsNil)
+		c.Assert(gotParticipant.LoginHash, qt.DeepEquals, expected)
+		c.Assert(gotParticipant.LoginHash, qt.Not(qt.DeepEquals), upperHash)
+
+		// End-to-end: the participant is now found using a lowercase login input.
+		census.ID, err = primitive.ObjectIDFromHex(censusID)
+		c.Assert(err, qt.IsNil)
+		input := OrgMember{OrgAddress: testOrgAddress, MemberNumber: "M-1", Email: "user@example.com"}
+		found, err := testDB.CensusParticipantByLoginHash(*census, input)
+		c.Assert(err, qt.IsNil)
+		c.Assert(found.ParticipantID, qt.Equals, member.ID.Hex())
+	})
+
+	t.Run("skips members that would collide after lowercasing", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		c.Assert(testDB.SetOrganization(org), qt.IsNil)
+
+		// Mail census with no auth fields: the login hash is derived solely from
+		// the email, so two emails differing only by case collide once lowered.
+		census := &Census{
+			OrgAddress:  testOrgAddress,
+			TwoFaFields: OrgMemberTwoFaFields{OrgMemberTwoFaFieldEmail},
+			CreatedAt:   time.Now(),
+		}
+		censusID, err := testDB.SetCensus(census)
+		c.Assert(err, qt.IsNil)
+		ctx := context.Background()
+
+		// Member already stored in lowercase form.
+		lowerMember := &OrgMember{
+			ID: primitive.NewObjectID(), OrgAddress: testOrgAddress, Email: "clash@example.com", CreatedAt: time.Now(),
+		}
+		_, err = testDB.orgMembers.InsertOne(ctx, lowerMember)
+		c.Assert(err, qt.IsNil)
+		lowerHash := HashAuthTwoFaFields(*lowerMember, census.AuthFields, census.TwoFaFields)
+		_, err = testDB.censusParticipants.InsertOne(ctx, &CensusParticipant{
+			ParticipantID: lowerMember.ID.Hex(), CensusID: censusID, LoginHash: lowerHash, CreatedAt: time.Now(),
+		})
+		c.Assert(err, qt.IsNil)
+
+		// Member stored with an uppercase variant of the same email.
+		upperMember := &OrgMember{
+			ID: primitive.NewObjectID(), OrgAddress: testOrgAddress, Email: "Clash@example.com", CreatedAt: time.Now(),
+		}
+		_, err = testDB.orgMembers.InsertOne(ctx, upperMember)
+		c.Assert(err, qt.IsNil)
+		upperHash := HashAuthTwoFaFields(*upperMember, census.AuthFields, census.TwoFaFields)
+		_, err = testDB.censusParticipants.InsertOne(ctx, &CensusParticipant{
+			ParticipantID: upperMember.ID.Hex(), CensusID: censusID, LoginHash: upperHash, CreatedAt: time.Now(),
+		})
+		c.Assert(err, qt.IsNil)
+
+		runNormalizeEmailsMigration(t)
+
+		// The uppercase member is left untouched (email and hash unchanged).
+		var gotUpper OrgMember
+		c.Assert(testDB.orgMembers.FindOne(ctx, bson.M{"_id": upperMember.ID}).Decode(&gotUpper), qt.IsNil)
+		c.Assert(gotUpper.Email, qt.Equals, "Clash@example.com")
+		var gotUpperParticipant CensusParticipant
+		c.Assert(testDB.censusParticipants.FindOne(ctx,
+			bson.M{"participantID": upperMember.ID.Hex(), "censusId": censusID}).Decode(&gotUpperParticipant), qt.IsNil)
+		c.Assert(gotUpperParticipant.LoginHash, qt.DeepEquals, upperHash)
+
+		// The already-lowercase member is untouched too.
+		var gotLower OrgMember
+		c.Assert(testDB.orgMembers.FindOne(ctx, bson.M{"_id": lowerMember.ID}).Decode(&gotLower), qt.IsNil)
+		c.Assert(gotLower.Email, qt.Equals, "clash@example.com")
+	})
+}

--- a/db/org_members.go
+++ b/db/org_members.go
@@ -171,8 +171,11 @@ func prepareOrgMember(org *Organization, m *OrgMember, salt string, currentTime 
 	}
 	member.OrgAddress = org.Address
 
-	// check if mail is valid
+	// normalize and validate the email. Normalizing to lowercase here is the
+	// single write chokepoint that keeps every member email (and the login
+	// hashes derived from it) case-insensitive across all write paths.
 	if member.Email != "" {
+		member.Email = internal.NormalizeEmail(member.Email)
 		if _, err := mail.ParseAddress(member.Email); err != nil {
 			errors = append(errors, fmt.Errorf("could not parse email: %s %v", member.Email, err))
 			// If email is invalid, set it to empty and store the error

--- a/db/org_members.go
+++ b/db/org_members.go
@@ -171,11 +171,9 @@ func prepareOrgMember(org *Organization, m *OrgMember, salt string, currentTime 
 	}
 	member.OrgAddress = org.Address
 
-	// normalize and validate the email. Normalizing to lowercase here is the
-	// single write chokepoint that keeps every member email (and the login
-	// hashes derived from it) case-insensitive across all write paths.
+	// normalize and validate the email
+	member.Email = internal.NormalizeEmail(member.Email)
 	if member.Email != "" {
-		member.Email = internal.NormalizeEmail(member.Email)
 		if _, err := mail.ParseAddress(member.Email); err != nil {
 			errors = append(errors, fmt.Errorf("could not parse email: %s %v", member.Email, err))
 			// If email is invalid, set it to empty and store the error

--- a/db/org_members_test.go
+++ b/db/org_members_test.go
@@ -298,6 +298,24 @@ func TestOrgMembers(t *testing.T) {
 		_, err = testDB.DeleteOrgMembers(common.Address{}, []string{"some-id"})
 		c.Assert(err, qt.Equals, ErrInvalidData)
 	})
+
+	t.Run("EmailNormalization", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		c.Assert(testDB.SetOrganization(&Organization{Address: testOrgAddress}), qt.IsNil)
+
+		member := &OrgMember{
+			OrgAddress:   testOrgAddress,
+			Email:        "  Mixed.Case@Example.COM ",
+			MemberNumber: testMemberNumber,
+			Name:         testName,
+		}
+		memberOID, err := testDB.SetOrgMember(testSalt, member)
+		c.Assert(err, qt.IsNil)
+
+		stored, err := testDB.OrgMember(testOrgAddress, memberOID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(stored.Email, qt.Equals, "mixed.case@example.com")
+	})
 }
 
 type orgMembersByFieldFixture struct {

--- a/db/types.go
+++ b/db/types.go
@@ -4,10 +4,8 @@ package db
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -385,8 +383,7 @@ func HashAuthTwoFaFields(memberData OrgMember, authFields OrgMemberAuthFields, t
 			continue
 		}
 	}
-	slices.Sort(data)
-	return sha256.New().Sum(fmt.Append(nil, data))
+	return internal.HashSortedFields(data)
 }
 
 type OrgMemberAggregationResults struct {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"math/big"
 	"regexp"
+	"slices"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/nyaruka/phonenumbers"
@@ -27,6 +29,29 @@ var emailRegex = regexp.MustCompile(EmailRegexTemplate)
 // ValidEmail helper function allows to validate an email address.
 func ValidEmail(email string) bool {
 	return emailRegex.MatchString(email)
+}
+
+// NormalizeEmail returns the canonical form of an email address used for
+// storage and login matching: trimmed of surrounding whitespace and
+// lowercased. Storing and comparing emails in this canonical form makes the
+// CSP 2FA login case-insensitive.
+func NormalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
+
+// HashSortedFields sorts the given field values and returns the login-hash
+// digest used to look up census participants during CSP authentication.
+//
+// IMPORTANT: the construction below is intentional and MUST NOT be "fixed".
+// sha256.New().Sum(b) appends the digest of what has been written to the
+// hasher (nothing, here) to b, so the returned bytes are the Go-formatted
+// representation of the sorted slice followed by the SHA-256 of the empty
+// input. Every loginHash/loginHashEmail already stored in the database depends
+// on this exact, byte-for-byte behaviour; changing it would invalidate every
+// stored hash and lock out every voter.
+func HashSortedFields(data []string) []byte {
+	slices.Sort(data)
+	return sha256.New().Sum(fmt.Append(nil, data))
 }
 
 // SanitizeAndVerifyPhoneNumber helper function allows to sanitize and verify a phone number

--- a/migrations/0012_normalize_member_emails.go
+++ b/migrations/0012_normalize_member_emails.go
@@ -1,0 +1,272 @@
+package migrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/vocdoni/saas-backend/internal"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.vocdoni.io/dvote/log"
+)
+
+func init() {
+	AddMigration(12, "normalize_member_emails", upNormalizeMemberEmails, downNormalizeMemberEmails)
+}
+
+// memberHashDoc holds the subset of an orgMember document needed to recompute
+// the census participant login hashes. Phone is decoded as raw bytes (the
+// driver unwraps the binData payload), matching string(HashedPhone) in the db
+// package.
+type memberHashDoc struct {
+	ID           primitive.ObjectID `bson:"_id"`
+	Email        string             `bson:"email"`
+	Phone        []byte             `bson:"phone"`
+	MemberNumber string             `bson:"memberNumber"`
+	NationalID   string             `bson:"nationalId"`
+	Name         string             `bson:"name"`
+	Surname      string             `bson:"surname"`
+	BirthDate    string             `bson:"birthDate"`
+}
+
+// censusHashDoc holds the census authentication configuration needed to know
+// which fields feed each login hash.
+type censusHashDoc struct {
+	AuthFields  []string `bson:"orgMemberAuthFields"`
+	TwoFaFields []string `bson:"orgMemberTwoFaFields"`
+}
+
+// participantHashDoc holds the census participant identifiers needed to locate
+// and update the participant document.
+type participantHashDoc struct {
+	ParticipantID string `bson:"participantID"`
+	CensusID      string `bson:"censusId"`
+}
+
+// hashMemberFields mirrors db.HashAuthTwoFaFields exactly: it collects the
+// configured auth and twoFa field values from the member and feeds them to the
+// shared internal.HashSortedFields primitive. The append order is irrelevant
+// because HashSortedFields sorts before hashing, so only the set of values
+// must match the canonical implementation.
+func hashMemberFields(m memberHashDoc, authFields, twoFaFields []string) []byte {
+	data := make([]string, 0, len(authFields)+len(twoFaFields))
+	for _, field := range authFields {
+		switch field {
+		case "name":
+			data = append(data, m.Name)
+		case "surname":
+			data = append(data, m.Surname)
+		case "memberNumber":
+			data = append(data, m.MemberNumber)
+		case "nationalId":
+			data = append(data, m.NationalID)
+		case "birthDate":
+			data = append(data, m.BirthDate)
+		default:
+			// ignore unknown fields, mirroring db.HashAuthTwoFaFields
+		}
+	}
+	for _, field := range twoFaFields {
+		switch field {
+		case "email":
+			data = append(data, m.Email)
+		case "phone":
+			if len(m.Phone) > 0 {
+				data = append(data, string(m.Phone))
+			}
+		default:
+			// ignore unknown fields, mirroring db.HashAuthTwoFaFields
+		}
+	}
+	return internal.HashSortedFields(data)
+}
+
+// recomputeParticipantHashes mirrors db.calculateParticipantHashesBson: it
+// produces exactly the same hash keys that were originally stored for a
+// participant, so the migration never adds or removes keys.
+func recomputeParticipantHashes(m memberHashDoc, c censusHashDoc) bson.M {
+	hashes := bson.M{
+		"loginHash": hashMemberFields(m, c.AuthFields, c.TwoFaFields),
+	}
+	if len(c.TwoFaFields) == 2 && len(m.Email) > 0 {
+		hashes["loginHashEmail"] = hashMemberFields(m, c.AuthFields, []string{"email"})
+	}
+	if len(c.TwoFaFields) == 2 && len(m.Phone) > 0 {
+		hashes["loginHashPhone"] = hashMemberFields(m, c.AuthFields, []string{"phone"})
+	}
+	return hashes
+}
+
+// upNormalizeMemberEmails lowercases every stored member email that still
+// contains uppercase characters and recomputes the affected census participant
+// login hashes, so that members imported before email normalization can still
+// authenticate via the (now lowercase) CSP 2FA login.
+//
+// When lowercasing an email would make two members collide on the same login
+// hash within a census (blocked by the unique index from migration 8), the
+// whole member is skipped and logged for manual review rather than aborting the
+// migration. A skipped member keeps its uppercase email, so it is re-detected
+// on a subsequent run once the conflict is resolved.
+func upNormalizeMemberEmails(ctx context.Context, database *mongo.Database) error {
+	orgMembers := database.Collection("orgMembers")
+	censusParticipants := database.Collection("censusParticipants")
+	censuses := database.Collection("census")
+
+	// Cache censuses by their hex id to avoid one lookup per participant.
+	censusCache := make(map[string]*censusHashDoc)
+	getCensus := func(hexID string) (*censusHashDoc, error) {
+		if c, ok := censusCache[hexID]; ok {
+			return c, nil
+		}
+		oid, err := primitive.ObjectIDFromHex(hexID)
+		if err != nil {
+			censusCache[hexID] = nil
+			return nil, nil
+		}
+		var c censusHashDoc
+		err = censuses.FindOne(ctx, bson.M{"_id": oid}).Decode(&c)
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			censusCache[hexID] = nil
+			return nil, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to load census %s: %w", hexID, err)
+		}
+		censusCache[hexID] = &c
+		return &c, nil
+	}
+
+	// Coarse server-side prefilter: only members whose email contains an ASCII
+	// uppercase letter. The exact check happens in Go below.
+	cursor, err := orgMembers.Find(ctx, bson.M{"email": bson.M{"$regex": "[A-Z]"}})
+	if err != nil {
+		return fmt.Errorf("failed to list members: %w", err)
+	}
+	defer func() {
+		if err := cursor.Close(ctx); err != nil {
+			log.Warnw("error closing cursor", "error", err)
+		}
+	}()
+
+	var normalized, skipped int
+	for cursor.Next(ctx) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		var member memberHashDoc
+		if err := cursor.Decode(&member); err != nil {
+			return fmt.Errorf("failed to decode member: %w", err)
+		}
+
+		lower := internal.NormalizeEmail(member.Email)
+		if lower == member.Email {
+			continue // already normalized (the regex is only a coarse prefilter)
+		}
+		memberHex := member.ID.Hex()
+
+		// Load this member's census participants.
+		pcur, err := censusParticipants.Find(ctx, bson.M{"participantID": memberHex})
+		if err != nil {
+			return fmt.Errorf("failed to find participants for member %s: %w", memberHex, err)
+		}
+		var participants []participantHashDoc
+		if err := pcur.All(ctx, &participants); err != nil {
+			return fmt.Errorf("failed to decode participants for member %s: %w", memberHex, err)
+		}
+
+		// Recompute the hashes from the lowercased member, checking for
+		// collisions before writing anything.
+		lowered := member
+		lowered.Email = lower
+
+		type participantUpdate struct {
+			filter bson.M
+			hashes bson.M
+		}
+		var updates []participantUpdate
+		conflictCensus := ""
+
+		for _, p := range participants {
+			census, err := getCensus(p.CensusID)
+			if err != nil {
+				return err
+			}
+			if census == nil {
+				// Census missing: cannot recompute, leave this participant untouched.
+				continue
+			}
+
+			hashes := recomputeParticipantHashes(lowered, *census)
+
+			findHashes := make([]bson.M, 0, len(hashes))
+			for k, v := range hashes {
+				findHashes = append(findHashes, bson.M{k: v})
+			}
+			if len(findHashes) == 0 {
+				continue
+			}
+
+			count, err := censusParticipants.CountDocuments(ctx, bson.M{
+				"participantID": bson.M{"$ne": p.ParticipantID},
+				"censusId":      p.CensusID,
+				"$or":           findHashes,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to check collisions for member %s in census %s: %w",
+					memberHex, p.CensusID, err)
+			}
+			if count > 0 {
+				conflictCensus = p.CensusID
+				break
+			}
+
+			updates = append(updates, participantUpdate{
+				filter: bson.M{"participantID": p.ParticipantID, "censusId": p.CensusID},
+				hashes: hashes,
+			})
+		}
+
+		if conflictCensus != "" {
+			log.Warnw("skipping member email normalization due to login hash collision",
+				"memberID", memberHex, "censusID", conflictCensus, "email", member.Email)
+			skipped++
+			continue
+		}
+
+		// No conflicts: update the participant hashes, then the member email.
+		now := time.Now()
+		for _, u := range updates {
+			set := bson.M{"updatedAt": now}
+			for k, v := range u.hashes {
+				set[k] = v
+			}
+			if _, err := censusParticipants.UpdateOne(ctx, u.filter, bson.M{"$set": set}); err != nil {
+				return fmt.Errorf("failed to update participant hashes for member %s: %w", memberHex, err)
+			}
+		}
+		if _, err := orgMembers.UpdateOne(ctx,
+			bson.M{"_id": member.ID},
+			bson.M{"$set": bson.M{"email": lower, "updatedAt": now}},
+		); err != nil {
+			return fmt.Errorf("failed to update email for member %s: %w", memberHex, err)
+		}
+		normalized++
+	}
+	if err := cursor.Err(); err != nil {
+		return fmt.Errorf("cursor error iterating members: %w", err)
+	}
+
+	log.Infow("normalized member emails", "normalized", normalized, "skipped", skipped)
+	return nil
+}
+
+// downNormalizeMemberEmails is intentionally a no-op: the normalization is lossy
+// (the original mixed-case emails and their derived login hashes cannot be
+// reconstructed), so this migration is irreversible by design.
+func downNormalizeMemberEmails(_ context.Context, _ *mongo.Database) error {
+	return nil
+}

--- a/migrations/0015_normalize_member_emails.go
+++ b/migrations/0015_normalize_member_emails.go
@@ -14,7 +14,7 @@ import (
 )
 
 func init() {
-	AddMigration(12, "normalize_member_emails", upNormalizeMemberEmails, downNormalizeMemberEmails)
+	AddMigration(15, "normalize_member_emails", upNormalizeMemberEmails, downNormalizeMemberEmails)
 }
 
 // memberHashDoc holds the subset of an orgMember document needed to recompute

--- a/migrations/0015_normalize_member_emails.go
+++ b/migrations/0015_normalize_member_emails.go
@@ -139,9 +139,10 @@ func upNormalizeMemberEmails(ctx context.Context, database *mongo.Database) erro
 		return &c, nil
 	}
 
-	// Coarse server-side prefilter: only members whose email contains an ASCII
-	// uppercase letter. The exact check happens in Go below.
-	cursor, err := orgMembers.Find(ctx, bson.M{"email": bson.M{"$regex": "[A-Z]"}})
+	// Coarse server-side prefilter: only members whose email would change after
+	// normalization (leading/trailing whitespace and/or an ASCII uppercase letter).
+	// The exact check happens in Go below.
+	cursor, err := orgMembers.Find(ctx, bson.M{"email": bson.M{"$regex": "(^\\s|\\s$|[A-Z])"}})
 	if err != nil {
 		return fmt.Errorf("failed to list members: %w", err)
 	}


### PR DESCRIPTION
Member emails were stored as-typed (mixed case). The CSP 2FA login finds a participant by recomputing a login hash that includes the email, then does an exact, case-sensitive hash match, so a member stored as `User@X.com` could not be matched by `user@x.com`. The `strings.EqualFold` check in verifyEmail runs only after the hash lookup already succeeded, so it never helped with case.

Normalize at the write chokepoint and at login, and backfill existing data:

- internal: add NormalizeEmail (trim + lowercase) and extract the login-hash primitive into HashSortedFields so the migration and db share one implementation. The sha256.New().Sum(fmt.Append(...)) construction is the legacy on-disk format and must not change.
- db: refactor HashAuthTwoFaFields to use the shared primitive; lowercase the email in prepareOrgMember (the single write path all member inserts/upserts and bulk/CSV imports funnel through), so stored emails and the hashes derived from them are canonical.
- csp: lowercase the login email input in authFirstStep so the lookup hash matches the now-normalized stored hash.
- migrations: add 0015 to lowercase existing member emails and recompute the affected participant login hashes. Members whose lowercased email would collide on a census login hash (unique index from 0008) are skipped and logged for manual review instead of aborting the run. Irreversible by design.

Tests: migration normalization + hash recompute + end-to-end login lookup, collision skip, and write-path normalization.

closes #508