### PR TITLE
fix(csp): use random OTP secret per token instead of deterministic derivation

### DIFF
--- a/api/csp_voting_test.go
+++ b/api/csp_voting_test.go
@@ -414,7 +414,7 @@ func TestCSPVoting(t *testing.T) {
 					bundleHex := internal.HexBytesFromString(bundleID)
 					seedVerifiedToken := func(memberID string) internal.HexBytes {
 						tok := internal.HexBytes(internal.RandomBytes(16))
-						c.Assert(testDB.SetCSPAuth(tok, internal.HexBytesFromString(memberID), bundleHex), qt.IsNil)
+						c.Assert(testDB.SetCSPAuth(tok, internal.HexBytesFromString(memberID), bundleHex, ""), qt.IsNil)
 						c.Assert(testDB.VerifyCSPAuth(tok), qt.IsNil)
 						return tok
 					}
@@ -447,7 +447,7 @@ func TestCSPVoting(t *testing.T) {
 					// An unverified token (issued but never verified) is not eligible,
 					// even for a genuine census participant.
 					unverifiedTok := internal.HexBytes(internal.RandomBytes(16))
-					c.Assert(testDB.SetCSPAuth(unverifiedTok, internal.HexBytesFromString(grace.ID), bundleHex), qt.IsNil)
+					c.Assert(testDB.SetCSPAuth(unverifiedTok, internal.HexBytesFromString(grace.ID), bundleHex, ""), qt.IsNil)
 					c.Assert(checkBelongs(unverifiedTok), qt.IsFalse)
 
 					// A missing auth token is a client error, not a membership answer.

--- a/api/process_bundles_test.go
+++ b/api/process_bundles_test.go
@@ -242,7 +242,7 @@ func TestCheckProcessBundleParticipants(t *testing.T) {
 		token := internal.HexBytes(util.RandomBytes(32))
 		address := internal.HexBytes(util.RandomBytes(20))
 
-		c.Assert(testDB.SetCSPAuth(token, userID, bundleIDBytes), qt.IsNil)
+		c.Assert(testDB.SetCSPAuth(token, userID, bundleIDBytes, ""), qt.IsNil)
 		c.Assert(testDB.VerifyCSPAuth(token), qt.IsNil)
 		c.Assert(testDB.ConsumeCSPProcess(token, processID, address), qt.IsNil)
 

--- a/csp/auth.go
+++ b/csp/auth.go
@@ -2,8 +2,7 @@
 package csp
 
 import (
-	"crypto/sha256"
-	"encoding/base32"
+	"crypto/subtle"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -57,13 +56,10 @@ func (c *CSP) BundleAuthToken(bID, uID internal.HexBytes, to string,
 			return nil, errors.ErrAttemptCoolDownTime.WithData(map[string]any{"coolDownTime": remainingTime.Milliseconds()})
 		}
 	}
-	// generate a new token, secret and code from the attempt number
-	token, code, err := c.generateToken(uID, bID)
-	if err != nil {
-		return nil, err
-	}
+	// generate a new token, secret and code
+	token, secret, code := c.generateToken()
 	// create the new token
-	if err := c.Storage.SetCSPAuth(token, uID, bID); err != nil {
+	if err := c.Storage.SetCSPAuth(token, uID, bID, secret); err != nil {
 		log.Warnw("error setting new token",
 			"userID", uID,
 			"bundleID", bID,
@@ -75,8 +71,9 @@ func (c *CSP) BundleAuthToken(bID, uID internal.HexBytes, to string,
 		"userID", uID,
 		"bundleID", bID,
 		"token", token)
-	// compose the notification challenge
-	remainingTimeN := c.notificationCoolDownTime.String()
+	// compose the notification challenge, advertising the OTP validity window
+	// (not the notification cooldown) as the code's expiry time
+	remainingTimeN := c.otpExpiry.String()
 	orgInfo := notifications.OrganizationInfo{
 		Address: orgAddress,
 		Name:    orgName,
@@ -124,24 +121,42 @@ func (c *CSP) ResendChallenge(token internal.HexBytes, to string,
 		return ErrInvalidAuthToken
 	}
 
-	remainingTime := c.notificationCoolDownTime - time.Since(authTokenData.CreatedAt)
-	if remainingTime.Seconds() < 0 {
-		log.Warnw("resend requested but cooldown time reached",
+	remainingTime := c.otpExpiry - time.Since(authTokenData.CreatedAt)
+	// an already-verified token is always reported as such, regardless of age,
+	// so it never masquerades as merely expired
+	if authTokenData.Verified {
+		coolDown := remainingTime.Seconds()
+		if coolDown < 0 {
+			coolDown = 0
+		}
+		return errors.ErrUserAlreadyVerified.WithData(map[string]any{"coolDownTime": coolDown})
+	}
+	if remainingTime <= 0 {
+		log.Warnw("resend requested but OTP has expired",
 			"userID", authTokenData.UserID,
 			"bundleID", authTokenData.BundleID,
-			"lastToken", authTokenData.Token)
+			"token", authTokenData.Token)
 		return ErrTokenExpired
-	} else if authTokenData.Verified {
-		return errors.ErrUserAlreadyVerified.WithData(map[string]any{"coolDownTime": remainingTime.Seconds()})
+	}
+	// reject unverified tokens without a stored challenge secret (legacy rows or
+	// auth-only tokens): regenerating a code from an empty secret would yield a
+	// guessable value, so such tokens are discarded. ErrTokenExpired prompts the
+	// client to restart the OTP flow rather than treating it as a hard failure.
+	if authTokenData.Secret == "" {
+		log.Warnw("resend requested for token without challenge secret",
+			"userID", authTokenData.UserID,
+			"bundleID", authTokenData.BundleID,
+			"token", token)
+		return ErrTokenExpired
 	}
 	// compose the notification challenge
-	remainingTimeN := c.notificationCoolDownTime.String()
+	remainingTimeN := remainingTime.String()
 	orgInfo := notifications.OrganizationInfo{
 		Address: orgAddress,
 		Name:    orgName,
 		Logo:    orgLogo,
 	}
-	code, err := c.regenerateTokenCode(authTokenData.UserID, authTokenData.BundleID)
+	code, err := c.regenerateTokenCode(authTokenData.Secret)
 	if err != nil {
 		log.Warnw("error regenerating token code",
 			"userID", authTokenData.UserID,
@@ -203,13 +218,57 @@ func (c *CSP) VerifyBundleAuthToken(token internal.HexBytes, solution string) er
 			"error", err)
 		return ErrInvalidAuthToken
 	}
-	// verify the solution, and if the solution is not correct, return an error
-	if !c.verifySolution(authTokenData.UserID, authTokenData.BundleID, solution) {
-		log.Warnw("challenge code do not match",
+	// reject tokens without a stored challenge secret. This covers legacy rows
+	// created before per-token secrets existed, auth-only tokens, and tokens
+	// already verified (whose secret was wiped): in all cases the OTP would be
+	// derived from an empty secret and thus trivially guessable, so the token is
+	// not OTP-verifiable. ErrTokenExpired prompts the client to restart the OTP
+	// flow rather than treating it as a hard failure.
+	if authTokenData.Secret == "" {
+		log.Warnw("verification attempted for token without challenge secret",
+			"userID", authTokenData.UserID,
+			"bundleID", authTokenData.BundleID,
+			"token", token)
+		return ErrTokenExpired
+	}
+	// reject if the OTP window has passed
+	if time.Since(authTokenData.CreatedAt) > c.otpExpiry {
+		log.Warnw("OTP expired",
+			"userID", authTokenData.UserID,
+			"bundleID", authTokenData.BundleID,
+			"token", token)
+		return ErrTokenExpired
+	}
+	// reject tokens that exhausted the maximum number of attempts
+	if authTokenData.Attempts >= MaxChallengeAttempts {
+		log.Warnw("too many challenge attempts",
 			"userID", authTokenData.UserID,
 			"bundleID", authTokenData.BundleID,
 			"token", token,
-			"solution", solution)
+			"attempts", authTokenData.Attempts)
+		return ErrTooManyAttempts
+	}
+	// verify the solution, and if the solution is not correct, atomically record
+	// the failed attempt while enforcing the cap
+	if !c.verifySolution(authTokenData.Secret, solution) {
+		log.Warnw("challenge code does not match",
+			"userID", authTokenData.UserID,
+			"bundleID", authTokenData.BundleID,
+			"token", token)
+		recorded, err := c.Storage.IncrementCSPAuthAttempts(token, MaxChallengeAttempts)
+		if err != nil {
+			// fail closed: if we cannot persist the attempt, do not allow the
+			// verification to proceed, otherwise attempt limiting could be
+			// bypassed while the database is unhealthy
+			log.Warnw("error incrementing challenge attempts",
+				"token", token,
+				"error", err)
+			return ErrStorageFailure
+		}
+		if !recorded {
+			// a concurrent request already pushed attempts to the cap
+			return ErrTooManyAttempts
+		}
 		return ErrChallengeCodeFailure
 	}
 	// set the token as verified
@@ -224,51 +283,27 @@ func (c *CSP) VerifyBundleAuthToken(token internal.HexBytes, solution string) er
 	return nil
 }
 
-// generateToken method generates a new authentication token for a user in a
-// process. It checks if the process is already consumed for this user. It
-// generates a new challenge secret, challenge token and OTP code for the
-// secret and the attempt number. It returns the token, the secret and the
-// code respectively.
-func (*CSP) generateToken(uID, bID internal.HexBytes) (
-	internal.HexBytes, string, error,
-) {
-	// generate a new challenge secret and challenge token
-	secret := otpSecret(uID, bID)
-	// generate the OTP code for the secret and the attempt number
-	otp := gotp.NewDefaultHOTP(secret)
-	code := otp.At(0)
-	// generate a new token and convert it to HexBytes
-	bToken, err := uuid.New().MarshalBinary()
-	if err != nil {
-		log.Warnw("error marshalling token",
-			"error", err,
-			"userID", uID,
-			"bundleID", bID)
-		return nil, "", ErrInvalidAuthToken
-	}
-	return bToken, code, nil
+// generateToken generates a new authentication token with a random OTP secret.
+// It returns the bearer token, the base32 OTP secret, and the 6-digit code.
+func (*CSP) generateToken() (bToken internal.HexBytes, secret, code string) {
+	secret = gotp.RandomSecret(16)
+	code = gotp.NewDefaultHOTP(secret).At(0)
+	// a uuid.UUID is a [16]byte; slice its bytes directly to avoid the fallible
+	// MarshalBinary call (and the panic path it would require).
+	id := uuid.New()
+	return internal.HexBytes(id[:]), secret, code
 }
 
-func (*CSP) regenerateTokenCode(uID, bID internal.HexBytes) (
-	string, error,
-) {
-	secret := otpSecret(uID, bID)
-	otp := gotp.NewDefaultHOTP(secret)
-	code := otp.At(0)
-	return code, nil
+// regenerateTokenCode recomputes the OTP code for a stored secret (used for resend).
+func (*CSP) regenerateTokenCode(secret string) (string, error) {
+	return gotp.NewDefaultHOTP(secret).At(0), nil
 }
 
-// verifySolution method verifies the solution for a user process. It generates
-// the OTP code for the process secret and the attempt number and compares it
-// with the solution. It returns true if the solution is correct, false
-// otherwise.
-func (*CSP) verifySolution(uID, bID internal.HexBytes, solution string) bool {
-	secret := otpSecret(uID, bID)
-	// generate the OTP code for the secret and the attempt number
-	otp := gotp.NewDefaultHOTP(secret)
-	code := otp.At(0)
-	// compare the generated code with the solution
-	return code == solution
+// verifySolution checks whether solution matches the HOTP code for secret. The
+// comparison is constant-time to avoid leaking the code through timing.
+func (*CSP) verifySolution(secret, solution string) bool {
+	code := gotp.NewDefaultHOTP(secret).At(0)
+	return subtle.ConstantTimeCompare([]byte(code), []byte(solution)) == 1
 }
 
 // createAuthOnlyToken creates a pre-verified token for auth-only censuses
@@ -285,8 +320,8 @@ func (c *CSP) createAuthOnlyToken(bID, uID internal.HexBytes) (internal.HexBytes
 		return nil, ErrInvalidAuthToken
 	}
 
-	// create the new token
-	if err := c.Storage.SetCSPAuth(bToken, uID, bID); err != nil {
+	// create the new token (auth-only tokens need no OTP secret)
+	if err := c.Storage.SetCSPAuth(bToken, uID, bID, ""); err != nil {
 		log.Warnw("error setting new token",
 			"userID", uID,
 			"bundleID", bID,
@@ -310,13 +345,4 @@ func (c *CSP) createAuthOnlyToken(bID, uID internal.HexBytes) (internal.HexBytes
 		"token", bToken)
 
 	return bToken, nil
-}
-
-// otpSecret method generates a new OTP secret for a user and a bundle. The
-// secret is generated by hashing the user ID and the bundle ID with SHA-256.
-// It returns the secret as HexBytes.
-func otpSecret(uID, bID internal.HexBytes) string {
-	hash := sha256.Sum256(append(uID, bID...))
-	// encode the secret in base32 and return it
-	return base32.StdEncoding.EncodeToString(hash[:])
 }

--- a/csp/auth_test.go
+++ b/csp/auth_test.go
@@ -2,8 +2,6 @@ package csp
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/base32"
 	"io"
 	"regexp"
 	"testing"
@@ -140,11 +138,9 @@ func TestBundleAuthToken(t *testing.T) {
 		)
 		c.Assert(err, qt.IsNil)
 		c.Assert(token, qt.Not(qt.IsNil))
-		// calculate expected code and token
-		_, expectedCode, err := csp.generateToken(testUserID, bundleID)
-		c.Assert(err, qt.IsNil)
 		authTokenResult, err := csp.Storage.CSPAuth(token)
 		c.Assert(err, qt.IsNil)
+		expectedCode := gotp.NewDefaultHOTP(authTokenResult.Secret).At(0)
 		c.Assert(authTokenResult.BundleID.Bytes(), qt.DeepEquals, bundleID.Bytes())
 		c.Assert(authTokenResult.UserID.Bytes(), qt.DeepEquals, testUserID.Bytes())
 		// wait to dequeue the notification
@@ -182,6 +178,7 @@ func TestVerifyBundleAuthToken(t *testing.T) {
 		SMSService:               testSMSService,
 		NotificationThrottleTime: time.Second,
 		NotificationCoolDownTime: time.Second * 5,
+		OTPExpiry:                time.Second * 5,
 		RootKey:                  *testRootKey,
 	})
 	c.Assert(err, qt.IsNil)
@@ -201,29 +198,71 @@ func TestVerifyBundleAuthToken(t *testing.T) {
 		c.Assert(err, qt.ErrorIs, ErrInvalidAuthToken)
 	})
 
+	c.Run("expired OTP", func(c *qt.C) {
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		// shrink the OTP window for this subtest so we can trigger expiry with a
+		// millisecond-scale sleep instead of waiting out the full window
+		origExpiry := csp.otpExpiry
+		csp.otpExpiry = 10 * time.Millisecond
+		c.Cleanup(func() { csp.otpExpiry = origExpiry })
+		secret := gotp.RandomSecret(16)
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID, secret), qt.IsNil)
+		code := gotp.NewDefaultHOTP(secret).At(0)
+		time.Sleep(50 * time.Millisecond)
+		err := csp.VerifyBundleAuthToken(testToken, code)
+		c.Assert(err, qt.ErrorIs, ErrTokenExpired)
+	})
+
 	c.Run("solution not match", func(c *qt.C) {
 		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
-		// create the token
-		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
-		// try to verify an invalid solution
+		secret := gotp.RandomSecret(16)
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID, secret), qt.IsNil)
 		err := csp.VerifyBundleAuthToken(testToken, "invalid")
 		c.Assert(err, qt.ErrorIs, ErrChallengeCodeFailure)
 	})
 
+	c.Run("empty secret rejected", func(c *qt.C) {
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		// a token without a stored challenge secret (legacy row, auth-only, or
+		// already-verified) must never OTP-verify, regardless of the solution.
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID, ""), qt.IsNil)
+		// the code an attacker would compute from an empty secret must not pass;
+		// the token is reported expired so the client restarts the OTP flow
+		emptySecretCode := gotp.NewDefaultHOTP("").At(0)
+		err := csp.VerifyBundleAuthToken(testToken, emptySecretCode)
+		c.Assert(err, qt.ErrorIs, ErrTokenExpired)
+	})
+
 	c.Run("success", func(c *qt.C) {
 		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
-		// create the token
-		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
-		// generate the code
-		_, code, err := csp.generateToken(testUserID, testBundleID)
-		c.Assert(err, qt.IsNil)
-		// try to verify an valid solution
+		secret := gotp.RandomSecret(16)
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID, secret), qt.IsNil)
+		code := gotp.NewDefaultHOTP(secret).At(0)
 		err = csp.VerifyBundleAuthToken(testToken, code)
 		c.Assert(err, qt.IsNil)
-		// check that the token is verified
+		// check that the token is verified and secret is cleared
 		authTokenResult, err := csp.Storage.CSPAuth(testToken)
 		c.Assert(err, qt.IsNil)
 		c.Assert(authTokenResult.Verified, qt.IsTrue)
+		c.Assert(authTokenResult.Secret, qt.Equals, "")
+		// re-verifying an already-verified token (secret now wiped) must fail
+		err = csp.VerifyBundleAuthToken(testToken, code)
+		c.Assert(err, qt.ErrorIs, ErrTokenExpired)
+	})
+
+	c.Run("too many attempts", func(c *qt.C) {
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		secret := gotp.RandomSecret(16)
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID, secret), qt.IsNil)
+		validCode := gotp.NewDefaultHOTP(secret).At(0)
+		// exhaust the allowed attempts with wrong codes
+		for range MaxChallengeAttempts {
+			err = csp.VerifyBundleAuthToken(testToken, "000000")
+			c.Assert(err, qt.ErrorIs, ErrChallengeCodeFailure)
+		}
+		// even the valid code is now rejected because attempts are exhausted
+		err = csp.VerifyBundleAuthToken(testToken, validCode)
+		c.Assert(err, qt.ErrorIs, ErrTooManyAttempts)
 	})
 }
 
