### PR TITLE
fix(account): bind OAuth signature verification to expected address (#527.2)

### DIFF
--- a/account/signature.go
+++ b/account/signature.go
@@ -3,8 +3,8 @@ package account
 import (
 	"encoding/hex"
 	"fmt"
-	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/util"
 	"go.vocdoni.io/proto/build/go/models"
@@ -57,18 +57,25 @@ func SignMessage(message []byte, signer *ethereum.SignKeys) ([]byte, error) {
 	return signature, nil
 }
 
+// VerifySignature recovers the signer address from the given message and
+// signature and checks that it matches the expected address. It returns an
+// error when the signature cannot be decoded, the address cannot be recovered,
+// or the recovered address does not match the expected one.
 func VerifySignature(message, signature, address string) error {
 	messageBytes := []byte(message)
 	signatureBytes, err := hex.DecodeString(util.TrimHex(signature))
 	if err != nil {
 		return fmt.Errorf("could not decode signature: %w", err)
 	}
-	calcAddress, err := ethereum.AddrFromSignature(messageBytes, signatureBytes)
+	recoveredAddr, err := ethereum.AddrFromSignature(messageBytes, signatureBytes)
 	if err != nil {
 		return fmt.Errorf("could not calculate address from signature: %w", err)
 	}
-	if strings.EqualFold(calcAddress.String(), util.TrimHex(address)) {
-		return fmt.Errorf("signature verification failed")
+	// common.HexToAddress normalizes the expected address regardless of the 0x
+	// prefix or letter case, so the comparison against the recovered address is
+	// reliable. The verification fails when they do not match.
+	if recoveredAddr != common.HexToAddress(address) {
+		return fmt.Errorf("signature verification failed: recovered address does not match expected address")
 	}
 	return nil
 }

--- a/account/signature_test.go
+++ b/account/signature_test.go
@@ -27,30 +27,30 @@ func TestVerifySignature(t *testing.T) {
 	addrNoPrefix := strings.TrimPrefix(addr, "0x")
 	addrLower := strings.ToLower(addr)
 
-	t.Run("valid signature and address", func(_ *testing.T) {
+	c.Run("valid signature and address", func(c *qt.C) {
 		c.Assert(VerifySignature(message, signature, addr), qt.IsNil)
 	})
-	t.Run("valid with non-0x address", func(_ *testing.T) {
+	c.Run("valid with non-0x address", func(c *qt.C) {
 		c.Assert(VerifySignature(message, signature, addrNoPrefix), qt.IsNil)
 	})
-	t.Run("valid with lowercase address", func(_ *testing.T) {
+	c.Run("valid with lowercase address", func(c *qt.C) {
 		c.Assert(VerifySignature(message, signature, addrLower), qt.IsNil)
 	})
-	t.Run("valid with 0x-prefixed signature", func(_ *testing.T) {
+	c.Run("valid with 0x-prefixed signature", func(c *qt.C) {
 		c.Assert(VerifySignature(message, "0x"+signature, addr), qt.IsNil)
 	})
-	t.Run("wrong expected address is rejected", func(_ *testing.T) {
+	c.Run("wrong expected address is rejected", func(c *qt.C) {
 		other := ethereum.NewSignKeys()
 		c.Assert(other.Generate(), qt.IsNil)
 		c.Assert(VerifySignature(message, signature, other.Address().Hex()), qt.Not(qt.IsNil))
 	})
-	t.Run("tampered message is rejected", func(_ *testing.T) {
+	c.Run("tampered message is rejected", func(c *qt.C) {
 		c.Assert(VerifySignature("tampered message", signature, addr), qt.Not(qt.IsNil))
 	})
-	t.Run("malformed signature is rejected", func(_ *testing.T) {
+	c.Run("malformed signature is rejected", func(c *qt.C) {
 		c.Assert(VerifySignature(message, "not-hex", addr), qt.Not(qt.IsNil))
 	})
-	t.Run("empty signature is rejected", func(_ *testing.T) {
+	c.Run("empty signature is rejected", func(c *qt.C) {
 		c.Assert(VerifySignature(message, "", addr), qt.Not(qt.IsNil))
 	})
 }

--- a/account/signature_test.go
+++ b/account/signature_test.go
@@ -1,0 +1,56 @@
+package account
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/dvote/crypto/ethereum"
+)
+
+// TestVerifySignature ensures that VerifySignature only succeeds when the
+// recovered signer address matches the expected address, regardless of the
+// address format (0x-prefixed or not, any letter case), and fails otherwise.
+func TestVerifySignature(t *testing.T) {
+	c := qt.New(t)
+
+	signer := ethereum.NewSignKeys()
+	c.Assert(signer.Generate(), qt.IsNil)
+
+	message := "hello vocdoni"
+	sigBytes, err := signer.SignEthereum([]byte(message))
+	c.Assert(err, qt.IsNil)
+	signature := hex.EncodeToString(sigBytes)
+
+	addr := signer.Address().Hex() // 0x-prefixed, checksummed
+	addrNoPrefix := strings.TrimPrefix(addr, "0x")
+	addrLower := strings.ToLower(addr)
+
+	t.Run("valid signature and address", func(_ *testing.T) {
+		c.Assert(VerifySignature(message, signature, addr), qt.IsNil)
+	})
+	t.Run("valid with non-0x address", func(_ *testing.T) {
+		c.Assert(VerifySignature(message, signature, addrNoPrefix), qt.IsNil)
+	})
+	t.Run("valid with lowercase address", func(_ *testing.T) {
+		c.Assert(VerifySignature(message, signature, addrLower), qt.IsNil)
+	})
+	t.Run("valid with 0x-prefixed signature", func(_ *testing.T) {
+		c.Assert(VerifySignature(message, "0x"+signature, addr), qt.IsNil)
+	})
+	t.Run("wrong expected address is rejected", func(_ *testing.T) {
+		other := ethereum.NewSignKeys()
+		c.Assert(other.Generate(), qt.IsNil)
+		c.Assert(VerifySignature(message, signature, other.Address().Hex()), qt.Not(qt.IsNil))
+	})
+	t.Run("tampered message is rejected", func(_ *testing.T) {
+		c.Assert(VerifySignature("tampered message", signature, addr), qt.Not(qt.IsNil))
+	})
+	t.Run("malformed signature is rejected", func(_ *testing.T) {
+		c.Assert(VerifySignature(message, "not-hex", addr), qt.Not(qt.IsNil))
+	})
+	t.Run("empty signature is rejected", func(_ *testing.T) {
+		c.Assert(VerifySignature(message, "", addr), qt.Not(qt.IsNil))
+	})
+}


### PR DESCRIPTION
## Summary

Fixes issue **#527 (2) — High: OAuth signature verification does not bind signatures to the expected address**.

`account.VerifySignature` had two defects:
1. **Inverted check** — it returned success when the recovered address did **not** match the expected one (`if strings.EqualFold(...) { return error }`).
2. **Format mismatch** — `calcAddress.String()` keeps the `0x` prefix while the expected address was passed through `util.TrimHex`, so even matching addresses compared unequal.

This allowed OAuth registration and account linking (`api/auth.go:197,220,324,345`) to accept signatures produced by the wrong key/address, enabling registration of verified accounts without a valid OAuth-service signature.

## Changes

- Recover the signer address and compare it against `common.HexToAddress(address)`, which normalizes the `0x` prefix and letter case reliably.
- Return an error when the recovered address differs from the expected one.
- Add `account/signature_test.go` covering valid signature, wrong signer, tampered message, malformed/empty signature, and `0x` / non-`0x` / lowercase address inputs.

## Testing

- `go test ./account/ -run TestVerifySignature -v` ✅ (all subtests pass)
- `golangci-lint` / `gofumpt` clean.

Refs #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)