### PR TITLE
fix(users): send verification email on password recovery for unverified accounts

### DIFF
--- a/api/users.go
+++ b/api/users.go
@@ -578,27 +578,46 @@ func (a *API) recoverUserPasswordHandler(w http.ResponseWriter, r *http.Request)
 		errors.ErrGenericInternalServerError.Write(w)
 		return
 	}
-	// check the user is verified
-	if user.Verified {
-		// generate a new verification code
-		code, link, err := a.generateVerificationCodeAndLink(user, db.CodeTypePasswordReset)
+	if !user.Verified {
+		// user exists but hasn't verified their email yet; send the account
+		// verification email so they can complete registration and then log in
+		code, link, err := a.generateVerificationCodeAndLink(user, db.CodeTypeVerifyAccount)
 		if err != nil {
 			log.Warnw("could not generate verification code", "error", err)
 			errors.ErrGenericInternalServerError.Write(w)
 			return
 		}
-		// send the password reset mail to the user email with the verification
-		// code and the verification link
-		if err := a.sendMail(r.Context(), user.Email, mailtemplates.PasswordResetNotification,
+		if err := a.sendMail(r.Context(), user.Email, mailtemplates.VerifyAccountNotification,
 			struct {
 				Code string
 				Link string
 			}{code, link},
 		); err != nil {
-			log.Warnw("could not send reset passworod code", "error", err)
+			log.Warnw("could not send verification code", "error", err)
 			errors.ErrGenericInternalServerError.Write(w)
 			return
 		}
+		apicommon.HTTPWriteOK(w)
+		return
+	}
+	// generate a new verification code
+	code, link, err := a.generateVerificationCodeAndLink(user, db.CodeTypePasswordReset)
+	if err != nil {
+		log.Warnw("could not generate verification code", "error", err)
+		errors.ErrGenericInternalServerError.Write(w)
+		return
+	}
+	// send the password reset mail to the user email with the verification
+	// code and the verification link
+	if err := a.sendMail(r.Context(), user.Email, mailtemplates.PasswordResetNotification,
+		struct {
+			Code string
+			Link string
+		}{code, link},
+	); err != nil {
+		log.Warnw("could not send reset password code", "error", err)
+		errors.ErrGenericInternalServerError.Write(w)
+		return
 	}
 	apicommon.HTTPWriteOK(w)
 }


### PR DESCRIPTION
## Summary

- Unverified users who called `POST /users/password/recovery` received a silent `200 OK` with no email, leaving them unable to log in **or** recover their account (deadlock: login requires `Verified=true`, recovery silently no-ops for unverified users)
- Fix: if the account exists but is not verified, re-send the account verification email so the user can complete registration
- Email enumeration protection is preserved — non-existent addresses still return `200 OK` with no email sent

## Test plan

- [x] Register a new account, do **not** verify it
- [x] Call `POST /users/password/recovery` with that email → should receive the account verification email (not a password reset email)
- [x] Verify the email using the code/link received → account becomes verified
- [x] Confirm normal password recovery now works for the verified account
- [x] Call `POST /users/password/recovery` with an unknown email → `200 OK`, no email (enumeration protection intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)