@@ -240,6 +279,7 @@ func TestResendChallenge(t *testing.T) {
 		SMSService:               testSMSService,
 		NotificationThrottleTime: time.Second,
 		NotificationCoolDownTime: time.Second * 5,
+		OTPExpiry:                time.Second * 30,
 		RootKey:                  *testRootKey,
 	})
 	c.Assert(err, qt.IsNil)
@@ -311,7 +351,7 @@ func TestResendChallenge(t *testing.T) {
 
 	c.Run("token already verified", func(c *qt.C) {
 		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
-		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID, gotp.RandomSecret(16)), qt.IsNil)
 		c.Assert(csp.Storage.VerifyCSPAuth(testToken), qt.IsNil)
 
 		err := csp.ResendChallenge(
@@ -326,12 +366,29 @@ func TestResendChallenge(t *testing.T) {
 		c.Assert(err, qt.ErrorIs, errors.ErrUserAlreadyVerified)
 	})
 
+	c.Run("empty secret rejected", func(c *qt.C) {
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		// an unverified token with no stored secret (legacy/auth-only) must not
+		// have a code resent; it is reported expired so the client restarts.
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID, ""), qt.IsNil)
+		err := csp.ResendChallenge(
+			testToken,
+			testUserEmail,
+			notifications.EmailChallenge,
+			apicommon.DefaultLang,
+			testOrgName,
+			testOrgLogo,
+			testAddress.Address(),
+		)
+		c.Assert(err, qt.ErrorIs, ErrTokenExpired)
+	})
+
 	c.Run("success", func(c *qt.C) {
 		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
-		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		secret := gotp.RandomSecret(16)
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID, secret), qt.IsNil)
 
