### PR TITLE
feat(api): new org bundles endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -248,6 +248,7 @@ func (a *API) initRouter() http.Handler {
 		handle(r, http.MethodDelete, organizationGroupEndpoint, a.deleteOrganizationMemberGroupHandler)
 		handle(r, http.MethodPost, organizationGroupValidateEndpoint, a.organizationMemberGroupValidateHandler)
 		handle(r, http.MethodGet, organizationJobsEndpoint, a.organizationJobsHandler)
+		handle(r, http.MethodGet, organizationBundlesEndpoint, a.organizationBundlesHandler)
 		handle(r, http.MethodPost, subscriptionsCheckout, a.stripeHandlers.CreateSubscriptionCheckout)
 		handle(r, http.MethodGet, subscriptionsCheckoutSession, a.stripeHandlers.GetCheckoutSession)
 		handle(r, http.MethodGet, subscriptionsPortal, func(w http.ResponseWriter, r *http.Request) {

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -269,6 +269,27 @@ type ListOrganizationProcesses struct {
 	Processes []db.Process `json:"processes"`
 }
 
+// OrganizationBundle represents an organization bundle. It contains the bundle ID and the main process ID.
+// swagger:model OrganizationBundle
+type OrganizationBundle struct {
+	// The ID of the bundle
+	BundleID string `json:"bundleId"`
+	// The ID of the primary process which identifies the set of processes in
+	// the bundle, no matter how many (one or more)
+	PrimaryProcessID string `json:"primaryProcessId"`
+	// The list of processes IDs in the bundle
+	Processes []string `json:"processes"`
+}
+
+// ListOrganizationBundles represents the response for listing the bundles of an organization.
+// swagger:model ListOrganizationBundles
+type ListOrganizationBundles struct {
+	// Pagination fields
+	Pagination *Pagination `json:"pagination"`
+	// List of organization bundles
+	Bundles []OrganizationBundle `json:"bundles"`
+}
+
 // ValidateMemberGroupRequest validates the request for creating or updating an organization member group.
 // Validates that either AuthFields or TwoFaFields are provided and checks for duplicates or empty fields.
 // swagger:model ValidateMemberGroupRequest

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -547,8 +547,9 @@ func (a *API) organizationJobsHandler(w http.ResponseWriter, r *http.Request) {
 //
 //	@Summary		List organization bundles and their main process
 //	@Description	Returns a paginated list of process bundles for an organization.
-//	@Description	Each entry contains the bundle ID and the primary vochain process ID (Processes[0]).
-//	@Description	Requires Manager or Admin role.
+//	@Description	Each entry contains the bundle ID, the primary vochain process ID
+//	@Description	(first element of Processes when present), and all process IDs in the bundle.
+//	@Description	Requires the user to be part of the organization (any role).
 //	@Tags			process
 //	@Accept			json
 //	@Produce		json
@@ -556,7 +557,7 @@ func (a *API) organizationJobsHandler(w http.ResponseWriter, r *http.Request) {
 //	@Param			address	path		string	true	"Organization address"
 //	@Param			page	query		int		false	"Page number (default 1)"
 //	@Param			limit	query		int		false	"Items per page (default 10, max 100)"
-//	@Success		200		{object}	apicommon.ListOrganizationBundleProcesses
+//	@Success		200		{object}	apicommon.ListOrganizationBundles
 //	@Failure		400		{object}	errors.Error	"Invalid request or organization not found"
 //	@Failure		401		{object}	errors.Error	"Unauthorized"
 //	@Failure		500		{object}	errors.Error	"Internal server error"
@@ -601,11 +602,16 @@ func (a *API) organizationBundlesHandler(w http.ResponseWriter, r *http.Request)
 	// array) and the list of processes IDs
 	finalBundles := []apicommon.OrganizationBundle{}
 	for _, bundle := range bundles {
+		// skip bundles with no processes
+		if len(bundle.Processes) == 0 {
+			continue
+		}
+		// get processes IDs
 		processes := make([]string, 0, len(bundle.Processes))
 		for _, process := range bundle.Processes {
 			processes = append(processes, process.String())
 		}
-
+		// add bundle with the primary process and all processes IDs
 		finalBundles = append(finalBundles, apicommon.OrganizationBundle{
 			BundleID:         bundle.ID.Hex(),
 			PrimaryProcessID: bundle.Processes[0].String(),

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -542,3 +542,79 @@ func (a *API) organizationJobsHandler(w http.ResponseWriter, r *http.Request) {
 		Jobs:       jobsResponse,
 	})
 }
+
+// organizationBundlesHandler godoc
+//
+//	@Summary		List organization bundles and their main process
+//	@Description	Returns a paginated list of process bundles for an organization.
+//	@Description	Each entry contains the bundle ID and the primary vochain process ID (Processes[0]).
+//	@Description	Requires Manager or Admin role.
+//	@Tags			process
+//	@Accept			json
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			address	path		string	true	"Organization address"
+//	@Param			page	query		int		false	"Page number (default 1)"
+//	@Param			limit	query		int		false	"Items per page (default 10, max 100)"
+//	@Success		200		{object}	apicommon.ListOrganizationBundleProcesses
+//	@Failure		400		{object}	errors.Error	"Invalid request or organization not found"
+//	@Failure		401		{object}	errors.Error	"Unauthorized"
+//	@Failure		500		{object}	errors.Error	"Internal server error"
+//	@Router			/organizations/{address}/processes [get]
+func (a *API) organizationBundlesHandler(w http.ResponseWriter, r *http.Request) {
+	// get the user from the request context
+	user, ok := apicommon.UserFromContext(r.Context())
+	if !ok {
+		errors.ErrUnauthorized.Write(w)
+		return
+	}
+	// get the organization info from the request context
+	org, _, ok := a.organizationFromRequest(r)
+	if !ok {
+		errors.ErrNoOrganizationProvided.Write(w)
+		return
+	}
+	// check if the user belongs to the organization
+	if _, ok := user.RoleFor(org.Address); !ok {
+		errors.ErrUnauthorized.Withf("user does not belong to the organization").Write(w)
+		return
+	}
+	// parse pagination params
+	params, err := parsePaginationParams(r.URL.Query().Get(ParamPage), r.URL.Query().Get(ParamLimit))
+	if err != nil {
+		errors.ErrMalformedURLParam.WithErr(err).Write(w)
+		return
+	}
+	// get paginated results
+	totalItems, bundles, err := a.db.ListOrganizationBundles(org.Address, params.Page, params.Limit)
+	if err != nil {
+		errors.ErrGenericInternalServerError.Withf("could not get organization bundles: %v", err).Write(w)
+		return
+	}
+	// calculate pagination
+	pagination, err := calculatePagination(params.Page, params.Limit, totalItems)
+	if err != nil {
+		errors.ErrMalformedURLParam.WithErr(err).Write(w)
+		return
+	}
+	// parse db bundles to get the primary process ID (the first one in the
+	// array) and the list of processes IDs
+	finalBundles := []apicommon.OrganizationBundle{}
+	for _, bundle := range bundles {
+		processes := make([]string, 0, len(bundle.Processes))
+		for _, process := range bundle.Processes {
+			processes = append(processes, process.String())
+		}
+
+		finalBundles = append(finalBundles, apicommon.OrganizationBundle{
+			BundleID:         bundle.ID.Hex(),
+			PrimaryProcessID: bundle.Processes[0].String(),
+			Processes:        processes,
+		})
+	}
+	// write response
+	apicommon.HTTPWriteJSON(w, &apicommon.ListOrganizationBundles{
+		Pagination: pagination,
+		Bundles:    finalBundles,
+	})
+}

--- a/api/organizations_test.go
+++ b/api/organizations_test.go
@@ -392,8 +392,10 @@ func TestOrganizationBundlesHandler(t *testing.T) {
 
 	token := testCreateUser(t, testPass)
 	orgAddress := testCreateOrganization(t, token)
-	bundle1ID, primaryProcess1 := testCreateOrganizationBundle(t, orgAddress, internal.HexBytes("api_process_1"))
-	bundle2ID, primaryProcess2 := testCreateOrganizationBundle(t, orgAddress, internal.HexBytes("api_process_2"))
+	primaryProcess1 := internal.HexBytes("primary_process_1")
+	primaryProcess2 := internal.HexBytes("primary_process_2")
+	bundle1ID := testCreateOrganizationBundle(t, orgAddress, primaryProcess1)
+	bundle2ID := testCreateOrganizationBundle(t, orgAddress, primaryProcess2)
 
 	resp, code := testRequest(t, http.MethodGet, token, nil, "organizations", orgAddress.String(), "processes")
 	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
@@ -439,10 +441,7 @@ func TestOrganizationBundlesHandler(t *testing.T) {
 	c.Assert(code, qt.Equals, http.StatusBadRequest)
 }
 
-func testCreateOrganizationBundle(t *testing.T, orgAddress common.Address, processID internal.HexBytes) (
-	internal.HexBytes,
-	internal.HexBytes,
-) {
+func testCreateOrganizationBundle(t *testing.T, orgAddress common.Address, processID internal.HexBytes) internal.HexBytes {
 	t.Helper()
 	c := qt.New(t)
 
@@ -476,7 +475,7 @@ func testCreateOrganizationBundle(t *testing.T, orgAddress common.Address, proce
 	})
 	c.Assert(err, qt.IsNil)
 
-	return bundleID, processID
+	return bundleID
 }
 
 func TestOrganizationWithOptionalFields(t *testing.T) {

--- a/api/organizations_test.go
+++ b/api/organizations_test.go
@@ -11,6 +11,8 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/internal"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 func TestCreateOrganizationHandler(t *testing.T) {
@@ -383,6 +385,98 @@ func TestOrganizationJobsHandler(t *testing.T) {
 
 	_, code = testRequest(t, http.MethodGet, token, nil, "organizations", orgAddress.String(), "jobs?limit=invalid")
 	c.Assert(code, qt.Equals, http.StatusBadRequest)
+}
+
+func TestOrganizationBundlesHandler(t *testing.T) {
+	c := qt.New(t)
+
+	token := testCreateUser(t, testPass)
+	orgAddress := testCreateOrganization(t, token)
+	bundle1ID, primaryProcess1 := testCreateOrganizationBundle(t, orgAddress, internal.HexBytes("api_process_1"))
+	bundle2ID, primaryProcess2 := testCreateOrganizationBundle(t, orgAddress, internal.HexBytes("api_process_2"))
+
+	resp, code := testRequest(t, http.MethodGet, token, nil, "organizations", orgAddress.String(), "processes")
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+
+	var bundles apicommon.ListOrganizationBundles
+	c.Assert(json.Unmarshal(resp, &bundles), qt.IsNil)
+	c.Assert(bundles.Pagination, qt.Not(qt.IsNil))
+	c.Assert(bundles.Pagination.TotalItems, qt.Equals, int64(2))
+	c.Assert(bundles.Bundles, qt.HasLen, 2)
+
+	bundlesByID := map[string]string{}
+	processesByID := map[string][]string{}
+	for _, bundle := range bundles.Bundles {
+		bundlesByID[bundle.BundleID] = bundle.PrimaryProcessID
+		processesByID[bundle.BundleID] = bundle.Processes
+	}
+	c.Assert(bundlesByID[bundle1ID.String()], qt.Equals, primaryProcess1.String())
+	c.Assert(processesByID[bundle1ID.String()], qt.HasLen, 1)
+	c.Assert(processesByID[bundle1ID.String()][0], qt.Equals, primaryProcess1.String())
+	c.Assert(bundlesByID[bundle2ID.String()], qt.Equals, primaryProcess2.String())
+	c.Assert(processesByID[bundle2ID.String()], qt.HasLen, 1)
+	c.Assert(processesByID[bundle2ID.String()][0], qt.Equals, primaryProcess2.String())
+
+	resp, code = testRequest(t, http.MethodGet, token, nil, "organizations", orgAddress.String(), "processes?page=1&limit=1")
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+	c.Assert(json.Unmarshal(resp, &bundles), qt.IsNil)
+	c.Assert(bundles.Pagination.TotalItems, qt.Equals, int64(2))
+	c.Assert(bundles.Pagination.LastPage, qt.Equals, int64(2))
+	c.Assert(bundles.Bundles, qt.HasLen, 1)
+
+	_, code = testRequest(t, http.MethodGet, "", nil, "organizations", orgAddress.String(), "processes")
+	c.Assert(code, qt.Equals, http.StatusUnauthorized)
+
+	anotherUserToken := testCreateUser(t, "anotherpassword")
+	_, code = testRequest(t, http.MethodGet, anotherUserToken, nil, "organizations", orgAddress.String(), "processes")
+	c.Assert(code, qt.Equals, http.StatusUnauthorized)
+
+	_, code = testRequest(t, http.MethodGet, token, nil, "organizations", orgAddress.String(), "processes?page=invalid")
+	c.Assert(code, qt.Equals, http.StatusBadRequest)
+
+	nonExistentAddr := common.HexToAddress("0x0000000000000000000000000000000000000001")
+	_, code = testRequest(t, http.MethodGet, token, nil, "organizations", nonExistentAddr.String(), "processes")
+	c.Assert(code, qt.Equals, http.StatusBadRequest)
+}
+
+func testCreateOrganizationBundle(t *testing.T, orgAddress common.Address, processID internal.HexBytes) (
+	internal.HexBytes,
+	internal.HexBytes,
+) {
+	t.Helper()
+	c := qt.New(t)
+
+	var root internal.HexBytes
+	c.Assert(root.ParseString("0xabcde"), qt.IsNil)
+	census := &db.Census{
+		OrgAddress: orgAddress,
+		Type:       db.CensusTypeMail,
+		Published: db.PublishedCensus{
+			Root: root,
+			URI:  "ipfs://test-census",
+		},
+	}
+	censusID, err := testDB.SetCensus(census)
+	c.Assert(err, qt.IsNil)
+	census.ID, err = primitive.ObjectIDFromHex(censusID)
+	c.Assert(err, qt.IsNil)
+
+	process := &db.Process{
+		Address:    processID,
+		OrgAddress: orgAddress,
+		Census:     *census,
+	}
+	_, err = testDB.SetProcess(process)
+	c.Assert(err, qt.IsNil)
+
+	bundleID, err := testDB.SetProcessBundle(&db.ProcessesBundle{
+		OrgAddress: orgAddress,
+		Census:     *census,
+		Processes:  []internal.HexBytes{processID},
+	})
+	c.Assert(err, qt.IsNil)
+
+	return bundleID, processID
 }
 
 func TestOrganizationWithOptionalFields(t *testing.T) {

--- a/api/routes.go
+++ b/api/routes.go
@@ -100,6 +100,8 @@ const (
 	organizationGroupValidateEndpoint = "/organizations/{address}/groups/{groupID}/validate"
 	// GET /organizations/{address}/jobs to list the organization import jobs
 	organizationJobsEndpoint = "/organizations/{address}/jobs"
+	// GET /organizations/{address}/processes to get the organization bundle processes
+	organizationBundlesEndpoint = "/organizations/{address}/processes"
 
 	// subscription routes
 	// GET /subscriptions to get the subscriptions of an organization

--- a/db/process_bundles.go
+++ b/db/process_bundles.go
@@ -205,7 +205,13 @@ func (ms *MongoStorage) ListOrganizationBundles(orgAddress common.Address, page,
 	if orgAddress.Cmp(common.Address{}) == 0 {
 		return 0, nil, ErrInvalidData
 	}
-	return paginatedDocuments[ProcessesBundle](ms.processBundles, page, limit, bson.M{"orgAddress": orgAddress}, options.Find())
+	filter := bson.M{
+		"orgAddress":  orgAddress,
+		"processes.0": bson.M{"$exists": true}, // has at least one process
+	}
+
+	sortedOptions := options.Find().SetSort(bson.D{{Key: "_id", Value: 1}})
+	return paginatedDocuments[ProcessesBundle](ms.processBundles, page, limit, filter, sortedOptions)
 }
 
 // ProcessBundlesByCensus retrieves process bundles that belong to a specific census.

--- a/db/process_bundles.go
+++ b/db/process_bundles.go
@@ -199,6 +199,15 @@ func (ms *MongoStorage) ProcessBundlesByOrg(orgAddress common.Address) ([]*Proce
 	return bundles, nil
 }
 
+// ListOrganizationBundles retrieves process bundles that belong to a specific organization.
+// This allows finding all bundles created by a particular organization with pagination.
+func (ms *MongoStorage) ListOrganizationBundles(orgAddress common.Address, page, limit int64) (int64, []ProcessesBundle, error) {
+	if orgAddress.Cmp(common.Address{}) == 0 {
+		return 0, nil, ErrInvalidData
+	}
+	return paginatedDocuments[ProcessesBundle](ms.processBundles, page, limit, bson.M{"orgAddress": orgAddress}, options.Find())
+}
+
 // ProcessBundlesByCensus retrieves process bundles that belong to a specific census.
 // This allows finding all bundles created for a particular census.
 func (ms *MongoStorage) ProcessBundlesByCensus(census *Census) ([]*ProcessesBundle, error) {

--- a/db/process_bundles_test.go
+++ b/db/process_bundles_test.go
@@ -308,6 +308,16 @@ func TestProcessBundles(t *testing.T) {
 		_, err = testDB.SetProcess(otherProcess)
 		c.Assert(err, qt.IsNil)
 
+		// Bundle with an empty processes array — should NOT appear in
+		// ListOrganizationBundles results regardless of belonging to the org.
+		emptyBundle := &ProcessesBundle{
+			OrgAddress: testOrgAddress,
+			Census:     *census,
+			Processes:  []internal.HexBytes{},
+		}
+		_, err = testDB.SetProcessBundle(emptyBundle)
+		c.Assert(err, qt.IsNil)
+
 		bundle1ID, err := testDB.SetProcessBundle(&ProcessesBundle{
 			OrgAddress: testOrgAddress,
 			Census:     *census,
@@ -329,11 +339,18 @@ func TestProcessBundles(t *testing.T) {
 
 		total, bundles, err := testDB.ListOrganizationBundles(testOrgAddress, 1, 10)
 		c.Assert(err, qt.IsNil)
+		// total must be 2 — the empty-process bundle is excluded
 		c.Assert(total, qt.Equals, int64(2))
 		c.Assert(bundles, qt.HasLen, 2)
 		bundleIDs := []string{bundles[0].ID.Hex(), bundles[1].ID.Hex()}
 		c.Assert(bundleIDs, qt.Contains, bundle1ID.String())
 		c.Assert(bundleIDs, qt.Contains, bundle2ID.String())
+
+		// Verify deterministic ascending sort order (by MongoDB _id)
+		// ObjectID hex values are lexicographically sortable and advance
+		// monotonically, so creation order == natural sort order.
+		c.Assert(bundleIDs[0] < bundleIDs[1], qt.IsTrue,
+			qt.Commentf("bundles must be sorted in ascending order by ID (ObjectID hex)"))
 
 		total, bundles, err = testDB.ListOrganizationBundles(testOrgAddress, 2, 1)
 		c.Assert(err, qt.IsNil)

--- a/db/process_bundles_test.go
+++ b/db/process_bundles_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -278,6 +279,74 @@ func TestProcessBundles(t *testing.T) {
 		bundles, err = testDB.ProcessBundlesByCensus(censusWithoutBundles)
 		c.Assert(err, qt.IsNil)
 		c.Assert(bundles, qt.HasLen, 0)
+	})
+
+	t.Run("TestListOrganizationBundles", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		census := setupTestPrerequisites1(c, testDB)
+
+		otherOrg := &Organization{Address: testAnotherOrgAddress}
+		c.Assert(testDB.SetOrganization(otherOrg), qt.IsNil)
+		otherCensus := &Census{
+			OrgAddress: testAnotherOrgAddress,
+			Type:       CensusTypeMail,
+			Published:  census.Published,
+		}
+		otherCensusID, err := testDB.SetCensus(otherCensus)
+		c.Assert(err, qt.IsNil)
+		otherCensus.ID, err = primitive.ObjectIDFromHex(otherCensusID)
+		c.Assert(err, qt.IsNil)
+
+		process1 := createTestProcess(c, testDB, testProcessID, census)
+		process2 := createTestProcess(c, testDB, testProcessID2, census)
+		otherProcess := &Process{
+			Address:    testProcessID3,
+			OrgAddress: testAnotherOrgAddress,
+			Census:     *otherCensus,
+			Metadata:   testProcessMetadata,
+		}
+		_, err = testDB.SetProcess(otherProcess)
+		c.Assert(err, qt.IsNil)
+
+		bundle1ID, err := testDB.SetProcessBundle(&ProcessesBundle{
+			OrgAddress: testOrgAddress,
+			Census:     *census,
+			Processes:  []internal.HexBytes{process1.Address},
+		})
+		c.Assert(err, qt.IsNil)
+		bundle2ID, err := testDB.SetProcessBundle(&ProcessesBundle{
+			OrgAddress: testOrgAddress,
+			Census:     *census,
+			Processes:  []internal.HexBytes{process2.Address},
+		})
+		c.Assert(err, qt.IsNil)
+		_, err = testDB.SetProcessBundle(&ProcessesBundle{
+			OrgAddress: testAnotherOrgAddress,
+			Census:     *otherCensus,
+			Processes:  []internal.HexBytes{otherProcess.Address},
+		})
+		c.Assert(err, qt.IsNil)
+
+		total, bundles, err := testDB.ListOrganizationBundles(testOrgAddress, 1, 10)
+		c.Assert(err, qt.IsNil)
+		c.Assert(total, qt.Equals, int64(2))
+		c.Assert(bundles, qt.HasLen, 2)
+		bundleIDs := []string{bundles[0].ID.Hex(), bundles[1].ID.Hex()}
+		c.Assert(bundleIDs, qt.Contains, bundle1ID.String())
+		c.Assert(bundleIDs, qt.Contains, bundle2ID.String())
+
+		total, bundles, err = testDB.ListOrganizationBundles(testOrgAddress, 2, 1)
+		c.Assert(err, qt.IsNil)
+		c.Assert(total, qt.Equals, int64(2))
+		c.Assert(bundles, qt.HasLen, 1)
+
+		total, bundles, err = testDB.ListOrganizationBundles(testThirdOrgAddress, 1, 10)
+		c.Assert(err, qt.IsNil)
+		c.Assert(total, qt.Equals, int64(0))
+		c.Assert(bundles, qt.HasLen, 0)
+
+		_, _, err = testDB.ListOrganizationBundles(common.Address{}, 1, 10)
+		c.Assert(err, qt.Equals, ErrInvalidData)
 	})
 
 	t.Run("TestAddProcessesToBundle", func(_ *testing.T) {

--- a/db/types.go
+++ b/db/types.go
@@ -47,14 +47,19 @@ type UserVerification struct {
 // TODO this is the default role function while it should be
 // used only when it is not necessary to consult the DB
 func (u *User) HasRoleFor(address common.Address, role UserRole) bool {
+	currentRole, ok := u.RoleFor(address)
+	return ok && currentRole == role
+}
+
+// RoleFor returns the role of the user in the organization with the given
+// address
+func (u *User) RoleFor(address common.Address) (UserRole, bool) {
 	for _, org := range u.Organizations {
-		if org.Address == address &&
-			// Check if the role matches the organization role
-			string(org.Role) == string(role) {
-			return true
+		if org.Address == address {
+			return org.Role, true
 		}
 	}
-	return false
+	return "", false
 }
 
 type UserRole string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -272,6 +272,18 @@ definitions:
         - $ref: '#/definitions/apicommon.Pagination'
         description: Pagination fields
     type: object
+  apicommon.ListOrganizationBundles:
+    properties:
+      bundles:
+        description: List of organization bundles
+        items:
+          $ref: '#/definitions/apicommon.OrganizationBundle'
+        type: array
+      pagination:
+        allOf:
+        - $ref: '#/definitions/apicommon.Pagination'
+        description: Pagination fields
+    type: object
   apicommon.ListOrganizationMemberGroupResponse:
     properties:
       members:
@@ -427,6 +439,22 @@ definitions:
           items:
             type: integer
           type: array
+        type: array
+    type: object
+  apicommon.OrganizationBundle:
+    properties:
+      bundleId:
+        description: The ID of the bundle
+        type: string
+      primaryProcessId:
+        description: |-
+          The ID of the primary process which identifies the set of processes in
+          the bundle, no matter how many (one or more)
+        type: string
+      processes:
+        description: The list of processes IDs in the bundle
+        items:
+          type: string
         type: array
     type: object
   apicommon.OrganizationCensus:
@@ -2633,6 +2661,53 @@ paths:
       summary: Check the progress of adding members
       tags:
       - organizations
+  /organizations/{address}/processes:
+    get:
+      consumes:
+      - application/json
+      description: |-
+        Returns a paginated list of process bundles for an organization.
+        Each entry contains the bundle ID, the primary vochain process ID
+        (first element of Processes when present), and all process IDs in the bundle.
+        Requires the user to be part of the organization (any role).
+      parameters:
+      - description: Organization address
+        in: path
+        name: address
+        required: true
+        type: string
+      - description: Page number (default 1)
+        in: query
+        name: page
+        type: integer
+      - description: Items per page (default 10, max 100)
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apicommon.ListOrganizationBundles'
+        "400":
+          description: Invalid request or organization not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+      security:
+      - BearerAuth: []
+      summary: List organization bundles and their main process
+      tags:
+      - process
   /organizations/{address}/processes/drafts:
     get:
       consumes:


### PR DESCRIPTION
### Goal                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                     
Provide a paginated API endpoint that allows organization managers/admins to retrieve the list of process bundles belonging to their organization, exposing the bundle ID, its primary (first) process, and all associated process IDs.                                                              
                                                                                                                                                                                                                                                                                                     
### Summary                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                     
This PR introduces the full stack (types, database method, API handler, route, and tests) for a new read‑only endpoint `GET /organizations/{address}/processes` that returns a paginated list of process bundles for a given organization. It also refactors the existing `HasRoleFor` method on the `User` type by extracting a reusable `RoleFor` helper that returns the user's role for an organization, which the new handler uses to authorize the request.                                                                                                                                                 
                                                                                                                                                                                                                                                                                                     
### Main Changes                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                     
1. New API types (`api/apicommon/types.go`) 
    - Added `OrganizationBundle` struct: holds `bundleId`, `primaryProcessId` (the first process in the bundle), and `processes` (all process IDs in the bundle).
    - Added `ListOrganizationBundles` struct: wraps a `Pagination` object and a slice of `OrganizationBundle`.
2. New DB pagination method (`db/process_bundles.go`).
    - Added `ListOrganizationBundles(orgAddress, page, limit)`: retrieves process bundles filtered by organization address using the existing `paginatedDocuments` generic.
  - Validates that the organization address is non‑zero; returns `ErrInvalidData` otherwise.                                                                                                                                                                                                                                                                                                     
3. New HTTP handler and route (`api/organizations.go`, `api/routes.go`, `api/api.go`).
    - Registered `GET /organizations/{address}/processes` → `organizationBundlesHandler`.                                                                                                                                                                                                                    
    - The handler:
      - Authenticates the user via bearer token.
      - Resolves the organization from the request context.
      - Authorizes the request using the new `RoleFor` helper (requires the user to have a role in the organization).
      - Parses `page`/`limit` query parameters.
      - Calls `db.ListOrganizationBundles`, calculates pagination metadata, maps DB bundles to the API `OrganizationBundle` type, and writes the JSON response.
4. Refactored user role lookup (db/types.go)
    - Extracted `RoleFor(address) (UserRole, bool)` from the existing `HasRoleFor` method.
    - `HasRoleFor` now delegates to `RoleFor` and checks the specific role match.
    - `RoleFor` returns the user's role for a given organization, enabling the new handler to do a simple membership check rather than a specific‑role check.
5. Tests (`api/organizations_test.go`, `db/process_bundles_test.go`):
    - API test: `TestOrganizationBundlesHandler` creates two test bundles, verifies paginated response shape, checks authorization failures (no token, non‑member user), malformed pagination params, and non‑existent org address.
    - DB test: `TestListOrganizationBundles` creates bundles across multiple organizations, verifies correct filtering, pagination (page size/offset), empty results for orgs without bundles, and invalid address validation.
    - Added `testCreateOrganizationBundle` test helper for setting up prerequisites (census, process, bundle).