### PR TITLE
docs(plan): add Phase 6 non-CSP (merkle/weighted/dynamic) election support

### DIFF
--- a/plan/APP_SDK_PLAN.md
+++ b/plan/APP_SDK_PLAN.md
@@ -90,14 +90,16 @@ transaction, tx hash, token, gas, faucet, signer, or private key:
   `AuthService`; callers never pass or read a token.
 - **Organizer ops** (create org / census / draft / publish / setStatus) are plain awaited REST
   calls returning resource ids (org address, `processId`). The SaaS forges and confirms every tx.
-  The three on-chain actions — `publish`, `setStatus`, `vote` — are **async on the wire** (the SaaS
-  returns `202` + a `jobId` and confirms on a background worker), but the SDK hides this: each method
-  enqueues, then polls `GET /jobs/{jobId}` until the job completes and resolves with the on-chain
-  result (or rejects on a failed job). Consumers just `await` and never see the job id.
-- **Voting** takes `vote(processId, choices)`. The ephemeral voter key needed to sign the CSP
+  The on-chain actions — `publish`, `setStatus`, dynamic census add, `vote` — are **async on the
+  wire** (the SaaS returns `202` + a `jobId` and confirms on a background worker), but the SDK hides
+  this: each method enqueues, then polls `GET /jobs/{jobId}` until the job completes and resolves with
+  the on-chain result (or rejects on a failed job). Consumers just `await` and never see the job id.
+- **Voting** takes `vote(processId, choices)`. The ephemeral voter key needed to sign the vote
   envelope is **generated and held internally by `VoteService`** (kept for the session so a
   re-vote/overwrite reuses the same nullifier). The integrator passes choices, gets back a
-  `voteId` receipt — no key handling, no envelope, no tx, no polling.
+  `voteId` receipt — no key handling, no envelope, no tx, no polling. `vote()` transparently handles
+  both the CSP path (blind signature) and the non-CSP Merkle path (proof fetched from the SaaS); the
+  consumer never sees the difference.
 
 The only crypto the SDK owns (the vote envelope, §5) runs entirely under the hood; it is an
 implementation detail of `vote()`, not part of the consumer surface.
@@ -143,6 +145,11 @@ the relay are all internal to `vote()`. `CspService` holds the completed auth to
 so `vote()` can use it.
 
 ### `vote(processId, choices)` internally
+`vote()` branches on the election's census origin, but the consumer surface is identical for both —
+they pass `choices`, get back a `{voteId}`. Blockchain concepts (proofs, envelopes, keys) stay
+hidden.
+
+**CSP census:**
 1. `electionService.results(processId)` (or a get) → process params needed for the envelope
    (censusOrigin=CSP, voteOptions, encryption pubkeys if `secretUntilTheEnd`).
 2. Use the **internally generated** ephemeral voter key (held by `VoteService` for the session)
@@ -152,13 +159,25 @@ so `vote()` can use it.
 4. `voteService.relay(processId, txPayload)` → `POST /process/{processId}/vote` → `202 {jobId}`,
    then `awaitJob(jobId)` → `{voteID}` (the receipt). The poll is internal to `vote()`.
 
+**Non-CSP (`weighted`/`zkweighted`) census:**
+1. `electionService.results(processId)` (or a get) → process params (censusOrigin = weighted,
+   voteOptions, `anonymous`).
+2. `voteService.censusProof(processId, voterAddress)` → `GET /process/{processId}/census/proof?key=`
+   — the SaaS proxies the Merkle proof; no client-side proof generation.
+3. `core/vote.ts` builds `VoteEnvelope` with the **Merkle proof** (`ProofArbo`) in place of
+   `ProofCA`, packages votes, signs with the internal voter key → hex `SignedTx`. (For
+   `zkweighted`/anonymous, the ZK proof path is out of scope for this round — see §5.)
+4. `voteService.relay(processId, txPayload)` → the **same** `POST /process/{processId}/vote` →
+   `202 {jobId}`, then `awaitJob(jobId)` → `{voteID}`. The relay accepts CSP- or proof-authorized
+   envelopes; the poll is internal to `vote()`.
+
 ## 5. Ported minimal vote-envelope module (the only crypto we own)
 
-Port from `other-repos/vocdoni-sdk/` (copy + trim to the CSP path only):
+Port from `other-repos/vocdoni-sdk/` (copy + trim to the CSP and Merkle non-anonymous paths):
 
 | Port into | From vocdoni-sdk |
 |-----------|------------------|
-| `core/vote.ts` `generateVoteTransaction` (CSP `ProofCA` branch), `packageVoteContent`, `cspCaBundle`, `encodeCspCaBundle` | `src/core/vote.ts` |
+| `core/vote.ts` `generateVoteTransaction` (CSP `ProofCA` branch **and** the Merkle `ProofArbo` branch), `packageVoteContent`, `cspCaBundle`, `encodeCspCaBundle` | `src/core/vote.ts` |
 | `core/transaction.ts` `encodeTransaction`, `hashTransaction` | `src/core/transaction.ts` |
 | `util/signing.ts` `Signing.signTransaction` | `src/util/signing.ts` |
 | `util/blind-signing.ts` `CensusBlind` (blind/unblind, decodePoint), `getBlindedPayload` | `src/util/blind-signing.ts` |
@@ -167,14 +186,22 @@ Port from `other-repos/vocdoni-sdk/` (copy + trim to the CSP path only):
 | types `Vote`, `CspVote`, `VotePackage`, `CspProofType` | `src/types/vote/*` |
 
 External deps for this module (same versions as vocdoni-sdk):
-- `@vocdoni/proto` — `VoteEnvelope`, `Tx`, `SignedTx`, `ProofCA`, `ProofCA_Type`, `CAbundle`.
+- `@vocdoni/proto` — `VoteEnvelope`, `Tx`, `SignedTx`, `ProofCA`, `ProofCA_Type`, `CAbundle`, plus
+  `ProofArbo`, `ProofArbo_Type`, `ProofArbo_KeyType` for the Merkle branch.
 - `@ethersproject/wallet` + `@ethersproject/keccak256` (ethers v5) — sign + hash.
 - `blindsecp256k1` — CSP blind/unblind.
 - `tweetnacl` — encrypted-vote sealedbox (phase 2 only).
 