-		expectedCode, err := csp.regenerateTokenCode(testUserID, testBundleID)
-		c.Assert(err, qt.IsNil)
+		expectedCode := gotp.NewDefaultHOTP(secret).At(0)
 
 		err = csp.ResendChallenge(
 			testToken,
@@ -363,6 +420,7 @@ func TestBundleAuthTokenResendAndVerifyFlow(t *testing.T) {
 		SMSService:               testSMSService,
 		NotificationThrottleTime: time.Second,
 		NotificationCoolDownTime: time.Second * 5,
+		OTPExpiry:                time.Second * 30,
 		RootKey:                  *testRootKey,
 	})
 	c.Assert(err, qt.IsNil)
@@ -381,7 +439,9 @@ func TestBundleAuthTokenResendAndVerifyFlow(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(token, qt.Not(qt.IsNil))
 
-	expectedFirstCode, err := csp.regenerateTokenCode(testUserID, testBundleID)
+	firstAuthData, err := csp.Storage.CSPAuth(token)
+	c.Assert(err, qt.IsNil)
+	expectedFirstCode, err := csp.regenerateTokenCode(firstAuthData.Secret)
 	c.Assert(err, qt.IsNil)
 	firstCode := fetchOTPCodeFromEmail(c, testUserEmail)
 	c.Assert(firstCode, qt.Equals, expectedFirstCode)
@@ -413,7 +473,9 @@ func TestBundleAuthTokenResendAndVerifyFlow(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(secondToken, qt.Not(qt.IsNil))
 
-	expectedSecondCode, err := csp.regenerateTokenCode(testUserID, secondBundleID)
+	secondAuthData, err := csp.Storage.CSPAuth(secondToken)
+	c.Assert(err, qt.IsNil)
+	expectedSecondCode, err := csp.regenerateTokenCode(secondAuthData.Secret)
 	c.Assert(err, qt.IsNil)
 	secondCode := fetchOTPCodeFromEmail(c, testUserEmail)
 	c.Assert(secondCode, qt.Equals, expectedSecondCode)
@@ -434,35 +496,23 @@ func TestBundleAuthTokenResendAndVerifyFlow(t *testing.T) {
 
 func TestGenerateToken(t *testing.T) {
 	c := qt.New(t)
-	secret := otpSecret(testUserID, testBundleID)
-	otp := gotp.NewDefaultHOTP(secret)
-	token, code, err := new(CSP).generateToken(testUserID, testBundleID)
-	c.Assert(err, qt.IsNil)
+	token, secret, code := new(CSP).generateToken()
 	c.Assert(token, qt.Not(qt.IsNil))
-	c.Assert(code, qt.Equals, otp.At(0))
+	c.Assert(secret, qt.Not(qt.Equals), "")
+	c.Assert(code, qt.Equals, gotp.NewDefaultHOTP(secret).At(0))
 }
 
 func TestVerifySolution(t *testing.T) {
 	c := qt.New(t)
 
-	secret := otpSecret(testUserID, testBundleID)
-	otp := gotp.NewDefaultHOTP(secret)
-	code := otp.At(0)
+	secret := gotp.RandomSecret(16)
+	code := gotp.NewDefaultHOTP(secret).At(0)
 
-	ok := new(CSP).verifySolution(testUserID, testBundleID, code)
+	ok := new(CSP).verifySolution(secret, code)
 	c.Assert(ok, qt.IsTrue)
 
-	ok = new(CSP).verifySolution(testUserID, testBundleID, "invalid")
+	ok = new(CSP).verifySolution(secret, "invalid")
 	c.Assert(ok, qt.IsFalse)
-}
-
-func TestOTPSecret(t *testing.T) {
-	c := qt.New(t)
-
-	expectedSecret := sha256.Sum256(append(testUserID, testBundleID...))
-	encodedSecret := base32.StdEncoding.EncodeToString(expectedSecret[:])
-	secret := otpSecret(testUserID, testBundleID)
-	c.Assert(secret, qt.Equals, encodedSecret)
 }
 
 func fetchOTPCodeFromEmail(c *qt.C, email string) string {

--- a/csp/csp.go
+++ b/csp/csp.go
@@ -15,7 +15,15 @@ import (
 	"go.vocdoni.io/dvote/log"
 )
 
-const DefaultNotificationCoolDownTime = time.Second * 60
+const (
+	DefaultNotificationCoolDownTime = time.Second * 60
+	DefaultOTPExpiry                = time.Minute * 15
+)
+
+// MaxChallengeAttempts is the maximum number of failed challenge-code
+// verification attempts allowed for a single authentication token before it is
+// rejected.
+const MaxChallengeAttempts = 5
 
 // Config struct contains the configuration for the CSP service. It includes
 // the database name, the MongoDB client, the notification cooldown time, the
@@ -33,6 +41,9 @@ type Config struct {
 	// breakers instead of a single throttled loop. Kept for backwards
 	// compatibility with existing configurations.
 	NotificationThrottleTime time.Duration
+	// OTPExpiry is how long a challenge OTP remains valid for verification.
+	// Resends within this window repeat the same code. Zero uses DefaultOTPExpiry (15 min).
+	OTPExpiry time.Duration
 	// NotificationQueueWorkers is the number of concurrent notification senders.
 	// It bounds the maximum number of in-flight provider sends. Zero uses the
 	// default (notifications.DefaultQueueWorkers).
@@ -58,6 +69,7 @@ type CSP struct {
 	notifyQueue  *notifications.Queue
 
 	notificationCoolDownTime time.Duration
+	otpExpiry                time.Duration
 }
 
 // New method creates a new CSP service. It requires a CSPConfig struct with
@@ -110,11 +122,16 @@ func New(ctx context.Context, config *Config) (*CSP, error) {
 	if notificationCoolDownTime <= 0 {
 		notificationCoolDownTime = DefaultNotificationCoolDownTime
 	}
+	otpExpiry := config.OTPExpiry
+	if otpExpiry <= 0 {
+		otpExpiry = DefaultOTPExpiry
+	}
 	return &CSP{
 		Storage:                  config.DB,
 		Signer:                   s,
 		notifyQueue:              queue,
 		notificationCoolDownTime: notificationCoolDownTime,
+		otpExpiry:                otpExpiry,
 	}, nil
 }
 

--- a/csp/errors.go
+++ b/csp/errors.go
@@ -13,9 +13,9 @@ var (
 	ErrNoBundleID = fmt.Errorf("no bundle ID provided")
 	// ErrNoProcessID is returned when no process ID is provided.
 	ErrNoProcessID = fmt.Errorf("no process ID provided")
-	// ErrTooManyAttempts is returned when no more SMS attempts available for a
-	// user.
-	ErrTooManyAttempts = fmt.Errorf("too many SMS attempts")
+	// ErrTooManyAttempts is returned when no more verification attempts are
+	// available for an authentication token (e.g. challenge code retries).
+	ErrTooManyAttempts = fmt.Errorf("too many verification attempts")
 	// ErrTokenExpired is returned when the authentication token has expired.
 	ErrTokenExpired = fmt.Errorf("authentication token has expired")
 	// ErrUserUnknown is returned if the userID is not found in the database.

--- a/csp/handlers/handlers.go
+++ b/csp/handlers/handlers.go
@@ -954,7 +954,8 @@ func (c *CSPHandlers) authSecondStep(r *http.Request) (internal.HexBytes, error)
 	switch err := c.csp.VerifyBundleAuthToken(req.AuthToken, req.AuthData[0]); err {
 	case nil:
 		return req.AuthToken, nil
-	case csp.ErrInvalidAuthToken, csp.ErrInvalidSolution, csp.ErrChallengeCodeFailure:
+	case csp.ErrInvalidAuthToken, csp.ErrInvalidSolution, csp.ErrChallengeCodeFailure,
+		csp.ErrTokenExpired, csp.ErrTooManyAttempts:
 		return nil, errors.ErrUnauthorized.WithErr(err)
 	case csp.ErrUserUnknown, csp.ErrUserNotBelongsToBundle:
 		return nil, errors.ErrUserNotFound.WithErr(err)

--- a/csp/sign_test.go
+++ b/csp/sign_test.go
@@ -42,7 +42,7 @@ func TestSign(t *testing.T) {
 		pid := internal.HexBytes(util.RandomBytes(32))
 		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
 		// index the token
-		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID, ""), qt.IsNil)
 		// verify the token
 		c.Assert(csp.Storage.VerifyCSPAuth(testToken), qt.IsNil)
 		sign, err := csp.Sign(testToken, testAddress, pid, testUserWeightBytes, signers.SignerTypeECDSASalted)
@@ -84,7 +84,7 @@ func TestPrepareSaltedKeySigner(t *testing.T) {
 			csp.unlock(testUserID, testPID)
 		})
 		// store the token and verify it
-		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID, ""), qt.IsNil)
 		c.Assert(csp.Storage.VerifyCSPAuth(testToken), qt.IsNil)
 		// lock the user
 		csp.lock(testUserID, testPID)
@@ -98,7 +98,7 @@ func TestPrepareSaltedKeySigner(t *testing.T) {
 			csp.unlock(testUserID, testPID)
 		})
 		// store the token
-		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID, ""), qt.IsNil)
 		// store the token status
 		c.Assert(csp.Storage.ConsumeCSPProcess(testToken, testPID, testAddress), qt.IsNil)
 		_, _, _, err := csp.prepareSaltedKeySigner(testToken, testAddress, testPID, testUserWeightBytes)
@@ -111,7 +111,7 @@ func TestPrepareSaltedKeySigner(t *testing.T) {
 			csp.unlock(testUserID, testPID)
 		})
 		// store the token
-		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID, ""), qt.IsNil)
 		// verify the token
 		c.Assert(csp.Storage.VerifyCSPAuth(testToken), qt.IsNil)
 		// consume the process
@@ -128,7 +128,7 @@ func TestPrepareSaltedKeySigner(t *testing.T) {
 			csp.unlock(testUserID, testPID)
 		})
 		// index the token
-		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID, ""), qt.IsNil)
 		// verify the token
 		c.Assert(csp.Storage.VerifyCSPAuth(testToken), qt.IsNil)
 		_, _, _, err := csp.prepareSaltedKeySigner(testToken, testAddress, util.RandomBytes(saltedkey.SaltSize-1), testUserWeightBytes)
@@ -141,7 +141,7 @@ func TestPrepareSaltedKeySigner(t *testing.T) {
 			csp.unlock(testUserID, testPID)
 		})
 		// index the token
-		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID, ""), qt.IsNil)
 		// verify the token
 		c.Assert(csp.Storage.VerifyCSPAuth(testToken), qt.IsNil)
 		userID, salt, message, err := csp.prepareSaltedKeySigner(testToken, testAddress, testPID, testUserWeightBytes)