+The **Merkle proof itself is not generated client-side** — the SDK fetches it from
+`GET /process/{processId}/census/proof` (the SaaS proxies the chain's `CensusGenProof`) and only
+**embeds** it as a `ProofArbo` in the envelope. So no Merkle/Arbo proof-generation code is ported;
+the added surface is just the envelope branch that wraps an already-fetched proof.
+
 **Explicitly NOT ported** (now done server-side by the SaaS): election creation
-(`core/election.ts`), account crypto (`core/account.ts`), Merkle/offchain census proofs,
-ZK/anonymous (`snarkjs`/`circomlibjs`), Census3. This keeps the SDK lean and dependency-light.
+(`core/election.ts`), account crypto (`core/account.ts`), Merkle/offchain census proof
+**generation** (fetched from the SaaS instead — only proof *embedding* is ported),
+ZK/anonymous (`snarkjs`/`circomlibjs`, so `zkweighted` anonymous voting is out of scope this round),
+Census3. This keeps the SDK lean and dependency-light.
 
 ## 6. Phases
 
@@ -184,8 +211,10 @@ ZK/anonymous (`snarkjs`/`circomlibjs`), Census3. This keeps the SDK lean and dep
 2. **Auth + Org + Census** services (pure REST) + unit tests.
 3. **Election** service: `createDraft/updateDraft/publish/setStatus/get/results` against the
    new SaaS endpoints.
-4. **Vote**: port the minimal crypto module (§5), implement `csp.*` + `vote()`, integration
-   test against a running SaaS + Voconed (publish → CSP auth/sign → vote → results).
+4. **Vote**: port the minimal crypto module (§5), implement `csp.*` + `vote()` for **both** the CSP
+   and the non-CSP Merkle path (`voteService.censusProof` → `ProofArbo` envelope), integration test
+   against a running SaaS + Voconed (publish → {CSP auth/sign | fetch census proof} → vote →
+   results).
 5. **Encrypted votes** (optional): NaCl sealedbox path for `secretUntilTheEnd` elections.
 6. **Docs + examples**, publish to npm, then migrate the vocdoni.app UI (§7).
 

--- a/plan/APP_SDK_PLAN.md
+++ b/plan/APP_SDK_PLAN.md
@@ -90,10 +90,14 @@ transaction, tx hash, token, gas, faucet, signer, or private key:
   `AuthService`; callers never pass or read a token.
 - **Organizer ops** (create org / census / draft / publish / setStatus) are plain awaited REST
   calls returning resource ids (org address, `processId`). The SaaS forges and confirms every tx.
+  The three on-chain actions — `publish`, `setStatus`, `vote` — are **async on the wire** (the SaaS
+  returns `202` + a `jobId` and confirms on a background worker), but the SDK hides this: each method
+  enqueues, then polls `GET /jobs/{jobId}` until the job completes and resolves with the on-chain
+  result (or rejects on a failed job). Consumers just `await` and never see the job id.
 - **Voting** takes `vote(processId, choices)`. The ephemeral voter key needed to sign the CSP
   envelope is **generated and held internally by `VoteService`** (kept for the session so a
   re-vote/overwrite reuses the same nullifier). The integrator passes choices, gets back a
-  `voteId` receipt — no key handling, no envelope, no tx.
+  `voteId` receipt — no key handling, no envelope, no tx, no polling.
 
 The only crypto the SDK owns (the vote envelope, §5) runs entirely under the hood; it is an
 implementation detail of `vote()`, not part of the consumer surface.
@@ -109,12 +113,16 @@ Integr.:  createManagedOrganization(integratorAddr, info)           // POST /org
           integratorInfo(integratorAddr): {enabled,limits,usage}    // GET  /organizations/{addr}/integrator
 Census:   createCensus(fromGroupId|members)  getCensus(id)         // /census
 Election: createDraft(params)  updateDraft(id,params)
-          publish(draftId): Promise<{processId}>                   // POST /process/{id}/publish
-          setStatus(processId, 'ready'|'paused'|'ended'|'canceled')// PUT  /process/{id}/status
+          publish(draftId): Promise<{processId}>                   // POST /process/{id}/publish → 202; polls /jobs/{jobId}
+          setStatus(processId, 'ready'|'paused'|'ended'|'canceled')// PUT  /process/{id}/status   → 202; polls /jobs/{jobId}
           get(draftId)  results(processId)                          // GET  /process/{id}[/results]
 Voter:    csp.info(bundleId)  csp.auth(bundleId,step,data)          // OTP challenge: consumer enters the code
-          vote(processId, choices): Promise<{voteId}>               // CSP sign + envelope + relay, all internal
+          vote(processId, choices): Promise<{voteId}>               // CSP sign + envelope + relay (202) + poll, all internal
 ```
+
+The `202` + `jobId` poll loop lives in a small shared helper (`awaitJob(jobId)`) inside the
+HTTP client, reused by `publish`, `setStatus` and `vote`; it polls `GET /jobs/{jobId}` until
+`status` is `completed` (resolve with `result`) or `failed` (reject with `error`).
 
 `election.publish/setStatus/results`, `vote`, and the integrator methods are the new managed
 endpoints; everything else maps to today's API. The integrator never constructs a transaction.
@@ -140,8 +148,9 @@ so `vote()` can use it.
 2. Use the **internally generated** ephemeral voter key (held by `VoteService` for the session)
    and the CSP auth token from the completed `csp.auth` → CSP blind-sign → unblinded signature.
 3. `core/vote.ts` builds `VoteEnvelope` with `ProofCA` (CSP), packages votes, signs with the
-   internal voter key → base64 `SignedTx`.
-4. `voteService.relay(processId, txPayload)` → `POST /process/{processId}/vote` → `{voteId}`.
+   internal voter key → hex `SignedTx`.
+4. `voteService.relay(processId, txPayload)` → `POST /process/{processId}/vote` → `202 {jobId}`,
+   then `awaitJob(jobId)` → `{voteID}` (the receipt). The poll is internal to `vote()`.
 
 ## 5. Ported minimal vote-envelope module (the only crypto we own)
 

--- a/plan/APP_SDK_PLAN.md
+++ b/plan/APP_SDK_PLAN.md
@@ -1,0 +1,206 @@
+# APP_SDK_PLAN.md — `vocdoni-app-sdk`
+
+A brand-new TypeScript SDK that consumes **only** the SaaS REST API (the existing endpoints plus
+the new managed, chain-abstracted ones). Used by third-party integrators and by the vocdoni.app UI
+itself. It mirrors the **structure and coding style of `@vocdoni/sdk`** (in
+`other-repos/vocdoni-sdk/`) but talks to the SaaS, not the Vochain.
+
+Design decisions already locked:
+- **Standalone**: no `@vocdoni/sdk` dependency. The one piece of Vochain crypto needed —
+  building + signing the vote envelope — is a **minimal ported module** (see §5).
+- **Thin vote relay**: the SDK builds + signs the vote locally and POSTs the opaque envelope
+  to the SaaS `/process/{id}/vote`; the SaaS never sees plaintext.
+- Organizer flows are **plain REST** (the SaaS forges all txs).
+
+## 1. Tooling & conventions (match vocdoni-sdk exactly)
+
+Mirror `other-repos/vocdoni-sdk/`:
+- **Package**: `@vocdoni/app-sdk` (name TBD), AGPL-3.0, `main: src/index.ts`.
+- **Build**: Rollup + esbuild (`rollup.config.mjs`), node-polyfills, outputs
+  `dist/index.{js,mjs,umd.js,d.ts}` (CJS/ESM/UMD + types).
+- **TS**: `tsconfig.json` target `esnext`, `moduleResolution nodenext`,
+  `noImplicitReturns`, `noUnusedLocals/Parameters`.
+- **Tests**: Jest (ts-jest), split `test/unit/`, `test/api/`, `test/integration/`.
+- **Lint/format**: ESLint + Prettier — 120 width, single quotes, trailing commas, no semis if
+  vocdoni-sdk omits them (match its `.prettierrc`).
+- **Repo location**: a new repo `vocdoni-app-sdk` (sibling of vocdoni-sdk/vocdoni-app).
+
+## 2. Source layout (mirror vocdoni-sdk's split)
+
+```
+src/
+  index.ts                 // barrel: export * from client/types/api/services/util
+  client.ts                // VocdoniAppClient (service composition, like VocdoniSDKClient)
+  api/                     // thin REST wrappers, one file per SaaS domain
+    auth.ts                //   /auth/login,/refresh,/addresses
+    organization.ts        //   /organizations... (+ managed-org + integrator endpoints)
+    census.ts              //   /census, members, groups
+    process.ts             //   /process create/update/publish/status/results
+    csp.ts                 //   /process/bundle/{id}/auth|sign|check|weight
+    vote.ts                //   /process/{id}/vote (relay)
+    index.ts
+  services/                // business logic over api/ (like vocdoni-sdk services)
+    auth.ts organization.ts census.ts election.ts vote.ts csp.ts
+    service.ts             // base Service (shared url/token)
+    index.ts
+  types/                   // domain types + validation (yup, like vocdoni-sdk)
+    organization/ census/ process/ vote/ auth/
+    index.ts
+  core/                    // the ONLY Vochain crypto — ported, minimal (see §5)
+    vote.ts                // VoteCore: envelope + CSP ProofCA assembly
+    transaction.ts         // encode/hash/sign SignedTx -> base64
+  util/
+    common.ts              // strip0x/ensure0x/getHex (port)
+    signing.ts             // ethers signMessage wrapper (port)
+    blind-signing.ts       // CensusBlind blind/unblind (port)
+    encryption.ts          // NaCl sealedbox for encrypted votes (port, optional/phase 2)
+    constants.ts           // SAAS_URL defaults per env, tx message templates
+```
+
+## 3. Main client (composition like `VocdoniSDKClient`)
+
+```ts
+export type AppClientOptions = {
+  env: EnvOptions               // DEV | STG | PROD (maps to default SaaS URL)
+  api_url?: string              // SaaS base URL override (that's it — no token, no wallet)
+}
+
+export class VocdoniAppClient {
+  public authService: AuthService             // owns the JWT internally (login/refresh)
+  public organizationService: OrganizationService
+  public censusService: CensusService
+  public electionService: ElectionService     // create/publish/status/results (REST)
+  public cspService: CspService               // CSP two-factor (REST)
+  public voteService: VoteService             // build+sign envelope, relay (owns voter key)
+  public url: string
+  // No public token, wallet, or signer. The JWT and the ephemeral voter key are private,
+  // managed by AuthService / VoteService respectively.
+}
+```
+
+Service-based composition with DI, identical to vocdoni-sdk's `client.ts`. `index.ts` is a
+barrel re-exporting `client`, `types`, `api`, `services`, `util/common`.
+
+### Consumer experience: no blockchain surface
+
+The SDK's public API is **100% like a standard SaaS client** — the integrator never sees a
+transaction, tx hash, token, gas, faucet, signer, or private key:
+
+- **Auth** is just `login(email, password)`. The JWT is stored and refreshed inside
+  `AuthService`; callers never pass or read a token.
+- **Organizer ops** (create org / census / draft / publish / setStatus) are plain awaited REST
+  calls returning resource ids (org address, `processId`). The SaaS forges and confirms every tx.
+- **Voting** takes `vote(processId, choices)`. The ephemeral voter key needed to sign the CSP
+  envelope is **generated and held internally by `VoteService`** (kept for the session so a
+  re-vote/overwrite reuses the same nullifier). The integrator passes choices, gets back a
+  `voteId` receipt — no key handling, no envelope, no tx.
+
+The only crypto the SDK owns (the vote envelope, §5) runs entirely under the hood; it is an
+implementation detail of `vote()`, not part of the consumer surface.
+
+## 4. Public method surface (maps 1:1 to SaaS endpoints)
+
+```
+Auth:     login(email,password) refresh() logout() me()            // /auth/*, /users/me
+Org:      createOrganization(...)  getOrganization(addr)            // POST forges the on-chain account server-side
+          members.* (list/add/import CSV/delete)  groups.*          // /organizations/*
+Integr.:  createManagedOrganization(integratorAddr, info)           // POST /organizations/{addr}/managed
+          listManagedOrganizations(integratorAddr)                  // GET  /organizations/{addr}/managed
+          integratorInfo(integratorAddr): {enabled,limits,usage}    // GET  /organizations/{addr}/integrator
+Census:   createCensus(fromGroupId|members)  getCensus(id)         // /census
+Election: createDraft(params)  updateDraft(id,params)
+          publish(draftId): Promise<{processId}>                   // POST /process/{id}/publish
+          setStatus(processId, 'ready'|'paused'|'ended'|'canceled')// PUT  /process/{id}/status
+          get(draftId)  results(processId)                          // GET  /process/{id}[/results]
+Voter:    csp.info(bundleId)  csp.auth(bundleId,step,data)          // OTP challenge: consumer enters the code
+          vote(processId, choices): Promise<{voteId}>               // CSP sign + envelope + relay, all internal
+```
+
+`election.publish/setStatus/results`, `vote`, and the integrator methods are the new managed
+endpoints; everything else maps to today's API. The integrator never constructs a transaction.
+
+**Chain-abstracted org creation:** `createOrganization` is a single REST call that sets
+`provisionAccount: true`, so the SaaS forges the org's on-chain `CreateAccount` server-side
+(idempotent). The SDK does **not** call `createAccount` and does **not** wire a `RemoteSigner`;
+there is no account/faucet/tx step on the org-creation path. (The flag is opt-in on the API, which
+keeps the legacy UI's two-step flow working; the new SDK always opts in.)
+
+**Integrator methods are optional** — they only succeed for integrator-enabled orgs. Managed
+(client) organizations are **first-class** orgs: each has its own address, on-chain account, and
+invitable members, and is linked to the integrator by `managedBy`. They are not sub-orgs.
+
+Only `csp.auth` is consumer-driven, because the two-factor challenge needs the human to enter the
+OTP they receive by email/SMS. The blind-signature step, the ephemeral voter key, the envelope and
+the relay are all internal to `vote()`. `CspService` holds the completed auth token for the session
+so `vote()` can use it.
+
+### `vote(processId, choices)` internally
+1. `electionService.results(processId)` (or a get) → process params needed for the envelope
+   (censusOrigin=CSP, voteOptions, encryption pubkeys if `secretUntilTheEnd`).
+2. Use the **internally generated** ephemeral voter key (held by `VoteService` for the session)
+   and the CSP auth token from the completed `csp.auth` → CSP blind-sign → unblinded signature.
+3. `core/vote.ts` builds `VoteEnvelope` with `ProofCA` (CSP), packages votes, signs with the
+   internal voter key → base64 `SignedTx`.
+4. `voteService.relay(processId, txPayload)` → `POST /process/{processId}/vote` → `{voteId}`.
+
+## 5. Ported minimal vote-envelope module (the only crypto we own)
+
+Port from `other-repos/vocdoni-sdk/` (copy + trim to the CSP path only):
+
+| Port into | From vocdoni-sdk |
+|-----------|------------------|
+| `core/vote.ts` `generateVoteTransaction` (CSP `ProofCA` branch), `packageVoteContent`, `cspCaBundle`, `encodeCspCaBundle` | `src/core/vote.ts` |
+| `core/transaction.ts` `encodeTransaction`, `hashTransaction` | `src/core/transaction.ts` |
+| `util/signing.ts` `Signing.signTransaction` | `src/util/signing.ts` |
+| `util/blind-signing.ts` `CensusBlind` (blind/unblind, decodePoint), `getBlindedPayload` | `src/util/blind-signing.ts` |
+| `util/common.ts` `strip0x/ensure0x/getHex` | `src/util/common.ts` |
+| `util/encryption.ts` NaCl sealedbox (encrypted votes — phase 2) | `src/util/encryption.ts` |
+| types `Vote`, `CspVote`, `VotePackage`, `CspProofType` | `src/types/vote/*` |
+
+External deps for this module (same versions as vocdoni-sdk):
+- `@vocdoni/proto` — `VoteEnvelope`, `Tx`, `SignedTx`, `ProofCA`, `ProofCA_Type`, `CAbundle`.
+- `@ethersproject/wallet` + `@ethersproject/keccak256` (ethers v5) — sign + hash.
+- `blindsecp256k1` — CSP blind/unblind.
+- `tweetnacl` — encrypted-vote sealedbox (phase 2 only).
+
+**Explicitly NOT ported** (now done server-side by the SaaS): election creation
+(`core/election.ts`), account crypto (`core/account.ts`), Merkle/offchain census proofs,
+ZK/anonymous (`snarkjs`/`circomlibjs`), Census3. This keeps the SDK lean and dependency-light.
+
+## 6. Phases
+
+1. **Scaffold** repo with vocdoni-sdk tooling (rollup/tsconfig/jest/eslint/prettier), empty
+   `VocdoniAppClient`, `Service` base, `api/` HTTP layer (fetch/axios wrapper with JWT +
+   refresh, mirroring the app's current `api()` wrapper).
+2. **Auth + Org + Census** services (pure REST) + unit tests.
+3. **Election** service: `createDraft/updateDraft/publish/setStatus/get/results` against the
+   new SaaS endpoints.
+4. **Vote**: port the minimal crypto module (§5), implement `csp.*` + `vote()`, integration
+   test against a running SaaS + Voconed (publish → CSP auth/sign → vote → results).
+5. **Encrypted votes** (optional): NaCl sealedbox path for `secretUntilTheEnd` elections.
+6. **Docs + examples**, publish to npm, then migrate the vocdoni.app UI (§7).
+
+## 7. vocdoni.app UI migration
+
+The UI currently uses `@vocdoni/sdk` + `RemoteSigner` (`src/components/Auth/*`,
+`src/queries/*`). Migration:
+- Replace the `RemoteSigner`/`VocdoniSDKClient` wiring with `VocdoniAppClient` (token-based).
+- Repoint `src/queries/*` data access to the new SDK's services (they already wrap the same
+  SaaS endpoints, so most query functions become thin pass-throughs).
+- Voting components call `client.vote(processId, choices)` instead of building envelopes.
+- Keep the migration incremental: the SaaS keeps `/transactions` alive, so the old and new
+  paths can coexist per-route during the switch.
+
+## 8. Testing
+
+- **Unit** (jest, no network): envelope assembly determinism, CSP proof bundle encoding,
+  blind/unblind round-trip, request builders.
+- **Integration**: against a local SaaS (`docker compose up` with `--profile with-vocone`):
+  login → create org/census → createDraft → publish → CSP auth/sign → vote → results.
+- Mirror vocdoni-sdk's `test/integration` structure (csp/election/account folders).
+
+## Definition of done
+
+Lint clean, build produces CJS/ESM/UMD + types, unit + integration suites green against a
+local SaaS, and the vocdoni.app UI builds against the new SDK for at least the org + voting
+flows.

--- a/plan/BACKEND_PLAN.md
+++ b/plan/BACKEND_PLAN.md
@@ -1,0 +1,353 @@
+# BACKEND_PLAN.md — Managed chain-abstraction for the SaaS API
+
+Goal: extend the SaaS backend so it forges + funds + signs + submits + confirms every
+organizer transaction, and relays client-signed votes — so integrators (and the new
+`vocdoni-app-sdk`) never call the Vochain or use `@vocdoni/sdk`.
+
+The model stays **organization-based**, exactly like the vocdoni.app UI today: a user registers,
+creates an organization (which now gets its on-chain account server-side), and the organization's
+admins/managers create elections under it. On top of that we add an **integrator** capability: a
+special organization that can create and manage organizations for its own clients via the API,
+under an accountable quota.
+
+This document is the build plan for:
+
+- an optional `electionParams` field on draft create/update,
+- **chain-abstracted organization creation** (the SaaS forges `CreateAccount` for the org),
+- the managed election endpoints: `POST /process/{draftId}/publish`,
+  `PUT /process/{processId}/status`, `POST /process/{processId}/vote`,
+  `GET /process/{processId}/results`, `GET /process/{processId}/metadata`,
+- the **integrator** layer: managed-organization creation/listing, plan + manual quota, and
+  quota enforcement that rolls election/census usage up to the integrator.
+
+## Non-negotiable: do not break the current API
+
+- **Keep** `POST /transactions` and `/transactions/message` (`api/transaction.go`) exactly
+  as-is. The old `RemoteSigner` path must keep working during and after the migration.
+- **Keep** `POST /process`, `PUT /process/{id}`, `GET /process/{id}`,
+  `GET /organizations/{address}/processes[/drafts]` behavior. Only add **optional** request
+  fields and **optional** struct fields.
+- `POST /organizations` stays **backwards compatible**. It gains **one optional request field**,
+  `provisionAccount` (default `false`): when set, the SaaS forges the org's on-chain
+  `CreateAccount` server-side (idempotent — see "Chain-abstracted organization creation").
+  Omitted/false → byte-for-byte today's behavior (DB row only; the on-chain account is still
+  created by the legacy SDK `createAccount` via `/transactions`, same latency, same failure modes).
+  The new SDK sets `provisionAccount: true`; the managed-org endpoint always forges. Every existing
+  client keeps working unchanged.
+- All new `db.Organization` / `db.Process` / `db.Plan` fields are optional/zero-valued → **no
+  migration needed** (Mongo is schemaless; existing docs unmarshal fine). No new indexes required.
+- After any handler/type/route change: run `make swagger` (regenerate `docs/swagger.yaml`)
+  and `make lint`. Tests (`make test`) require Docker (testcontainers Mongo + Voconed).
+
+## What already exists and is reused (no rebuild)
+
+From `account/` (the remote-signer core):
+- `account.OrganizationSigner(secret, creatorEmail, nonce)` — restores the org's signer.
+- `account.NewSigner(secret, creatorEmail)` — derives a fresh signer + nonce (used at org creation).
+- `Account.FundTransaction(tx, addr)` (`account/tx_funder.go`) — already funds `CreateAccount`,
+  `SetAccount`, `NewProcess`, `SetProcess`, `SetSIK`, `CollectFaucet` with a faucet package +
+  election price.
+- `Account.SignTransaction(tx, signer)` — signs.
+- `Account.client *apiclient.HTTPclient` — the dvote client; already used to submit + confirm
+  (`AccountBootstrap` + `WaitUntilTxIsMined`, see `account/account.go:88`). `ensureAccountExist`
+  there is for the **SaaS master/faucet account**, not per-org accounts; model the org submit +
+  `WaitUntilTxIsMined` on the same pattern.
+- `Account.ElectionPriceCalc`, `Account.TxCosts` — pricing.
+- `subscriptions.HasTxPermission(tx, txType, org, user)` + org process counter — the permission/
+  quota logic in `api/transaction.go`, reused by the publish handler and extended for integrators.
+- CSP signer (`csp/`) — provides the CSP public key used as the census root and the
+  `/process/bundle/.../auth|sign` flow (unchanged).
+
+The genuinely new work is: (a) **forging** `CreateAccount` server-side at org creation, (b)
+**building** the protobuf election txs server-side from high-level input (today the client builds
+them), (c) **submitting** the org-signed tx, (d) a **vote relay**, (e) **read proxies**, (f)
+extending the draft model, and (g) the **integrator** layer (managed orgs + quota).
+
+## Architecture
+
+Thin handlers; reuse `account` for chain primitives; reuse/extend `subscriptions` for quota.
+
+```
+api/organizations.go (handlers)
+      │  create org (+ forge CreateAccount) / create managed org / list managed / integrator usage
+      ▼
+api/process.go (handlers)
+      │  publish / status / vote-relay / results / metadata
+      ▼
+account.Account  (new methods, alongside tx_funder.go / account.go)
+   ├─ CreateOrgAccount(org)                       // idempotent CreateAccount + fund + sign + submit + wait
+   ├─ BuildNewProcessTx(org, draft, metaURL)      // construct models.Tx_NewProcess
+   ├─ BuildSetProcessStatusTx(processId, status)  // construct models.Tx_SetProcess
+   ├─ SubmitSignedTx(stx) (data, error)           // apiclient submit + WaitUntilTxIsMined
+   ├─ RelayVote(processId, signedTxBytes)         // verify Vote+process, submit, return voteID
+   └─ ProcessResults(processId)                   // apiclient.Election(id) -> trimmed view
+
+subscriptions.Subscriptions (new methods)
+   ├─ IsIntegrator(org)                           // manual flag OR plan feature
+   ├─ EffectiveIntegratorLimits(org)              // manual override if set, else plan limits
+   ├─ CanCreateManagedOrg(integrator)             // ManagedOrgs counter < MaxManagedOrgs
+   └─ CanPublishForManagedOrg(org, integrator, maxCensusSize)  // per-org + aggregate caps
+```
+
+Rationale: thin handlers + methods on `account`/`subscriptions` reusing the existing
+client/funder/signer and quota engine. No new package (YAGNI); matches current structure and the
+testcontainers/Voconed test harness.
+
+## Chain-abstracted organization creation (opt-in, eager)
+
+Before an org can own an on-chain election it must have an on-chain **account** (a one-time
+`CreateAccount` tx). The **chosen model is org-based and eager** (not lazy-at-first-publish),
+matching the current UX where, right after creating an organization, its admins can immediately
+create elections — but it is **opt-in** so the existing UI/SDK flow is untouched.
+
+- **Trigger:** the SaaS forges the org account when (a) `POST /organizations` is called with
+  `provisionAccount: true`, or (b) the org is created via the managed-org endpoint (always). When
+  `provisionAccount` is omitted/false, `createOrganizationHandler` behaves exactly as today: it
+  derives the org signer + nonce, stores the `db.Organization`, and returns — the account is left
+  to the legacy SDK `createAccount` path.
+- **Forge (`account.CreateOrgAccount(dbOrg)`):** after `SetOrganization`, when triggered, it:
+  1. checks whether the account already exists on chain (`apiclient.Account(addr)`); if so, returns
+     nil (idempotent — safe to retry, and safe if a legacy client later calls `createAccount`),
+  2. otherwise builds `CreateAccount` (with an account-metadata URL), funds it via the faucet,
+     signs it with the org signer, submits, and `WaitUntilTxIsMined`.
+- On forge failure the handler returns 500; the `db.Organization` already exists, so a retry (or
+  the next management call) completes account creation idempotently.
+- **No organizer-facing account/faucet/tx surface**: callers only ever see `POST /organizations`
+  returning the org resource.
+
+**Faucet cost / watch-out:** opt-in eager creation funds every org that requests it, including
+dormant ones. For integrators it is bounded by the `MaxManagedOrgs` quota (below), so the blast
+radius is capped per integrator. Legacy (flag-off) org creation funds nothing extra — unchanged.
+
+## Integrator model
+
+An **integrator** is an ordinary organization that has been granted the integrator capability and
+can create/manage organizations for its clients through the API.
+
+- **Enablement:** an org is an integrator if `org.IsIntegrator == true` (manual grant) **or** its
+  plan has `Features.Integrator == true` (bought the integration plan). `subscriptions.IsIntegrator`
+  encapsulates this OR.
+- **Managed (client) organizations:** created via a dedicated endpoint by an admin of the
+  integrator org. Each managed org is a **first-class organization** (own address, own on-chain
+  account forged at creation, own members invitable later) and carries `ManagedBy = <integrator
+  address>`. They are **not** sub-orgs (`Parent` is untouched), so a client can still use the
+  normal parent/sub-org feature itself.
+- **Accounting anchor:** aggregate usage (managed orgs, total elections, total census) is tracked
+  as counters on the **integrator** org and checked against the integrator's effective limits.
+- **Quota source:** `EffectiveIntegratorLimits(org)` = `org.IntegratorLimits` (manual override) if
+  non-nil, else the plan's `IntegratorLimits`. Zero in any field means "unlimited" for that
+  dimension.
+- **Manual setup:** enabling an integrator and/or setting an override quota is an internal/admin
+  operation done via a `cmd/cli` command (we run it); no public write endpoint. Integrators read
+  their own quota + usage via `GET /organizations/{address}/integrator`.
+
+## Data-model changes (additive)
+
+`db/types.go`:
+
+- Extend `Process` with optional election params + cached on-chain state:
+  ```go
+  type Process struct {
+      ID             primitive.ObjectID
+      Address        internal.HexBytes        // on-chain id (set on publish)
+      OrgAddress     common.Address
+      Census         Census
+      Metadata       map[string]any
+      ElectionParams *ElectionParams `json:"electionParams,omitempty" bson:"electionParams,omitempty"` // NEW
+      Status         string          `json:"status,omitempty" bson:"status,omitempty"`                 // NEW (cached)
+      PublishedAt    time.Time       `json:"publishedAt,omitempty" bson:"publishedAt,omitempty"`       // NEW
+  }
+  ```
+- Add `ElectionParams` (+ `Question`, `Choice`, `VoteType`, `ElectionType`, `ElectionTypeMetadata`,
+  and a `MultiLangString` helper): the high-level election inputs the publish handler maps into the
+  on-chain `models.Process`.
+- Extend `Organization` (all optional/zero-valued):
+  ```go
+  ManagedBy        common.Address    `json:"managedBy,omitempty" bson:"managedBy,omitempty"`               // integrator that owns this client org
+  IsIntegrator     bool              `json:"isIntegrator,omitempty" bson:"isIntegrator,omitempty"`         // manual enablement
+  IntegratorLimits *IntegratorLimits `json:"integratorLimits,omitempty" bson:"integratorLimits,omitempty"` // manual quota override (nil = use plan)
+  ```
+- Extend `OrganizationCounters` with integrator aggregates:
+  ```go
+  ManagedOrgs       int   `json:"managedOrgs" bson:"managedOrgs"`             // client orgs created
+  ManagedProcesses  int   `json:"managedProcesses" bson:"managedProcesses"`   // elections across all managed orgs
+  ManagedCensusSize int64 `json:"managedCensusSize" bson:"managedCensusSize"` // census across all managed orgs
+  ```
+- Add `IntegratorLimits` and add it to `Plan` + an `Integrator` flag to `Features`:
+  ```go
+  type IntegratorLimits struct {
+      MaxManagedOrgs      int   `json:"maxManagedOrgs" bson:"maxManagedOrgs"`           // number of client orgs
+      MaxProcessesPerOrg  int   `json:"maxProcessesPerOrg" bson:"maxProcessesPerOrg"`   // elections per managed org
+      MaxTotalProcesses   int   `json:"maxTotalProcesses" bson:"maxTotalProcesses"`     // elections across all managed orgs
+      MaxCensusPerProcess int64 `json:"maxCensusPerProcess" bson:"maxCensusPerProcess"` // census size per election
+      MaxCensusPerOrg     int64 `json:"maxCensusPerOrg" bson:"maxCensusPerOrg"`         // census size per managed org
+      MaxTotalCensusSize  int64 `json:"maxTotalCensusSize" bson:"maxTotalCensusSize"`   // census across all managed orgs
+  }
+  // Plan gains:      IntegratorLimits IntegratorLimits
+  // Features gains:   Integrator bool
+  ```
+
+`api/apicommon/types.go`:
+- Add optional `ElectionParams *db.ElectionParams` to `CreateProcessRequest` and
+  `UpdateProcessRequest`.
+- Add optional `ProvisionAccount bool `json:"provisionAccount,omitempty"`` to `OrganizationInfo`
+  (the `POST /organizations` body) — default false preserves today's behavior.
+- Add `PublishProcessRequest/Response`, `SetProcessStatusRequest`, `RelayVoteRequest/Response`,
+  `ProcessResultsResponse`.
+- Add `CreateManagedOrganizationRequest` (client org info + optional `ownerEmail`),
+  `IntegratorInfoResponse` (`enabled`, `limits`, `usage`).
+
+`db/organizations.go` / `db/process.go`: `SetOrganization` / `SetProcess` already upsert the whole
+struct, so the new fields persist with no extra code. Add counter helpers mirroring
+`IncrementOrganizationSubOrgsCounter`: `Increment/DecrementOrganizationManagedOrgsCounter`, and
+`AddOrganizationManagedProcesses/ManagedCensusSize` (delta updates).
+
+## Metadata hosting — resolution of the URL circular dependency
+
+The on-chain `Process.Metadata` must hold a public `https://` URL **before** the `NewProcess` tx is
+submitted, but the `processId` is only known **after** submit. So the URL cannot contain the
+`processId`. Resolution:
+
+- Build the `ElectionMetadata` JSON from `electionParams`, then store it **content-addressed** in
+  `objectstorage/` (key = hash of the JSON), yielding a stable, immutable
+  `https://.../storage/{hash}.json` URL that is known **before** the tx. That URL becomes the
+  on-chain `Process.Metadata`.
+- `objectstorage/` is currently image-only (content-type sniffing). Add a small JSON path: store
+  with explicit `ContentType: "application/json"` and allow `.json` in the download handler.
+- `GET /process/{processId}/metadata` is a convenience proxy: look up `db.Process` by `Address`
+  (= processId) and serve the same stored document (or 302 to the content-addressed URL). Resolving
+  the on-chain pointer and calling this endpoint therefore return the same JSON.
+
+## Routes & handlers
+
+`api/routes.go` — add path constants:
+```go
+processPublishEndpoint       = "/process/{processId}/publish"   // POST  (processId = draftId here)
+processStatusEndpoint        = "/process/{processId}/status"    // PUT
+processVoteEndpoint          = "/process/{processId}/vote"      // POST  (public)
+processResultsEndpoint       = "/process/{processId}/results"   // GET   (public)
+processMetadataEndpoint      = "/process/{processId}/metadata"  // GET   (public)
+managedOrganizationsEndpoint = "/organizations/{address}/managed"     // POST create, GET list (integrator)
+integratorEndpoint           = "/organizations/{address}/integrator"  // GET quota + usage
+```
+`api/api.go` — register publish/status, managed-org create/list, and integrator usage in the
+**protected** group (`jwtauth.Verifier` + `a.authenticator`); register vote + results + metadata in
+the **public** group (next to the CSP voter routes). Election handlers in `api/process.go` (relay in
+a small `api/process_vote.go`); integrator/managed-org handlers in `api/organizations.go`. There is
+**no** org-account endpoint — account creation is internal to org creation.
+
+**Path-param naming (do not be misled by the docs):** the chi param is literally `processId` in
+*every* `/process/{…}` route (matching the existing `processEndpoint`). Read it with
+`chi.URLParam(r, "processId")` and interpret per handler: **draft ObjectID** for `publish` and the
+existing `GET /process/{processId}`, **on-chain election id** for `status`/`vote`/`results`/
+`metadata`. NEW_API.md writes `{draftId}` only as a readability hint.
+
+## Implementation phases
+
+### Phase 0 — scaffolding (election params on drafts)
+- Add `ElectionParams` types (`db/types.go`, `apicommon`) and the optional fields on
+  create/update requests + `db.Process` (`ElectionParams`, `Status`, `PublishedAt`).
+- Extend `createProcessHandler`/`updateProcessHandler` to persist `electionParams` (optional;
+  draft with no params is still valid, exactly as today).
+- `make swagger` + `make lint`. No behavior change for existing callers.
+- **Tests:** round-trip a draft with `electionParams`; confirm a draft without params still works.
+
+### Phase 1 — chain-abstracted organization creation (opt-in)
+- `account.CreateOrgAccount(org)`: idempotent (check `apiclient.Account`); build `CreateAccount`
+  (+ account metadata URL) → fund → sign(orgSigner) → submit → `WaitUntilTxIsMined`.
+- Add optional `ProvisionAccount` to `OrganizationInfo`. In `createOrganizationHandler`, after
+  `SetOrganization`, call `CreateOrgAccount` **only when** `provisionAccount` is true (the
+  managed-org endpoint, Phase 5, always calls it). Response shape unchanged.
+- Reuse the `CREATE_ACCOUNT` permission path in `HasTxPermission`.
+- **Tests:** (a) default (flag off) → org created, **no** on-chain account, behavior identical to
+  today; (b) `provisionAccount: true` → assert the account exists on chain (`apiclient.Account`);
+  (c) idempotency (re-provision / legacy `createAccount` afterwards does not error); (d) a
+  subsequent `/publish` works without any explicit account step.
+
+### Phase 2 — process publish (centerpiece)
+1. `POST /process/{draftId}/publish`: load draft; require Manager/Admin; require `electionParams`
+   + census present.
+2. Build `ElectionMetadata` from `electionParams`; store content-addressed in `objectstorage/`;
+   that `https://` URL becomes `Process.Metadata` (also served by `GET .../metadata`).
+3. Resolve census: origin = CSP, `CensusRoot` = CSP pubkey, `CensusURI` = SaaS CSP endpoint.
+4. `BuildNewProcessTx` → `FundTransaction` → `SignTransaction(orgSigner)` → `SubmitSignedTx` →
+   `WaitUntilTxIsMined` → on-chain `processId` (the `data` returned by the submit).
+5. Quota: reuse `HasTxPermission(NEW_PROCESS)` + counter bump. **Replicate the existing nuance**
+   (`api/transaction.go`): only increment the org `Processes` counter when
+   `MaxCensusSize > db.TestMaxCensusSize` (so test-sized elections don't count), keeping quota
+   behavior identical to the `/transactions` path. If the org is managed (`ManagedBy != 0`), also
+   enforce `CanPublishForManagedOrg` and bump the integrator's `ManagedProcesses` /
+   `ManagedCensusSize` counters.
+6. Persist `Address`, `Status="READY"`, `PublishedAt`. Idempotent: if `Address` already set,
+   return it without a new tx.
+- **Tests:** publish a draft against Voconed; assert election exists on chain and `Address` set;
+  idempotency; Manager/Admin + quota enforcement (patterns from `api/process_test.go`,
+  `api/csp_voting_test.go`).
+
+### Phase 3 — vote relay + status lifecycle
+- `POST /process/{processId}/vote` (public): decode `txPayload` (base64 → `models.SignedTx`),
+  unmarshal inner `Tx`, assert `Tx_Vote` and matching `processId`; submit + confirm; return
+  `{voteId}` (the nullifier). Never decode the VotePackage; never expose the tx hash.
+- `PUT /process/{processId}/status`: map `ready|paused|ended|canceled` → `models.ProcessStatus`;
+  `BuildSetProcessStatusTx` → fund/sign/submit. Manager/Admin.
+- **Tests:** drive CSP `auth`→`sign`, build a vote envelope (as in `api/csp_voting_test.go`),
+  relay it, assert the nullifier on chain; publish→pause→resume→end and assert chain transitions.
+
+### Phase 4 — read proxies
+- `GET /process/{processId}/results`: `apiclient.Election(processId)` → trimmed
+  `ProcessResultsResponse` (status, voteCount, dates, results, finalResults).
+- `GET /process/{processId}/metadata`: serve the stored `ElectionMetadata` JSON.
+- **Tests:** publish + cast → results reflect the vote count; metadata round-trips the draft's
+  `electionParams`.
+
+### Phase 5 — integrator layer
+- Data model: `ManagedBy`, `IsIntegrator`, `IntegratorLimits` (Organization), `Integrator` flag +
+  `IntegratorLimits` (Plan/Features), integrator counters (`OrganizationCounters`), DB counter
+  helpers.
+- `subscriptions`: `IsIntegrator`, `EffectiveIntegratorLimits`, `CanCreateManagedOrg`,
+  `CanPublishForManagedOrg`.
+- `POST /organizations/{address}/managed` (admin of integrator `{address}`, integrator-enabled):
+  enforce `CanCreateManagedOrg`; create a first-class org with `ManagedBy={address}`, forge its
+  account (Phase 1), bypass `MaxOrgsPerUser`, set the integrator's user as creator/admin (or the
+  optional `ownerEmail`), bump `ManagedOrgs`.
+- `GET /organizations/{address}/managed`: paginated list of managed orgs (mirror the drafts list).
+- `GET /organizations/{address}/integrator`: `{enabled, limits, usage}`.
+- Wire integrator-aware quota into the publish handler (Phase 2, step 5).
+- `cmd/cli`: a `set-integrator` command to enable an org and/or set its `IntegratorLimits` override.
+- **Tests:** non-integrator is rejected from managed endpoints; integrator creates managed orgs up
+  to `MaxManagedOrgs` then is blocked; publishing under a managed org enforces per-org + aggregate
+  caps and bumps integrator counters; quota override beats plan limits.
+
+## Error handling & idempotency
+
+- Chain submit/confirm uses a context timeout (~40s, as in `account.go`); failures map to
+  `errors.ErrVochainRequestFailed`. Reuse typed `errors.Error`; messages start lowercase; wrap with
+  `fmt.Errorf("...: %w", err)`.
+- Org-account creation and publish are idempotent (on `apiclient.Account` existence and
+  `db.Process.Address` respectively). Status changes are naturally idempotent on chain (re-ending an
+  ended process → chain error → surfaced as 400).
+- Vote relay returns the chain's nullifier/error verbatim (already-voted → 409).
+- New typed errors: `ErrNotAnIntegrator` (403), `ErrMaxManagedOrgsReached`,
+  `ErrIntegratorQuotaExceeded`.
+
+## Risks / watch-outs
+
+- **Org-creation back-compat (resolved):** forging is **opt-in** via `provisionAccount`. Legacy
+  clients omit it and keep the exact two-step flow (DB org + SDK `createAccount`). The new SDK sets
+  it and drops its own `createAccount`. The idempotent on-chain check additionally protects against
+  any double-create races. No breaking change for existing callers.
+- **Faucet spend:** eager account creation funds every org; integrator blast radius is bounded by
+  `MaxManagedOrgs`.
+- **Metadata hosting:** content-addressed `https://` URL (no IPFS); ensure it is stable, public,
+  and immutable per content hash so the on-chain pointer never dangles.
+- **apiclient submit method:** model the org-signed submit + `WaitUntilTxIsMined` on
+  `account/account.go:88`; confirm the raw-tx submit call name in the pinned dvote version in Phase 2.
+- **Param validation:** validate `electionParams` at publish (dates, maxCount ≤ choices, positive
+  census size) — boundary input.
+- **Quota races:** counter-based aggregate quotas can race under concurrent publishes; acceptable
+  for now (small overshoot), tighten with atomic `$inc`-guarded updates if it matters.
+
+## Definition of done (per phase)
+
+`make lint` clean, `make swagger` regenerated, `make test` green (Docker), and the matching new
+integration test passes against Voconed. Old `/transactions` path still green.

--- a/plan/BACKEND_PLAN.md
+++ b/plan/BACKEND_PLAN.md
@@ -76,7 +76,7 @@ api/process.go (handlers)
       ▼
 account.Account  (new methods, alongside tx_funder.go / account.go)
    ├─ CreateOrgAccount(org)                       // idempotent CreateAccount + fund + sign + submit + wait
-   ├─ BuildNewProcessTx(org, draft, metaURL)      // construct models.Tx_NewProcess
+   ├─ BuildNewProcessTx(org, draft, metaURL)      // construct models.Tx_NewProcess (NewProcessParams carries CensusOrigin)
    ├─ BuildSetProcessStatusTx(processId, status)  // construct models.Tx_SetProcess
    ├─ SubmitSignedTx(stx) (data, error)           // apiclient submit + WaitUntilTxIsMined
    ├─ RelayVote(processId, signedTxBytes)         // verify Vote+process, submit, return voteID
@@ -161,6 +161,9 @@ can create/manage organizations for its clients through the API.
 - Add `ElectionParams` (+ `Question`, `Choice`, `VoteType`, `ElectionType`, `ElectionTypeMetadata`,
   and a `MultiLangString` helper): the high-level election inputs the publish handler maps into the
   on-chain `models.Process`.
+- Add the non-CSP census types to `db.CensusType` — `CensusTypeWeighted="weighted"` and
+  `CensusTypeZKWeighted="zkweighted"` — alongside the existing CSP types. For these, census
+  participants carry `{key: address/pubkey, weight}` instead of email/phone (see Phase 6).
 - Extend `Organization` (all optional/zero-valued):
   ```go
   ManagedBy        common.Address    `json:"managedBy,omitempty" bson:"managedBy,omitempty"`               // integrator that owns this client org
@@ -227,14 +230,18 @@ processStatusEndpoint        = "/process/{processId}/status"    // PUT
 processVoteEndpoint          = "/process/{processId}/vote"      // POST  (public)
 processResultsEndpoint       = "/process/{processId}/results"   // GET   (public)
 processMetadataEndpoint      = "/process/{processId}/metadata"  // GET   (public)
+processCensusProofEndpoint   = "/process/{processId}/census/proof"  // GET   (public; Phase 6)
+processCensusEndpoint        = "/process/{processId}/census"        // PUT   (dynamic add; Phase 6)
 managedOrganizationsEndpoint = "/organizations/{address}/managed"     // POST create, GET list (integrator)
 integratorEndpoint           = "/organizations/{address}/integrator"  // GET quota + usage
 ```
-`api/api.go` — register publish/status, managed-org create/list, and integrator usage in the
-**protected** group (`jwtauth.Verifier` + `a.authenticator`); register vote + results + metadata in
-the **public** group (next to the CSP voter routes). Election handlers in `api/process.go` (relay in
-a small `api/process_vote.go`); integrator/managed-org handlers in `api/organizations.go`. There is
-**no** org-account endpoint — account creation is internal to org creation.
+`api/api.go` — register publish/status, managed-org create/list, integrator usage, and the dynamic
+census add (`PUT .../census`, Phase 6) in the **protected** group (`jwtauth.Verifier` +
+`a.authenticator`); register vote + results + metadata + the census-proof proxy
+(`GET .../census/proof`, Phase 6) in the **public** group (next to the CSP voter routes). Election
+handlers in `api/process.go` (relay in a small `api/process_vote.go`); integrator/managed-org
+handlers in `api/organizations.go`. There is **no** org-account endpoint — account creation is
+internal to org creation.
 
 **Path-param naming (do not be misled by the docs):** the chi param is literally `processId` in
 *every* `/process/{…}` route (matching the existing `processEndpoint`). Read it with
@@ -269,7 +276,10 @@ existing `GET /process/{processId}`, **on-chain election id** for `status`/`vote
    + census present.
 2. Build `ElectionMetadata` from `electionParams`; store content-addressed in `objectstorage/`;
    that `https://` URL becomes `Process.Metadata` (also served by `GET .../metadata`).
-3. Resolve census: origin = CSP, `CensusRoot` = CSP pubkey, `CensusURI` = SaaS CSP endpoint.
+3. Resolve census: this is the **CSP case** of a now-general census-origin switch (generalized in
+   Phase 6) — origin = `OFF_CHAIN_CA`, `CensusRoot` = CSP pubkey, `CensusURI` = SaaS CSP endpoint.
+   For the non-CSP (`weighted`/`zkweighted`) types the root/URI instead come from the published
+   on-chain census.
 4. `BuildNewProcessTx` → `FundTransaction` → `SignTransaction(orgSigner)` → `SubmitSignedTx` →
    `WaitUntilTxIsMined` → on-chain `processId` (the `data` returned by the submit).
 5. Quota: reuse `HasTxPermission(NEW_PROCESS)` + counter bump. **Replicate the existing nuance**
@@ -317,6 +327,66 @@ existing `GET /process/{processId}`, **on-chain election id** for `status`/`vote
 - **Tests:** non-integrator is rejected from managed endpoints; integrator creates managed orgs up
   to `MaxManagedOrgs` then is blocked; publishing under a managed org enforces per-org + aggregate
   caps and bumps integrator counters; quota override beats plan limits.
+
+### Phase 6 — non-CSP (merkle / weighted / dynamic) elections
+
+So far every census in this plan is **CSP** (origin `OFF_CHAIN_CA`, root = CSP pubkey). The
+vocdoni.app UI, however, still creates **non-CSP** elections — `weighted` and `zkweighted`
+(anonymous) censuses with an explicit participant list — by talking to the Vochain via
+`@vocdoni/sdk` directly, **bypassing the backend**. For the UI to use **only** the backend, the
+managed path must also create these elections.
+
+**No new crypto, nothing to vendor — reference only.** Everything Phase 6 needs is already exposed
+by the `apiclient.HTTPclient` the backend already wraps (`account.Account.client`, from the existing
+`go.vocdoni.io/dvote` dependency): census build/publish/proof and the election census setters. Proof
+**verification** happens on-chain (node side); the backend only **generates** census proofs and
+**relays** votes — it never holds a voter key and never decodes a ballot. So Phase 6 is **pure
+wiring**: no import beyond the dependency already in `go.mod`, no vendored package, no new crypto.
+
+Census taxonomy (the real on-chain types — there is no plain "tree" type; all censuses are weighted
+now):
+
+| `db.CensusType` | Anonymous | On-chain `CensusOrigin`     | Root / participants |
+|-----------------|-----------|----------------------------|---------------------|
+| `weighted`      | no        | `OFF_CHAIN_TREE_WEIGHTED`  | merkle root of `{key, weight}` participants |
+| `zkweighted`    | yes (Poseidon hash; `EnvelopeType.Anonymous=true`) | `OFF_CHAIN_TREE_WEIGHTED` | merkle root of `{key, weight}` participants |
+| `csp`           | no        | `OFF_CHAIN_CA`             | CSP pubkey (existing path, unchanged) |
+
+apiclient methods reused (all already available on the wrapped client, signatures stable):
+`NewCensus(censusType)` → root id; `CensusAddParticipants(censusID, *api.CensusParticipants)`
+(participants are `{Key, Weight}`); `CensusPublish(censusID)` → `(root HexBytes, uri string)`;
+`CensusGenProof(censusID, voterKey)` → `*CensusProof{Root, Proof, LeafValue, Siblings, LeafWeight}`;
+`SetElectionCensus(electionID, api.ElectionCensus)` / `SetElectionCensusSize(electionID, newSize)`.
+
+**Voter model (decided):** the voter signs the ballot **client-side**; the backend issues the census
+proof and relays. The backend never holds the voter key and never decodes the ballot — identical
+trust boundary to the CSP path, only the authorization artifact differs (merkle proof vs CSP blind
+signature).
+
+Six changes:
+
+1. **`db.CensusType`:** add `CensusTypeWeighted="weighted"` and `CensusTypeZKWeighted="zkweighted"`
+   (also done in the data-model section above). For these, census participants carry
+   `{key: address/pubkey, weight}` instead of email/phone.
+2. **`publishCensusHandler`:** for the new types, build the on-chain census
+   (`NewCensus` → `CensusAddParticipants` → `CensusPublish`) and store the returned **root + URI**,
+   instead of stuffing the CSP pubkey. The CSP path is unchanged.
+3. **`BuildNewProcessTx` / `NewProcessParams`:** gain a `CensusOrigin` field; the root/URI come from
+   the published census (CSP path unchanged). Anonymous (`zkweighted`) additionally sets
+   `EnvelopeType.Anonymous`.
+4. **`GET /process/{processId}/census/proof?key=<addr>`** (new, public): proxies `CensusGenProof`.
+   The voter fetches the proof, builds + signs the envelope client-side, then posts it.
+5. **`POST /process/{processId}/vote`** (existing relay, Phase 3): generalize so it accepts a
+   CSP-authorized envelope **OR** a merkle-proof-carrying envelope, and relays either. It still
+   verifies the tx is a `Vote` for `processId` and **never decodes the ballot**.
+6. **`PUT /process/{processId}/census`** (new): dynamic add — `CensusAddParticipants` +
+   `SetElectionCensusSize`. Gated behind the election's `DynamicCensus` mode flag.
+
+- **Tests:** publish a `weighted` election against Voconed; fetch a proof via the new GET; build +
+  sign a vote envelope (merkle proof instead of CSP) and relay it; assert the nullifier on chain. A
+  `zkweighted` election sets `EnvelopeType.Anonymous`. Dynamic add grows the census and bumps
+  `SetElectionCensusSize` (rejected when `DynamicCensus` is off). The CSP path (Phase 2/3 tests)
+  stays green.
 
 ## Error handling & idempotency
 

--- a/plan/NEW_API.md
+++ b/plan/NEW_API.md
@@ -23,9 +23,10 @@ Integrators additionally create and manage client organizations under a quota.
 | `POST` | `/organizations` (+ optional `provisionAccount`) | Bearer | existing org fields, optional `provisionAccount` | Create an org. With `provisionAccount: true` the SaaS **also forges the org's on-chain `CreateAccount`** (idempotent). Omitted/false → today's behavior (DB only). |
 | `POST` | `/process` (+ `electionParams`) | Bearer | `orgAddress`, `censusId`, `metadata`, optional `electionParams` | Create a draft. **Additive:** gains an optional `electionParams` field carrying all on-chain election inputs. |
 | `PUT`  | `/process/{draftId}` (+ `electionParams`) | Bearer | `censusId`, `metadata`, optional `electionParams` | Update a draft. Same optional `electionParams` field. |
-| `POST` | `/process/{draftId}/publish` | Bearer (Manager/Admin) | optional `{ startDate }` (overrides the draft's start) | Publish a draft to the chain: forge → fund → sign → submit → confirm `NewProcess`. Returns the `processId`. |
-| `PUT`  | `/process/{processId}/status` | Bearer (Manager/Admin) | `{ status }` (`ready`/`paused`/`ended`/`canceled`) | Change lifecycle status. |
-| `POST` | `/process/{processId}/vote` | Public | `{ txPayload }` (base64 of the signed `Vote` envelope) | Relay an already-signed vote envelope to the chain. Returns a `voteId` receipt. |
+| `POST` | `/process/{draftId}/publish` | Bearer (Manager/Admin) | optional `{ startDate }` (overrides the draft's start) | Publish a draft to the chain: forge → fund → sign → submit → confirm `NewProcess`. **Async:** validates synchronously, returns `202` + `jobId`; poll `GET /jobs/{jobId}` for the `processId`. |
+| `PUT`  | `/process/{processId}/status` | Bearer (Manager/Admin) | `{ status }` (`ready`/`paused`/`ended`/`canceled`) | Change lifecycle status. **Async:** returns `202` + `jobId`. |
+| `POST` | `/process/{processId}/vote` | Public | `{ txPayload }` (hex of the signed `Vote` envelope) | Relay an already-signed vote envelope to the chain. **Async:** returns `202` + `jobId`; poll for the `voteID` receipt. |
+| `GET`  | `/jobs/{jobId}` | Public (capability) | — (none) | Poll an async tx job (publish/status/vote). Always `200`; `status` is `pending`/`completed`/`failed`, with the on-chain `result` when completed. |
 | `GET`  | `/process/{processId}/results` | Public | — (none) | Read live status, vote count and tally. |
 | `GET`  | `/process/{processId}/metadata` | Public | — (none) | Read the public election metadata (title, questions, choices). |
 | `POST` | `/organizations/{address}/managed` | Bearer (Admin of integrator) | client org info + optional `ownerEmail` | **Integrator only.** Create a first-class client org managed by `{address}` (forges its account). Quota-enforced. |
@@ -181,17 +182,21 @@ POST /process/{draftId}/publish
   { "startDate": "2026-07-01T09:00:00Z" }
   ```
   Overrides the draft's start date if provided.
-- **200 OK:**
+- **202 Accepted:** the draft is validated, built, funded and signed **synchronously** (so bad,
+  unauthorized or over-quota requests still fail immediately); the on-chain submit/confirm is queued
+  on a bounded worker pool. The response carries the job id and sets `Location: /jobs/{jobId}`:
   ```json
-  { "processId": "<64-hex on-chain election id>" }
+  { "jobId": "<hex job id>" }
   ```
-  `processId` is also persisted to `db.Process.Address`. No transaction hash is exposed — the
-  SaaS confirms the tx on chain before returning.
-- **Idempotent:** if the draft is already published, returns the existing `processId` with 200
-  (no new tx).
-- **Errors:** `400` draft incomplete (no `electionParams` or no census), `401` not a
-  manager/admin, `403` plan/quota exceeded, `404` draft not found, `500`
-  `ErrVochainRequestFailed` (submit/mine failed).
+  Poll `GET /jobs/{jobId}` (see *Poll an async transaction job*) until `status` is `completed`; the
+  result is `{ "address": "<64-hex on-chain election id>", "status": "READY" }`. `address` (the
+  `processId`) is persisted to `db.Process.Address`. No transaction hash is exposed.
+- **Idempotent:** if the draft is already published, returns **200** synchronously with
+  `{ "address": "<processId>", "status": "..." }` (no new tx, no job).
+- **Errors (synchronous):** `400` draft incomplete (no `electionParams`), `401` not a
+  manager/admin, `403` plan/quota exceeded, `404` draft not found, `409` a publish is already in
+  progress for this draft, `503` tx queue full. A submit/mine failure surfaces on the job as
+  `status: failed` with an `error` message (the draft is reset and any quota reservation released).
 
 ---
 
@@ -209,9 +214,14 @@ PUT /process/{processId}/status
   ```json
   { "status": "ready" | "paused" | "ended" | "canceled" }
   ```
-- **200 OK:** `{ "status": "paused" }` (the new status, echoed back after the SaaS confirms the
-  tx on chain).
-- **Errors:** `400` invalid/illegal transition, `401`, `404` process unknown to SaaS, `500`.
+- **202 Accepted:** built, funded and signed synchronously; submit/confirm is queued.
+  ```json
+  { "jobId": "<hex job id>" }
+  ```
+  (+ `Location: /jobs/{jobId}`.) Poll the job until `completed`; the result is
+  `{ "status": "PAUSED" }` (the new status, set after the SaaS confirms the tx on chain).
+- **Errors:** `400` invalid/illegal transition, `401`, `404` process unknown to SaaS, `503` tx
+  queue full. On-chain failure surfaces on the job as `status: failed`.
 
 ---
 
@@ -230,16 +240,52 @@ POST /process/{processId}/vote
 - **Path:** `processId` — on-chain election ID (hex).
 - **Body:**
   ```json
-  { "txPayload": "<base64 of protobuf SignedTx wrapping a Vote>" }
+  { "txPayload": "<hex of protobuf SignedTx wrapping a Vote>" }
   ```
   (`txPayload` matches the field name used by `apicommon.TransactionData`.)
-- **200 OK:**
+- **202 Accepted:** the envelope is decoded and validated synchronously; the submit is queued.
   ```json
-  { "voteId": "<hex nullifier / vote id>" }
+  { "jobId": "<hex job id>" }
   ```
-  `voteId` is the vote receipt the voter can use to later verify their vote was counted.
+  (+ `Location: /jobs/{jobId}`.) Poll the job until `completed`; the result is
+  `{ "voteID": "<hex nullifier>" }` — the receipt the voter can use to later verify their vote
+  was counted.
 - **Errors:** `400` payload is not a Vote tx or targets a different process, `404` process
-  not found, `409` already voted / nullifier used (as reported by chain), `500`.
+  not found, `503` tx queue full. A chain rejection (e.g. already voted / nullifier used) surfaces
+  on the job as `status: failed`.
+
+---
+
+## Poll an async transaction job
+
+The three endpoints above (publish, status, vote) submit on a bounded background worker pool to keep
+on-chain confirmation (up to ~40s under congestion) off the request path, where it would share the
+router's throttle/timeout budget with the public voter endpoints. Each returns a `jobId`; this single
+endpoint reports the outcome.
+
+```
+GET /jobs/{jobId}
+```
+
+- **Auth:** Public. The 32-byte `jobId` **is** the capability — it is unguessable and the result
+  contains only public on-chain data (process id, vote nullifier, status), so no token is needed
+  (the relay-vote flow is itself public).
+- **Path:** `jobId` — the hex id returned by a `202`.
+- **200 OK** (always, while the job exists):
+  ```json
+  {
+    "jobId":  "<hex>",
+    "type":   "publish_process" | "set_process_status" | "relay_vote",
+    "status": "pending" | "completed" | "failed",
+    "result": { "address": "<hex>", "voteID": "<hex>", "status": "READY" },
+    "error":  "<reason, when failed>"
+  }
+  ```
+  `result` is present only when `status` is `completed`, and carries just the fields relevant to the
+  job type (`address`+`status` for publish, `status` for a status change, `voteID` for a vote).
+  `error` is present only when `status` is `failed`.
+- **Polling:** clients poll until `status` leaves `pending`. There is no push/webhook.
+- **Errors:** `400` malformed id, `404` unknown job.
 
 ---
 
@@ -392,17 +438,19 @@ GET /organizations/{address}/integrator
 2. `POST /process/bundle/{bundleId}/sign` — CSP blind signature (existing).
 3. The client builds + signs the `Vote` envelope locally using the CSP signature (the only
    client-side crypto).
-4. `POST /process/{processId}/vote` — **new** relay endpoint submits it to the chain.
-5. `GET /process/{processId}/results` — **new** read endpoint for live tally.
+4. `POST /process/{processId}/vote` — **new** relay endpoint queues it; returns `202` + `jobId`.
+5. `GET /jobs/{jobId}` — poll until `completed`; the result's `voteID` is the vote receipt.
+6. `GET /process/{processId}/results` — **new** read endpoint for live tally.
 
 ## New apicommon types (summary)
 
 | Type | Used by |
 |------|---------|
 | `ElectionParams` (+ `Question`, `Choice`, `VoteType`, `ElectionType`) | create/update draft |
-| `PublishProcessRequest` / `PublishProcessResponse` | `POST /process/{id}/publish` |
-| `SetProcessStatusRequest` | `PUT /process/{id}/status` |
-| `RelayVoteRequest` / `RelayVoteResponse` | `POST /process/{id}/vote` |
+| `PublishProcessRequest` / `PublishProcessResponse` (idempotent 200 only) / `EnqueuedResponse` (202) | `POST /process/{id}/publish` |
+| `SetProcessStatusRequest` / `EnqueuedResponse` (202) | `PUT /process/{id}/status` |
+| `RelayVoteRequest` / `EnqueuedResponse` (202) | `POST /process/{id}/vote` |
+| `EnqueuedResponse` (`jobId`) / `JobStatusResponse` (`jobId`, `type`, `status`, `result`, `error`) | `GET /jobs/{jobId}` |
 | `ProcessResultsResponse` | `GET /process/{id}/results` |
 | `CreateManagedOrganizationRequest` | `POST /organizations/{address}/managed` |
 | `IntegratorInfoResponse` (`enabled`, `limits`, `usage`) | `GET /organizations/{address}/integrator` |

--- a/plan/NEW_API.md
+++ b/plan/NEW_API.md
@@ -1,0 +1,408 @@
+# NEW_API.md — Managed (chain-abstracted) endpoints
+
+New endpoints layered on top of the existing SaaS API so an integrator can run the
+**full election lifecycle and voting without the Vocdoni SDK and without touching the
+Vochain**. The SaaS *forges + funds + signs + submits + confirms* every management
+transaction, and *relays* (never decodes) client-signed votes.
+
+The model stays **organization-based**, exactly like the vocdoni.app UI today: a user registers,
+creates an organization (which now gets its on-chain account server-side), and the organization's
+admins/managers create elections under it. On top of that, an **integrator** organization can
+create and manage organizations for its own clients through the API, under an accountable quota.
+
+## Summary
+
+A handful of new endpoints turn the SaaS into a complete, chain-abstracted election API. The
+organizer creates an organization (its on-chain account is forged automatically), creates a draft
+(now carrying the on-chain election parameters), publishes it, and drives its lifecycle; the voter
+casts and verifies; everyone reads results and metadata — all without ever seeing a transaction.
+Integrators additionally create and manage client organizations under a quota.
+
+| Method | Endpoint | Auth | Body (JSON) | Purpose |
+|--------|----------|------|-------------|---------|
+| `POST` | `/organizations` (+ optional `provisionAccount`) | Bearer | existing org fields, optional `provisionAccount` | Create an org. With `provisionAccount: true` the SaaS **also forges the org's on-chain `CreateAccount`** (idempotent). Omitted/false → today's behavior (DB only). |
+| `POST` | `/process` (+ `electionParams`) | Bearer | `orgAddress`, `censusId`, `metadata`, optional `electionParams` | Create a draft. **Additive:** gains an optional `electionParams` field carrying all on-chain election inputs. |
+| `PUT`  | `/process/{draftId}` (+ `electionParams`) | Bearer | `censusId`, `metadata`, optional `electionParams` | Update a draft. Same optional `electionParams` field. |
+| `POST` | `/process/{draftId}/publish` | Bearer (Manager/Admin) | optional `{ startDate }` (overrides the draft's start) | Publish a draft to the chain: forge → fund → sign → submit → confirm `NewProcess`. Returns the `processId`. |
+| `PUT`  | `/process/{processId}/status` | Bearer (Manager/Admin) | `{ status }` (`ready`/`paused`/`ended`/`canceled`) | Change lifecycle status. |
+| `POST` | `/process/{processId}/vote` | Public | `{ txPayload }` (base64 of the signed `Vote` envelope) | Relay an already-signed vote envelope to the chain. Returns a `voteId` receipt. |
+| `GET`  | `/process/{processId}/results` | Public | — (none) | Read live status, vote count and tally. |
+| `GET`  | `/process/{processId}/metadata` | Public | — (none) | Read the public election metadata (title, questions, choices). |
+| `POST` | `/organizations/{address}/managed` | Bearer (Admin of integrator) | client org info + optional `ownerEmail` | **Integrator only.** Create a first-class client org managed by `{address}` (forges its account). Quota-enforced. |
+| `GET`  | `/organizations/{address}/managed` | Bearer (Admin of integrator) | — (none) | **Integrator only.** Paginated list of orgs managed by `{address}`. |
+| `GET`  | `/organizations/{address}/integrator` | Bearer (Admin of integrator) | — (none) | **Integrator only.** Read the integrator's effective quota + current usage. |
+
+Everything below details each of these. Existing routes are unchanged (see Back-compatibility).
+
+## Back-compatibility
+
+Everything here is **additive** and **backwards compatible**. No existing route changes behavior:
+
+- `POST /transactions` and `/transactions/message` stay exactly as they are (the old
+  SDK `RemoteSigner` keeps working). The new endpoints are an alternative, higher-level path.
+- `POST /process`, `PUT /process/{id}`, `GET /process/{id}` keep their current behavior;
+  the request bodies only gain **optional** fields.
+- `POST /organizations` keeps its current behavior **by default**. It gains one **optional** body
+  field, `provisionAccount` (default false). Only when `true` does the SaaS forge the on-chain
+  account (see §0); when omitted, the endpoint is byte-for-byte unchanged (DB row only; the account
+  is still created by the legacy SDK `createAccount` via `/transactions`). So existing clients are
+  untouched, and the new SDK opts in. The idempotent on-chain check also makes a stray legacy
+  `createAccount` after a provisioned org a safe no-op rather than an error.
+- New `db.Process` / `db.Organization` / `db.Plan` fields are optional and default to zero — no
+  migration required.
+
+## Conventions
+
+- Base path: `http://localhost:8080` (default). Bearer JWT for protected routes.
+- Hex strings for chain IDs/addresses; errors use the `errors.Error` shape
+  `{ "code": int, "error": string, "data": any }`.
+- **Resource-oriented, no blockchain surface.** This is a standard SaaS API: responses carry
+  resource ids (organization address, election id, vote receipt id) — never transaction
+  payloads, tx hashes, gas, faucet credits, or signers. The backend holds the organization
+  private keys and abstracts all transaction complexity.
+- **Two kinds of process identifier**, do not mix them:
+  - `draftId` — Mongo ObjectID (24-hex) of the DB draft (`db.Process.ID`). Organizer-facing CRUD.
+  - `processId` — on-chain election ID (64-hex), set after publishing (`db.Process.Address`).
+    Voting and chain reads use this.
+  - In the URL the path segment is always literally `{processId}` (the existing route convention),
+    even where this doc writes `{draftId}` for clarity — `publish` and the existing
+    `GET /process/{processId}` resolve it as a draft ObjectID; `status`/`vote`/`results`/`metadata`
+    resolve it as the on-chain id.
+
+---
+
+## 0. Chain-abstracted organization creation (opt-in, eager)
+
+Before an org can own an on-chain election it needs an on-chain **account**. The SaaS can forge this
+eagerly, the moment the organization is created — matching the current UX where, right after
+creating an organization, its admins can immediately create elections. This is **opt-in** so the
+existing flow is untouched.
+
+```
+POST /organizations          // body gains optional: { "provisionAccount": true }
+```
+
+- **Default (omitted/false):** unchanged behavior — the SaaS stores the `db.Organization` and
+  returns; the on-chain account is created by the legacy SDK `createAccount` via `/transactions`,
+  exactly as today (same latency, same failure modes).
+- **`provisionAccount: true`:** after storing the org, the SaaS builds `CreateAccount`, funds it via
+  the faucet, signs it with the org key, submits and confirms it on chain — all internally. The
+  response shape is unchanged (the org resource).
+- **Idempotent:** if the on-chain account already exists, the forge is a no-op. Safe to retry; safe
+  if a legacy client later calls `createAccount` against the same org.
+- **No organizer-facing account/faucet/tx surface.** There is no account-creation endpoint; for the
+  new SDK / integrator, creating an organization is a single REST call.
+- **Errors:** if the forge fails, the org row already exists, so a retry (or the next management
+  call) completes account creation idempotently.
+
+The managed-org endpoint (§8a) always provisions the account. This is the eager counterpart to (and
+replaces) any "lazy bootstrap at first publish" idea: when requested, account creation happens at
+org-creation time, not deferred. See §7.
+
+---
+
+## 1. Election parameters on a draft (additive)
+
+To forge `NewProcess` server-side, the draft must carry the on-chain election parameters
+that the SDK used to build client-side. `CreateProcessRequest` and `UpdateProcessRequest`
+gain one **optional** field, `electionParams`:
+
+```jsonc
+// ElectionParams (apicommon.ElectionParams) — all on-chain NewProcess inputs
+{
+  "title":       "Board election 2026",          // string | {"default": "...","ca": "..."}
+  "description": "Annual board election",         // optional, multilang
+  "header":      "https://.../banner.png",        // optional
+  "startDate":   "2026-07-01T09:00:00Z",          // optional RFC3339; omitted/null = start ASAP
+  "endDate":     "2026-07-08T09:00:00Z",          // required (or "duration" seconds)
+  "duration":    604800,                           // optional, seconds; alternative to endDate
+  "maxCensusSize": 5000,                           // optional; defaults to census size
+  "questions": [
+    {
+      "title":       "Choose a candidate",
+      "description": "",
+      "choices": [
+        { "title": "Alice", "value": 0 },
+        { "title": "Bob",   "value": 1 }
+      ]
+    }
+  ],
+  "voteType": {                                    // -> models.Process.VoteOptions
+    "maxCount":          1,
+    "maxValue":          1,
+    "maxVoteOverwrites": 0,
+    "costExponent":      10000,
+    "uniqueChoices":     false,
+    "costFromWeight":    false
+  },
+  "electionType": {                               // -> models.Process.EnvelopeType + flags
+    "interruptible":      true,
+    "secretUntilTheEnd":  false,
+    "anonymous":          false,
+    "metadata": { "encrypted": false }
+  }
+}
+```
+
+Mapping to the on-chain `models.Process` (built server-side):
+
+| ElectionParams                       | models.Process / Tx field                            |
+|--------------------------------------|------------------------------------------------------|
+| `title/description/questions/...`    | `ElectionMetadata` JSON stored by the SaaS, served at a public `https://` URL → `Process.Metadata` (the URL, **not** an `ipfs://` CID) |
+| `startDate` / `duration`/`endDate`   | `Process.StartTime` / `Process.Duration`             |
+| `maxCensusSize`                      | `Process.MaxCensusSize`                              |
+| `voteType.*`                         | `Process.VoteOptions` (maxCount/maxValue/costExponent/maxVoteOverwrites) |
+| `electionType.anonymous/encrypted`  | `Process.EnvelopeType` (Anonymous/EncryptedVotes)    |
+| `electionType.interruptible`        | `Process.Mode.Interruptible`                         |
+| census (from `censusId`)            | `Process.CensusOrigin = OFF_CHAIN_CA` (CSP), `CensusRoot = CSP pubkey`, `CensusURI = SaaS CSP endpoint` |
+
+Census origin is always **CSP** for SaaS censuses (`auth`/`mail`/`sms`/`sms_or_mail`), so
+there is no Merkle tree to publish — the CSP public key is the census root.
+
+---
+
+## 2. Publish a draft to the chain
+
+Forge → fund → sign → submit → confirm a `NewProcess`. The org's on-chain account already exists by
+this point (provisioned at org creation via §0, or created through the legacy `createAccount` path),
+so publish never touches account bootstrap.
+
+```
+POST /process/{draftId}/publish
+```
+
+- **Auth:** Bearer. Caller must be **Manager or Admin** of the draft's org.
+- **Plan:** enforces `subscriptions.HasTxPermission(NEW_PROCESS, org, user)` and bumps the
+  org process counter (same rule as today's `/transactions` path — including the existing nuance
+  that test-sized elections, `maxCensusSize ≤ TestMaxCensusSize`, are not counted).
+- **Path:** `draftId` — the draft ObjectID.
+- **Body (optional):**
+  ```json
+  { "startDate": "2026-07-01T09:00:00Z" }
+  ```
+  Overrides the draft's start date if provided.
+- **200 OK:**
+  ```json
+  { "processId": "<64-hex on-chain election id>" }
+  ```
+  `processId` is also persisted to `db.Process.Address`. No transaction hash is exposed — the
+  SaaS confirms the tx on chain before returning.
+- **Idempotent:** if the draft is already published, returns the existing `processId` with 200
+  (no new tx).
+- **Errors:** `400` draft incomplete (no `electionParams` or no census), `401` not a
+  manager/admin, `403` plan/quota exceeded, `404` draft not found, `500`
+  `ErrVochainRequestFailed` (submit/mine failed).
+
+---
+
+## 3. Change process status (lifecycle)
+
+Forge `SetProcessStatus` (pause / resume / end / cancel).
+
+```
+PUT /process/{processId}/status
+```
+
+- **Auth:** Bearer. Manager or Admin of the owning org.
+- **Path:** `processId` — on-chain election ID (hex).
+- **Body:**
+  ```json
+  { "status": "ready" | "paused" | "ended" | "canceled" }
+  ```
+- **200 OK:** `{ "status": "paused" }` (the new status, echoed back after the SaaS confirms the
+  tx on chain).
+- **Errors:** `400` invalid/illegal transition, `401`, `404` process unknown to SaaS, `500`.
+
+---
+
+## 4. Relay a vote
+
+Submit an already-signed vote envelope to the Vochain. The SaaS **verifies it is a Vote tx
+for `processId` and forwards it**; it never decrypts or inspects the ballot (ballot secrecy
+preserved at the operator).
+
+```
+POST /process/{processId}/vote
+```
+
+- **Auth:** Public. The voter is authorized by the CSP proof embedded inside the envelope
+  (obtained via the existing `/process/bundle/{id}/auth|sign` flow).
+- **Path:** `processId` — on-chain election ID (hex).
+- **Body:**
+  ```json
+  { "txPayload": "<base64 of protobuf SignedTx wrapping a Vote>" }
+  ```
+  (`txPayload` matches the field name used by `apicommon.TransactionData`.)
+- **200 OK:**
+  ```json
+  { "voteId": "<hex nullifier / vote id>" }
+  ```
+  `voteId` is the vote receipt the voter can use to later verify their vote was counted.
+- **Errors:** `400` payload is not a Vote tx or targets a different process, `404` process
+  not found, `409` already voted / nullifier used (as reported by chain), `500`.
+
+---
+
+## 5. Read process results / status (proxy)
+
+So integrators never query the Vochain directly.
+
+```
+GET /process/{processId}/results
+```
+
+- **Auth:** Public.
+- **Path:** `processId` — on-chain election ID (hex).
+- **200 OK:** subset of the on-chain election, e.g.:
+  ```json
+  {
+    "status": "READY",
+    "voteCount": 123,
+    "startDate": "2026-07-01T09:00:00Z",
+    "endDate": "2026-07-08T09:00:00Z",
+    "results": [ ["10", "23"], ["5", "28"] ],
+    "finalResults": false
+  }
+  ```
+- **Errors:** `404` process not found on chain, `500` `ErrVochainRequestFailed`.
+
+> The existing `GET /process/{draftId}` (by ObjectID) is unchanged and still returns the
+> stored `db.Process` (draft + census + metadata). Use `/results` for live chain state.
+
+---
+
+## 6. Public election metadata (read)
+
+The on-chain `Process.Metadata` is a public `https://` URL served by the SaaS (not IPFS). The
+SDK and any client can fetch the human-readable election metadata (title, description,
+questions, choices) here:
+
+```
+GET /process/{processId}/metadata
+```
+
+- **Auth:** Public.
+- **Path:** `processId` — on-chain election ID (hex).
+- **200 OK:** the `ElectionMetadata` JSON (same shape derived from the draft's `electionParams`).
+- **Errors:** `404` unknown process.
+
+This is the exact URL embedded as `Process.Metadata` at publish time, so resolving the on-chain
+metadata pointer and calling this endpoint return the same document.
+
+---
+
+## 7. Account bootstrap is internal (no endpoint)
+
+There is **no organizer-facing account-creation step** in the chain-abstracted path. When
+`provisionAccount` is set (§0) — or always, for managed orgs (§8a) — the org's on-chain account is
+forged at organization-creation time. The backend holds the org private key, builds `CreateAccount`,
+funds it, signs, submits and confirms — all invisibly. From the new SDK's / integrator's point of
+view, creating an organization and publishing an election are plain REST calls; there is no account,
+faucet, or transaction concept to manage. (Legacy clients that don't set the flag keep using the
+SDK `createAccount` via `/transactions`, unchanged.)
+
+---
+
+## 8. Integrator: managed organizations + quota
+
+An **integrator** is an ordinary organization granted the integrator capability, so it can create
+and manage organizations for its own clients via the API, under an accountable quota.
+
+- **Enablement:** an org is an integrator if it was manually flagged (`IsIntegrator`) **or** its
+  plan carries the integrator feature. Enabling and quota setup are **internal/admin operations**
+  (a `cmd/cli` command we run) — there is no public write endpoint to grant integrator status or
+  set limits.
+- **Managed organizations are first-class:** each has its own address, its own on-chain account
+  (forged at creation, §0), and its own invitable members. They are linked to the integrator by a
+  `managedBy` field — they are **not** sub-orgs, so a client can still use the normal parent/sub-org
+  feature itself.
+- **Accounting:** aggregate usage (managed orgs, total elections, total census across all managed
+  orgs) is tracked on the integrator org and checked against its effective limits. Quota dimensions:
+  managed orgs, elections per managed org, total elections, census per election, census per managed
+  org, total census.
+
+### 8a. Create a managed organization
+
+```
+POST /organizations/{address}/managed
+```
+
+- **Auth:** Bearer. Caller must be **Admin** of the integrator org `{address}`, and `{address}`
+  must be integrator-enabled.
+- **Path:** `address` — the integrator org address.
+- **Body:** the client org info (same fields as a normal org), plus an optional `ownerEmail` to
+  designate the client org's owner/admin (defaults to the integrator's calling user).
+- **200 OK:** the created org resource (its `address`, etc.). Its on-chain account is already
+  forged. `managedBy` is set to `{address}`. The per-user `MaxOrgsPerUser` cap is bypassed for
+  managed orgs.
+- **Quota:** enforces `CanCreateManagedOrg` (the integrator's `ManagedOrgs` counter `<`
+  `MaxManagedOrgs`); bumps the counter on success.
+- **Errors:** `401` not an admin, `403` `ErrNotAnIntegrator` / `ErrMaxManagedOrgsReached`, `500`
+  forge failed.
+
+### 8b. List managed organizations
+
+```
+GET /organizations/{address}/managed
+```
+
+- **Auth:** Bearer. Admin of the integrator org `{address}`.
+- **200 OK:** a paginated list of the orgs managed by `{address}` (mirrors the drafts list shape).
+- **Errors:** `401`, `403` `ErrNotAnIntegrator`.
+
+### 8c. Integrator quota + usage
+
+```
+GET /organizations/{address}/integrator
+```
+
+- **Auth:** Bearer. Admin of the integrator org `{address}`.
+- **200 OK:**
+  ```jsonc
+  {
+    "enabled": true,
+    "limits": {                       // effective limits: manual override if set, else plan
+      "maxManagedOrgs":      100,
+      "maxProcessesPerOrg":  50,
+      "maxTotalProcesses":   1000,
+      "maxCensusPerProcess": 10000,
+      "maxCensusPerOrg":     50000,
+      "maxTotalCensusSize":  500000
+    },
+    "usage": {                        // current counters rolled up to the integrator
+      "managedOrgs":       12,
+      "managedProcesses":  87,
+      "managedCensusSize": 41230
+    }
+  }
+  ```
+  A `0` in any limit field means **unlimited** for that dimension.
+- **Errors:** `401`, `403` `ErrNotAnIntegrator`.
+
+> **Publish under a managed org** (`POST /process/{draftId}/publish`, §2) additionally enforces the
+> integrator's per-org and aggregate caps and bumps the integrator's `managedProcesses` /
+> `managedCensusSize` counters. The endpoint shape is unchanged; only quota accounting differs when
+> the draft's org is managed.
+
+---
+
+## Voter flow end-to-end (with the new SDK)
+
+1. `POST /process/bundle/{bundleId}/auth/0` … `/auth/{step}` — CSP challenge (existing).
+2. `POST /process/bundle/{bundleId}/sign` — CSP blind signature (existing).
+3. The client builds + signs the `Vote` envelope locally using the CSP signature (the only
+   client-side crypto).
+4. `POST /process/{processId}/vote` — **new** relay endpoint submits it to the chain.
+5. `GET /process/{processId}/results` — **new** read endpoint for live tally.
+
+## New apicommon types (summary)
+
+| Type | Used by |
+|------|---------|
+| `ElectionParams` (+ `Question`, `Choice`, `VoteType`, `ElectionType`) | create/update draft |
+| `PublishProcessRequest` / `PublishProcessResponse` | `POST /process/{id}/publish` |
+| `SetProcessStatusRequest` | `PUT /process/{id}/status` |
+| `RelayVoteRequest` / `RelayVoteResponse` | `POST /process/{id}/vote` |
+| `ProcessResultsResponse` | `GET /process/{id}/results` |
+| `CreateManagedOrganizationRequest` | `POST /organizations/{address}/managed` |
+| `IntegratorInfoResponse` (`enabled`, `limits`, `usage`) | `GET /organizations/{address}/integrator` |

--- a/plan/NEW_API.md
+++ b/plan/NEW_API.md
@@ -25,8 +25,10 @@ Integrators additionally create and manage client organizations under a quota.
 | `PUT`  | `/process/{draftId}` (+ `electionParams`) | Bearer | `censusId`, `metadata`, optional `electionParams` | Update a draft. Same optional `electionParams` field. |
 | `POST` | `/process/{draftId}/publish` | Bearer (Manager/Admin) | optional `{ startDate }` (overrides the draft's start) | Publish a draft to the chain: forge → fund → sign → submit → confirm `NewProcess`. **Async:** validates synchronously, returns `202` + `jobId`; poll `GET /jobs/{jobId}` for the `processId`. |
 | `PUT`  | `/process/{processId}/status` | Bearer (Manager/Admin) | `{ status }` (`ready`/`paused`/`ended`/`canceled`) | Change lifecycle status. **Async:** returns `202` + `jobId`. |
-| `POST` | `/process/{processId}/vote` | Public | `{ txPayload }` (hex of the signed `Vote` envelope) | Relay an already-signed vote envelope to the chain. **Async:** returns `202` + `jobId`; poll for the `voteID` receipt. |
-| `GET`  | `/jobs/{jobId}` | Public (capability) | — (none) | Poll an async tx job (publish/status/vote). Always `200`; `status` is `pending`/`completed`/`failed`, with the on-chain `result` when completed. |
+| `PUT`  | `/process/{processId}/census` | Bearer (Manager/Admin) | `{ participants }` (`{key, weight}[]`) | **Non-CSP only.** Dynamic-census add: append participants and grow the election census size. Gated behind the `DynamicCensus` mode flag. **Async:** returns `202` + `jobId`; poll for the new census size. |
+| `POST` | `/process/{processId}/vote` | Public | `{ txPayload }` (hex of the signed `Vote` envelope) | Relay an already-signed vote envelope to the chain — a **CSP- or proof-authorized** envelope. **Async:** returns `202` + `jobId`; poll for the `voteID` receipt. |
+| `GET`  | `/process/{processId}/census/proof` | Public | `?key=<addr>` | **Non-CSP only.** Proxy a Merkle census proof for the voter key, so the voter can build + sign the envelope. |
+| `GET`  | `/jobs/{jobId}` | Public (capability) | — (none) | Poll an async tx job (publish/status/census/vote). Always `200`; `status` is `pending`/`completed`/`failed`, with the on-chain `result` when completed. |
 | `GET`  | `/process/{processId}/results` | Public | — (none) | Read live status, vote count and tally. |
 | `GET`  | `/process/{processId}/metadata` | Public | — (none) | Read the public election metadata (title, questions, choices). |
 | `POST` | `/organizations/{address}/managed` | Bearer (Admin of integrator) | client org info + optional `ownerEmail` | **Integrator only.** Create a first-class client org managed by `{address}` (forges its account). Quota-enforced. |
@@ -155,10 +157,26 @@ Mapping to the on-chain `models.Process` (built server-side):
 | `voteType.*`                         | `Process.VoteOptions` (maxCount/maxValue/costExponent/maxVoteOverwrites) |
 | `electionType.anonymous/encrypted`  | `Process.EnvelopeType` (Anonymous/EncryptedVotes)    |
 | `electionType.interruptible`        | `Process.Mode.Interruptible`                         |
-| census (from `censusId`)            | `Process.CensusOrigin = OFF_CHAIN_CA` (CSP), `CensusRoot = CSP pubkey`, `CensusURI = SaaS CSP endpoint` |
+| census (from `censusId`)            | `Process.CensusOrigin`, `CensusRoot`, `CensusURI` — depend on the census type (see table below) |
 
-Census origin is always **CSP** for SaaS censuses (`auth`/`mail`/`sms`/`sms_or_mail`), so
-there is no Merkle tree to publish — the CSP public key is the census root.
+### Census types → on-chain origin
+
+The census `type` selects the on-chain `CensusOrigin`, the root, and what a participant record
+carries. The SaaS supports three (there is no plain "tree" type — all censuses are weighted now):
+
+| Census type   | Anonymous | `CensusOrigin`            | Root / participants |
+|---------------|-----------|--------------------------|---------------------|
+| `csp`         | no        | `OFF_CHAIN_CA`           | CSP public key is the root — no Merkle tree to publish; participant = email/phone identity |
+| `weighted`    | no        | `OFF_CHAIN_TREE_WEIGHTED`| Merkle root of `{key: address/pubkey, weight}` participants, published by the SaaS |
+| `zkweighted`  | yes (sets `electionType.anonymous`) | `OFF_CHAIN_TREE_WEIGHTED` | same as `weighted`, but anonymous (Poseidon) |
+
+- **CSP** (`auth`/`mail`/`sms`/`sms_or_mail`) is the existing path: the CSP public key is the
+  census root, so there is no tree to publish, and the voter is authorized by a CSP blind signature.
+- **`weighted` / `zkweighted`** are the **non-CSP (Merkle)** path added in Phase 6: at publish the
+  SaaS builds the on-chain census from the participant list and uses its **published root + URI**;
+  the voter is authorized by a **Merkle census proof** (fetched via §4a) instead of a CSP signature.
+  `zkweighted` additionally sets `EnvelopeType.Anonymous`. The vote relay (§4) accepts either
+  authorization and still never decodes the ballot.
 
 ---
 
@@ -225,6 +243,35 @@ PUT /process/{processId}/status
 
 ---
 
+## 3a. Dynamic census add (non-CSP)
+
+Append participants to a published **non-CSP** (`weighted`/`zkweighted`) census and grow the
+election's census size on chain. The SaaS calls `CensusAddParticipants` then
+`SetElectionCensusSize`. Only valid for elections whose `DynamicCensus` mode flag is set; CSP
+elections (where the root is the CSP pubkey, not a tree) do not support this.
+
+```
+PUT /process/{processId}/census
+```
+
+- **Auth:** Bearer. Manager or Admin of the owning org.
+- **Path:** `processId` — on-chain election ID (hex).
+- **Body:**
+  ```json
+  { "participants": [ { "key": "0x<addr/pubkey>", "weight": "1" } ] }
+  ```
+- **202 Accepted:** participants are validated synchronously; the `CensusAddParticipants` +
+  `SetElectionCensusSize` submit is queued.
+  ```json
+  { "jobId": "<hex job id>" }
+  ```
+  (+ `Location: /jobs/{jobId}`.) Poll the job until `completed`; the result is
+  `{ "censusSize": 5050 }` (the new on-chain census size, set after the SaaS confirms the tx).
+- **Errors:** `400` election is not dynamic / CSP election / empty participants, `401`, `404`
+  process unknown, `503` tx queue full. On-chain failure surfaces on the job as `status: failed`.
+
+---
+
 ## 4. Relay a vote
 
 Submit an already-signed vote envelope to the Vochain. The SaaS **verifies it is a Vote tx
@@ -235,8 +282,10 @@ preserved at the operator).
 POST /process/{processId}/vote
 ```
 
-- **Auth:** Public. The voter is authorized by the CSP proof embedded inside the envelope
-  (obtained via the existing `/process/bundle/{id}/auth|sign` flow).
+- **Auth:** Public. The voter is authorized by the proof embedded inside the envelope — either a
+  **CSP blind signature** (CSP censuses, obtained via the existing `/process/bundle/{id}/auth|sign`
+  flow) **or** a **Merkle census proof** (non-CSP `weighted`/`zkweighted` censuses, obtained via
+  §4a). The relay accepts both and forwards either unchanged; it still never decodes the ballot.
 - **Path:** `processId` — on-chain election ID (hex).
 - **Body:**
   ```json
@@ -258,10 +307,10 @@ POST /process/{processId}/vote
 
 ## Poll an async transaction job
 
-The three endpoints above (publish, status, vote) submit on a bounded background worker pool to keep
-on-chain confirmation (up to ~40s under congestion) off the request path, where it would share the
-router's throttle/timeout budget with the public voter endpoints. Each returns a `jobId`; this single
-endpoint reports the outcome.
+The four endpoints above (publish, status, census add, vote) submit on a bounded background worker
+pool to keep on-chain confirmation (up to ~40s under congestion) off the request path, where it would
+share the router's throttle/timeout budget with the public voter endpoints. Each returns a `jobId`;
+this single endpoint reports the outcome.
 
 ```
 GET /jobs/{jobId}
@@ -275,17 +324,48 @@ GET /jobs/{jobId}
   ```json
   {
     "jobId":  "<hex>",
-    "type":   "publish_process" | "set_process_status" | "relay_vote",
+    "type":   "publish_process" | "set_process_status" | "add_census_participants" | "relay_vote",
     "status": "pending" | "completed" | "failed",
-    "result": { "address": "<hex>", "voteID": "<hex>", "status": "READY" },
+    "result": { "address": "<hex>", "voteID": "<hex>", "status": "READY", "censusSize": 5050 },
     "error":  "<reason, when failed>"
   }
   ```
   `result` is present only when `status` is `completed`, and carries just the fields relevant to the
-  job type (`address`+`status` for publish, `status` for a status change, `voteID` for a vote).
-  `error` is present only when `status` is `failed`.
+  job type (`address`+`status` for publish, `status` for a status change, `censusSize` for a census
+  add, `voteID` for a vote). `error` is present only when `status` is `failed`.
 - **Polling:** clients poll until `status` leaves `pending`. There is no push/webhook.
 - **Errors:** `400` malformed id, `404` unknown job.
+
+---
+
+## 4a. Census proof for a voter (non-CSP)
+
+For **non-CSP** (`weighted`/`zkweighted`) elections the voter is authorized by a **Merkle census
+proof** rather than a CSP blind signature. This endpoint proxies the chain's `CensusGenProof` for
+the given voter key so the voter can assemble + sign the vote envelope client-side; the backend
+never holds the voter key. CSP elections don't use it (their authorization is the CSP signature).
+
+```
+GET /process/{processId}/census/proof?key=<addr>
+```
+
+- **Auth:** Public.
+- **Path:** `processId` — on-chain election ID (hex).
+- **Query:** `key` — the voter's address/public key (hex), as registered in the census.
+- **200 OK:** the census proof for the key, e.g.:
+  ```json
+  {
+    "root":      "<hex census root>",
+    "proof":     "<hex merkle proof>",
+    "leafValue": "<hex>",
+    "siblings":  "<hex>",
+    "weight":    "1"
+  }
+  ```
+  The voter feeds this into the envelope (in place of the CSP `ProofCA`), signs it locally, then
+  posts it to §4.
+- **Errors:** `400` CSP election (no Merkle proof) / missing `key`, `404` key not in census /
+  process unknown, `500` `ErrVochainRequestFailed`.
 
 ---
 
@@ -434,6 +514,7 @@ GET /organizations/{address}/integrator
 
 ## Voter flow end-to-end (with the new SDK)
 
+**CSP census:**
 1. `POST /process/bundle/{bundleId}/auth/0` … `/auth/{step}` — CSP challenge (existing).
 2. `POST /process/bundle/{bundleId}/sign` — CSP blind signature (existing).
 3. The client builds + signs the `Vote` envelope locally using the CSP signature (the only
@@ -442,6 +523,16 @@ GET /organizations/{address}/integrator
 5. `GET /jobs/{jobId}` — poll until `completed`; the result's `voteID` is the vote receipt.
 6. `GET /process/{processId}/results` — **new** read endpoint for live tally.
 
+**Non-CSP (`weighted`/`zkweighted`) census:**
+1. `GET /process/{processId}/census/proof?key=<addr>` — **new** fetch the Merkle census proof for
+   the voter key (§4a).
+2. The client builds + signs the `Vote` envelope locally, embedding the Merkle proof in place of
+   the CSP `ProofCA` (the only client-side crypto).
+3. `POST /process/{processId}/vote` — same relay endpoint; it accepts the proof-authorized envelope,
+   queues it and returns `202` + `jobId`.
+4. `GET /jobs/{jobId}` — poll until `completed`; the result's `voteID` is the vote receipt.
+5. `GET /process/{processId}/results` — live tally.
+
 ## New apicommon types (summary)
 
 | Type | Used by |
@@ -449,7 +540,9 @@ GET /organizations/{address}/integrator
 | `ElectionParams` (+ `Question`, `Choice`, `VoteType`, `ElectionType`) | create/update draft |
 | `PublishProcessRequest` / `PublishProcessResponse` (idempotent 200 only) / `EnqueuedResponse` (202) | `POST /process/{id}/publish` |
 | `SetProcessStatusRequest` / `EnqueuedResponse` (202) | `PUT /process/{id}/status` |
-| `RelayVoteRequest` / `EnqueuedResponse` (202) | `POST /process/{id}/vote` |
+| `AddCensusParticipantsRequest` / `EnqueuedResponse` (202) | `PUT /process/{id}/census` (non-CSP dynamic add) |
+| `RelayVoteRequest` / `EnqueuedResponse` (202) | `POST /process/{id}/vote` (CSP- or proof-authorized) |
+| `CensusProofResponse` | `GET /process/{id}/census/proof` (non-CSP) |
 | `EnqueuedResponse` (`jobId`) / `JobStatusResponse` (`jobId`, `type`, `status`, `result`, `error`) | `GET /jobs/{jobId}` |
 | `ProcessResultsResponse` | `GET /process/{id}/results` |
 | `CreateManagedOrganizationRequest` | `POST /organizations/{address}/managed` |

--- a/plan/SUMMARY.md
+++ b/plan/SUMMARY.md
@@ -49,13 +49,22 @@ RemoteSigner path) keeps working throughout, so old and new can coexist during m
 | Election | `POST /process` / `PUT /process/{id}` *(+ optional `electionParams`)* | organizer |
 | Publish | `POST /process/{draftId}/publish` → `{processId}` | manager/admin |
 | Lifecycle | `PUT /process/{processId}/status` (ready/paused/ended/canceled) | manager/admin |
-| Vote relay | `POST /process/{processId}/vote` → `{voteId}` | public (CSP-authorized) |
+| Vote relay | `POST /process/{processId}/vote` → `{voteId}` | public (CSP- or proof-authorized) |
+| Non-CSP census | `GET /process/{processId}/census/proof` · `PUT /process/{processId}/census` (dynamic add) | public proof · manager/admin |
 | Reads | `GET /process/{processId}/results` · `GET /process/{processId}/metadata` | public |
 | Integrator | `POST`/`GET /organizations/{address}/managed` · `GET /organizations/{address}/integrator` | integrator admin |
 
 Integrator quota dimensions: managed orgs, elections per org, total elections, census per election,
 census per org, total census. A `0` limit means unlimited. Publishing under a managed org rolls
 usage up to the integrator and enforces its caps.
+
+**Non-CSP (Merkle) elections:** the backend was CSP-only, but the vocdoni.app UI still creates
+`weighted` / `zkweighted` (anonymous) censuses straight against the Vochain. Phase 6 brings these
+into the managed path — the backend builds + publishes the on-chain census, issues Merkle census
+proofs (`GET /process/{id}/census/proof`), relays proof-authorized votes alongside CSP ones, and
+supports dynamic-census adds (`PUT /process/{id}/census`) — so the UI can drop `@vocdoni/sdk`
+entirely. It is **pure wiring** over the already-wrapped dvote `apiclient`: no new crypto, nothing
+to vendor.
 
 ## How the hard parts are solved
 
@@ -80,7 +89,7 @@ migrates to it incrementally.
 
 ## Plan & status
 
-Backend ships in 6 phases (each: `make lint` + `make swagger` + `make test` green, plus a Voconed
+Backend ships in 7 phases (each: `make lint` + `make swagger` + `make test` green, plus a Voconed
 integration test):
 
 0. Election params on drafts *(scaffolding)*
@@ -89,6 +98,7 @@ integration test):
 3. Vote relay + status lifecycle
 4. Read proxies (results + metadata)
 5. Integrator layer (managed orgs + quota)
+6. Non-CSP (merkle / weighted / dynamic) elections
 
 **Current status:** designs finalized and reconciled across the three plan docs; implementation
 starting at Phase 0. The SDK is planned but **out of scope for this round** — backend first.

--- a/plan/SUMMARY.md
+++ b/plan/SUMMARY.md
@@ -1,0 +1,94 @@
+# SUMMARY — Chain-abstracted SaaS API + new app SDK
+
+A high-level overview for the team. Detailed designs live in
+[BACKEND_PLAN.md](BACKEND_PLAN.md), [NEW_API.md](NEW_API.md), and [APP_SDK_PLAN.md](APP_SDK_PLAN.md).
+
+## The goal
+
+Make the Vocdoni SaaS a **complete, chain-abstracted election API**. Today an integrator (and our
+own UI) must use `@vocdoni/sdk` + `RemoteSigner` and understand Vochain transactions to run an
+election. After this work, they run the **entire election lifecycle and voting through plain REST**,
+never touching the chain.
+
+The backend already holds each organization's key and signs on its behalf. We extend it so it also
+**forges, funds, submits and confirms** every organizer transaction server-side, and **relays**
+client-signed votes — so callers see a normal SaaS API: resource ids in, resource ids out, no tx
+hashes, gas, faucet, or signers.
+
+## What's changing (in one picture)
+
+```
+            BEFORE                                   AFTER
+  UI ──@vocdoni/sdk──► Vochain            UI / integrator ──REST──► SaaS ──► Vochain
+   └── RemoteSigner ──► SaaS                         (no SDK, no chain, no signer)
+```
+
+## The model: organization-based (unchanged) + integrator (new)
+
+We keep the **organization-based** flow exactly as vocdoni.app works today: register → create an
+organization → its admins create elections. The new behavior is **opt-in and backwards compatible**:
+when a caller sets `provisionAccount` (the new SDK does; managed client orgs always do), the SaaS
+**forges the org's on-chain account server-side** at creation — no separate account/faucet step.
+Existing clients omit the flag and keep today's two-step flow (DB org + SDK `createAccount`)
+completely unchanged.
+
+On top of that we add an **integrator**: an ordinary org granted a special capability so it can
+**create and manage organizations for its own clients** through the API, under an accountable quota.
+Managed client orgs are first-class (own address, own account, invitable members), linked to the
+integrator by a `managedBy` field. Enabling an integrator and setting its quota are internal/admin
+operations (a CLI command we run) — no public endpoint grants integrator status.
+
+## New API surface
+
+Everything below is **additive** — no existing route changes shape. `POST /transactions` (the old
+RemoteSigner path) keeps working throughout, so old and new can coexist during migration.
+
+| Area | Endpoint | Who |
+|------|----------|-----|
+| Org account | `POST /organizations` *(+ optional `provisionAccount` to forge the on-chain account)* | organizer |
+| Election | `POST /process` / `PUT /process/{id}` *(+ optional `electionParams`)* | organizer |
+| Publish | `POST /process/{draftId}/publish` → `{processId}` | manager/admin |
+| Lifecycle | `PUT /process/{processId}/status` (ready/paused/ended/canceled) | manager/admin |
+| Vote relay | `POST /process/{processId}/vote` → `{voteId}` | public (CSP-authorized) |
+| Reads | `GET /process/{processId}/results` · `GET /process/{processId}/metadata` | public |
+| Integrator | `POST`/`GET /organizations/{address}/managed` · `GET /organizations/{address}/integrator` | integrator admin |
+
+Integrator quota dimensions: managed orgs, elections per org, total elections, census per election,
+census per org, total census. A `0` limit means unlimited. Publishing under a managed org rolls
+usage up to the integrator and enforces its caps.
+
+## How the hard parts are solved
+
+- **No migration:** all new DB fields (on `Process`, `Organization`, `Plan`) are optional/zero —
+  Mongo is schemaless, existing docs unmarshal fine.
+- **Election metadata URL chicken-and-egg:** the on-chain `Process.Metadata` needs a public URL
+  *before* submit, but the `processId` only exists *after*. Solved by storing the metadata JSON
+  **content-addressed** (`https://.../storage/{hash}.json`) — a stable URL known before the tx.
+- **Ballot secrecy:** the vote relay verifies the envelope is a Vote for the right process and
+  forwards it; it never decodes the ballot.
+- **Idempotency:** org-account creation and publish are safe to retry (checked against on-chain
+  account existence / stored `processId`).
+
+## The new SDK — `vocdoni-app-sdk`
+
+A standalone TypeScript SDK that talks **only** to this SaaS REST API (no `@vocdoni/sdk`
+dependency). Mirrors `@vocdoni/sdk`'s structure/tooling. Consumer surface has **zero blockchain
+concepts**: `login`, `createOrganization`, `createDraft`, `publish`, `setStatus`, `results`,
+`vote(processId, choices)`, plus integrator methods. The only crypto it owns is building+signing the
+vote envelope (a minimal ported module), entirely hidden inside `vote()`. The vocdoni.app UI
+migrates to it incrementally.
+
+## Plan & status
+
+Backend ships in 6 phases (each: `make lint` + `make swagger` + `make test` green, plus a Voconed
+integration test):
+
+0. Election params on drafts *(scaffolding)*
+1. Chain-abstracted org creation
+2. Publish *(centerpiece)*
+3. Vote relay + status lifecycle
+4. Read proxies (results + metadata)
+5. Integrator layer (managed orgs + quota)
+
+**Current status:** designs finalized and reconciled across the three plan docs; implementation
+starting at Phase 0. The SDK is planned but **out of scope for this round** — backend first.


### PR DESCRIPTION
Stacked on top of `docs/chain-abstraction-plan` (base is that branch, **not** `main`).

## Why
The saas-backend is **CSP-only** today. The vocdoni.app UI still creates **non-CSP** elections (merkle / weighted / dynamic census) by talking to the Vochain via `@vocdoni/sdk` directly, bypassing the backend. For the UI to use **only** the backend, the backend's API must also support creating non-CSP elections.

This is a **docs-only** change: it amends the four plan documents to add **Phase 6** plus the cross-cutting edits to the previously CSP-only assumptions. No code is touched.

## Key facts encoded
- **Reference only — no import, no vendor, no new crypto.** Everything needed is already exposed by the `apiclient.HTTPclient` the backend wraps (`account.Account.client`, from the existing `go.vocdoni.io/dvote` dep). Proof verification is on-chain; the backend only generates proofs and relays votes. Phase 6 is pure wiring.
- Census taxonomy: `weighted`, `zkweighted` (anonymous, Poseidon, `EnvelopeType.Anonymous=true`), `csp`. On-chain origin: `weighted`+`zkweighted` → `OFF_CHAIN_TREE_WEIGHTED`; `csp` → `OFF_CHAIN_CA`.
- Voter signs the ballot client-side; the backend issues the census proof and relays. It never holds the voter key and never decodes the ballot.

## Phase 6 (6 changes documented)
1. `db.CensusType`: add `weighted` / `zkweighted` (participants carry `{key, weight}`).
2. `publishCensusHandler`: build + publish the on-chain census for the new types (store root+URI).
3. `BuildNewProcessTx` / `NewProcessParams`: gain a `CensusOrigin` field; anonymous sets `EnvelopeType.Anonymous`.
4. New `GET /process/{processId}/census/proof?key=<addr>` — proxies `CensusGenProof`.
5. `POST /process/{processId}/vote` relay: generalized to accept CSP- **or** merkle-proof-authorized envelopes.
6. New `PUT /process/{processId}/census` — dynamic add (`CensusAddParticipants` + `SetElectionCensusSize`), gated behind the DynamicCensus flag.

## Cross-cutting edits
- **BACKEND_PLAN.md** — Phase 2 census step generalized; route constants; `db.CensusType` additions; pure-wiring statement.
- **NEW_API.md** — census-type → CensusOrigin table; two new endpoints; vote relay generalized; non-CSP voter flow.
- **SUMMARY.md** — vote-relay line generalized; non-CSP mention in API-surface table and phase list (now 7 phases).
- **APP_SDK_PLAN.md** — SDK `vote()` supports the merkle path (fetch proof → embed `ProofArbo` → relay) alongside CSP, blockchain concepts stay hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)