@@ -183,7 +183,7 @@ func TestFinishSaltedKeySigner(t *testing.T) {
 	c.Run("token not verified", func(c *qt.C) {
 		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
 		// store the token
-		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID, ""), qt.IsNil)
 		err := csp.finishSaltedKeySigner(testToken, testAddress, testPID)
 		c.Assert(err, qt.ErrorIs, ErrAuthTokenNotVerified)
 	})
@@ -194,7 +194,7 @@ func TestFinishSaltedKeySigner(t *testing.T) {
 			defer csp.unlock(testUserID, testPID)
 		})
 		// store the token
-		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID, ""), qt.IsNil)
 		// verify the token
 		c.Assert(csp.Storage.VerifyCSPAuth(testToken), qt.IsNil)
 		err := csp.finishSaltedKeySigner(testToken, testAddress, testPID)
@@ -207,7 +207,7 @@ func TestFinishSaltedKeySigner(t *testing.T) {
 			defer csp.unlock(testUserID, testPID)
 		})
 		// store the token
-		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID, ""), qt.IsNil)
 		// verify the token
 		c.Assert(csp.Storage.VerifyCSPAuth(testToken), qt.IsNil)
 		_, _, _, err := csp.prepareSaltedKeySigner(testToken, testAddress, testPID, testUserWeightBytes)

--- a/db/csp.go
+++ b/db/csp.go
@@ -16,12 +16,16 @@ import (
 
 // CSPAuth represents a user authentication information for a bundle of processes
 type CSPAuth struct {
-	Token      internal.HexBytes `json:"token" bson:"_id"`
-	UserID     internal.HexBytes `json:"userID" bson:"userid"`
-	BundleID   internal.HexBytes `json:"bundleID" bson:"bundleid"`
-	CreatedAt  time.Time         `json:"createdAt" bson:"createdat"`
-	Verified   bool              `json:"verified" bson:"verified"`
-	VerifiedAt time.Time         `json:"verifiedAt" bson:"verifiedat"`
+	Token     internal.HexBytes `json:"token" bson:"_id"`
+	UserID    internal.HexBytes `json:"userID" bson:"userid"`
+	BundleID  internal.HexBytes `json:"bundleID" bson:"bundleid"`
+	CreatedAt time.Time         `json:"createdAt" bson:"createdat"`
+	// Secret is the per-token OTP challenge secret. It must never leave the
+	// server, so it is excluded from JSON serialization.
+	Secret     string    `json:"-" bson:"secret,omitempty"`
+	Attempts   int       `json:"attempts" bson:"attempts"`
+	Verified   bool      `json:"verified" bson:"verified"`
+	VerifiedAt time.Time `json:"verifiedAt" bson:"verifiedat"`
 }
 
 // CSPProcess is the status of a process in a bundle of processes for a user
@@ -39,7 +43,7 @@ type CSPProcess struct {
 // SetCSPAuth method stores a new CSP authentication token for a user and a
 // bundle of processes. It returns an error if the token, user ID or bundle
 // ID are nil.
-func (ms *MongoStorage) SetCSPAuth(token, userID, bundleID internal.HexBytes) error {
+func (ms *MongoStorage) SetCSPAuth(token, userID, bundleID internal.HexBytes, secret string) error {
 	if token == nil || userID == nil || bundleID == nil {
 		return ErrBadInputs
 	}
@@ -54,6 +58,7 @@ func (ms *MongoStorage) SetCSPAuth(token, userID, bundleID internal.HexBytes) er
 		UserID:    userID,
 		BundleID:  bundleID,
 		CreatedAt: time.Now(),
+		Secret:    secret,
 		Verified:  false,
 	}); err != nil {
 		return errors.Join(ErrStoreToken, err)
@@ -113,13 +118,46 @@ func (ms *MongoStorage) VerifyCSPAuth(token internal.HexBytes) error {
 	if _, err := ms.fetchCSPAuthFromDB(ctx, token); err != nil {
 		return err
 	}
-	// update the token
+	// update the token: mark verified and clear the secret so the code cannot be reused
 	filter := bson.M{"_id": token}
-	updateDoc := bson.M{"$set": bson.M{"verified": true, "verifiedat": time.Now()}}
+	updateDoc := bson.M{"$set": bson.M{"verified": true, "verifiedat": time.Now()}, "$unset": bson.M{"secret": ""}}
 	if _, err := ms.cspTokens.UpdateOne(ctx, filter, updateDoc, nil); err != nil {
 		return errors.Join(ErrStoreToken, err)
 	}
 	return nil
+}
+
+// IncrementCSPAuthAttempts atomically records a failed verification attempt for
+// the given token, but only while the stored attempt count is still below
+// maxAttempts. It returns recorded=true when the attempt was counted, and
+// recorded=false when the cap had already been reached (no increment performed)
+// — this is done in a single conditional update so concurrent verifications
+// cannot push the counter past maxAttempts. It returns ErrTokenNotFound if the
+// token does not exist and ErrBadInputs if the token is nil.
+func (ms *MongoStorage) IncrementCSPAuthAttempts(token internal.HexBytes, maxAttempts int) (recorded bool, err error) {
+	if token == nil {
+		return false, ErrBadInputs
+	}
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	// conditional increment: only bump attempts while still below the cap
+	res, err := ms.cspTokens.UpdateOne(ctx,
+		bson.M{"_id": token, "attempts": bson.M{"$lt": maxAttempts}},
+		bson.M{"$inc": bson.M{"attempts": 1}})
+	if err != nil {
+		return false, errors.Join(ErrStoreToken, err)
+	}
+	if res.MatchedCount == 1 {
+		return true, nil
+	}
+	// no document matched: either the token does not exist or the cap is already
+	// reached. Distinguish the two so callers can react correctly.
+	if _, err := ms.fetchCSPAuthFromDB(ctx, token); err != nil {
+		return false, err
+	}
+	return false, nil
 }
 
 // CSPProcess returns the CSPProcess for the given token and processID.

--- a/db/csp_test.go
+++ b/db/csp_test.go
@@ -23,18 +23,18 @@ func TestSetGetCSPAuth(t *testing.T) {
 	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
 
 	c.Run("nil token", func(c *qt.C) {
-		c.Assert(testDB.SetCSPAuth(nil, testUserID, testCSPBundleID), qt.ErrorIs, ErrBadInputs)
+		c.Assert(testDB.SetCSPAuth(nil, testUserID, testCSPBundleID, ""), qt.ErrorIs, ErrBadInputs)
 	})
 	c.Run("nil userID", func(c *qt.C) {
-		c.Assert(testDB.SetCSPAuth(testAuthToken, nil, testCSPBundleID), qt.ErrorIs, ErrBadInputs)
+		c.Assert(testDB.SetCSPAuth(testAuthToken, nil, testCSPBundleID, ""), qt.ErrorIs, ErrBadInputs)
 	})
 	c.Run("nil bundleID", func(c *qt.C) {
-		c.Assert(testDB.SetCSPAuth(testAuthToken, testUserID, nil), qt.ErrorIs, ErrBadInputs)
+		c.Assert(testDB.SetCSPAuth(testAuthToken, testUserID, nil, ""), qt.ErrorIs, ErrBadInputs)
 	})
 	c.Run("valid token", func(c *qt.C) {
 		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
 		// set the token and check it was set
-		c.Assert(testDB.SetCSPAuth(testAuthToken, testUserID, testCSPBundleID), qt.IsNil)
+		c.Assert(testDB.SetCSPAuth(testAuthToken, testUserID, testCSPBundleID, ""), qt.IsNil)
 		token, err := testDB.CSPAuth(testAuthToken)
 		c.Assert(err, qt.IsNil)
 		c.Assert(token.Token, qt.DeepEquals, testAuthToken)
@@ -49,7 +49,7 @@ func TestSetGetCSPAuth(t *testing.T) {
 		c.Assert(err, qt.ErrorIs, ErrTokenNotFound)
 		// set first token
 		firtstToken := internal.HexBytes(uuid.New().String())
-		c.Assert(testDB.SetCSPAuth(firtstToken, testUserID, testCSPBundleID), qt.IsNil)
+		c.Assert(testDB.SetCSPAuth(firtstToken, testUserID, testCSPBundleID, ""), qt.IsNil)
 		// get last token
 		token, err := testDB.LastCSPAuth(testUserID, testCSPBundleID)
 		c.Assert(err, qt.IsNil)
@@ -61,7 +61,7 @@ func TestSetGetCSPAuth(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 		// set second token
 		secondToken := internal.HexBytes(uuid.New().String())
-		c.Assert(testDB.SetCSPAuth(secondToken, testUserID, testCSPBundleID), qt.IsNil)
+		c.Assert(testDB.SetCSPAuth(secondToken, testUserID, testCSPBundleID, ""), qt.IsNil)
 		// get last token
 		token, err = testDB.LastCSPAuth(testUserID, testCSPBundleID)
 		c.Assert(err, qt.IsNil)
@@ -89,12 +89,46 @@ func TestVerifyCSPAuth(t *testing.T) {
 	})
 	c.Run("valid token", func(c *qt.C) {
 		// set the token and verify it
-		c.Assert(testDB.SetCSPAuth(testAuthToken, testUserID, testCSPBundleID), qt.IsNil)
+		c.Assert(testDB.SetCSPAuth(testAuthToken, testUserID, testCSPBundleID, ""), qt.IsNil)
 		c.Assert(testDB.VerifyCSPAuth(testAuthToken), qt.IsNil)
 		token, err := testDB.CSPAuth(testAuthToken)
 		c.Assert(err, qt.IsNil)
 		c.Assert(token.Verified, qt.IsTrue)
 		c.Assert(token.VerifiedAt.IsZero(), qt.IsFalse)
+	})
+}
+
+func TestIncrementCSPAuthAttempts(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	const maxAttempts = 5
+
+	c.Run("nil token", func(c *qt.C) {
+		_, err := testDB.IncrementCSPAuthAttempts(nil, maxAttempts)
+		c.Assert(err, qt.ErrorIs, ErrBadInputs)
+	})
+	c.Run("non existing token", func(c *qt.C) {
+		_, err := testDB.IncrementCSPAuthAttempts(invalidAuthToken, maxAttempts)
+		c.Assert(err, qt.ErrorIs, ErrTokenNotFound)
+	})
+	c.Run("conditional increment caps at max", func(c *qt.C) {
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		c.Assert(testDB.SetCSPAuth(testAuthToken, testUserID, testCSPBundleID, "secret"), qt.IsNil)
+		// the first maxAttempts increments are recorded
+		for range maxAttempts {
+			recorded, err := testDB.IncrementCSPAuthAttempts(testAuthToken, maxAttempts)
+			c.Assert(err, qt.IsNil)
+			c.Assert(recorded, qt.IsTrue)
+		}
+		// once the cap is reached, further increments are not recorded
+		recorded, err := testDB.IncrementCSPAuthAttempts(testAuthToken, maxAttempts)
+		c.Assert(err, qt.IsNil)
+		c.Assert(recorded, qt.IsFalse)
+		// the counter never exceeds the cap
+		token, err := testDB.CSPAuth(testAuthToken)
+		c.Assert(err, qt.IsNil)
+		c.Assert(token.Attempts, qt.Equals, maxAttempts)
 	})
 }
 
@@ -121,7 +155,7 @@ func TestCSPProcess(t *testing.T) {
 
 	c.Run("vote once correctly", func(c *qt.C) {
 		// set the token and consume it
-		c.Assert(testDB.SetCSPAuth(testAuthToken, testUserID, testCSPBundleID), qt.IsNil)
+		c.Assert(testDB.SetCSPAuth(testAuthToken, testUserID, testCSPBundleID, ""), qt.IsNil)
 		c.Assert(testDB.ConsumeCSPProcess(testAuthToken, testCSPProcessID, testUserAddress), qt.IsNil)
 		status, err := testDB.CSPProcess(testAuthToken, testCSPProcessID)
 		c.Assert(err, qt.IsNil)

--- a/db/process_bundles_check_test.go
+++ b/db/process_bundles_check_test.go
@@ -252,7 +252,7 @@ func seedUsedCSPProcess(t *testing.T, memberID string, bundleID, processID inter
 	token := internal.HexBytes(append([]byte{0xC5, 0x90}, processID...))
 	userID := internal.HexBytesFromString(memberID)
 	address := internal.HexBytes{0x11, 0x22, 0x33}
-	c.Assert(testDB.SetCSPAuth(token, userID, bundleID), qt.IsNil)
+	c.Assert(testDB.SetCSPAuth(token, userID, bundleID, ""), qt.IsNil)
 	c.Assert(testDB.VerifyCSPAuth(token), qt.IsNil)
 	c.Assert(testDB.ConsumeCSPProcess(token, processID, address), qt.IsNil)
 }
@@ -295,7 +295,7 @@ func TestMembersWithUsedCSPProcess(t *testing.T) {
 		// Verified auth exists, but the process was never consumed → no CSPProcess.
 		token := internal.HexBytes{0x01, 0x02, 0x03}
 		userID := internal.HexBytesFromString(fixture.alice.ID.Hex())
-		c.Assert(testDB.SetCSPAuth(token, userID, fixture.bundleID), qt.IsNil)
+		c.Assert(testDB.SetCSPAuth(token, userID, fixture.bundleID, ""), qt.IsNil)
 		c.Assert(testDB.VerifyCSPAuth(token), qt.IsNil)
 
 		got, err := testDB.MembersWithUsedCSPProcess(processID, []string{fixture.alice.ID.Hex()})

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -8,6 +8,13 @@ definitions:
           type: string
         type: array
     type: object
+  api.VersionInfo:
+    properties:
+      goVersion:
+        type: string
+      version:
+        type: string
+    type: object
   apicommon.AcceptOrganizationInvitation:
     properties:
       code:
@@ -5452,6 +5459,19 @@ paths:
       summary: Resend verification code
       tags:
       - users
+  /version:
+    get:
+      description: Returns the service version and build information
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.VersionInfo'
+      summary: Get service version
+      tags:
+      - health
 schemes:
 - http
 - https


### PR DESCRIPTION
## Summary

- The OTP secret was previously derived deterministically as `SHA256(userID + bundleID)`, making every challenge code predictable and permanently reusable for a given user+bundle pair
- Each token now receives a fresh random secret via `gotp.RandomSecret(16)`, stored in the `CSPAuth` document alongside the token
- On successful verification (`VerifyCSPAuth`), the secret is wiped from the DB with `$unset`, making each code non-replayable after use

## Security impact

Before this fix:
- The OTP code never changed between sessions — an intercepted code was valid indefinitely
- The code was fully computable by anyone who knew the user's MongoDB ObjectID and the bundle ID
- `HOTP.At(0)` (counter always 0) meant the "one-time" property was not enforced

After this fix:
- Each `BundleAuthToken` call generates a new unpredictable code
- The secret is deleted from the DB as soon as the voter verifies, so the code cannot be replayed in a later session
- Resend still works: the secret persists until verification, so `ResendChallenge` can regenerate the same code from the stored secret

## Test plan

- [x] `go test ./csp/...` — `TestGenerateToken`, `TestVerifySolution`, `TestBundleAuthToken`, `TestVerifyBundleAuthToken`, `TestResendChallenge`, `TestBundleAuthTokenResendAndVerifyFlow` all updated and passing
- [ ] `go test ./db/...` — `SetCSPAuth` callers updated with secret parameter
- [ ] `go test ./api/...` — CSP voting and bundle participant tests updated
- [x] `go build ./...` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Note (out-of-scope drive-by):** this branch also regenerates `docs/swagger.yaml` to add the `/version` endpoint. That endpoint already exists in `api/health.go` on `main` but its spec was never regenerated; the regen here is an unrelated doc fix picked up by `make swagger`, not part of the CSP OTP work.