### PR TITLE
fix(csp): random, expiring, attempt-limited 2FA challenge codes (#527.3)

### DIFF
--- a/csp/auth.go
+++ b/csp/auth.go
@@ -2,8 +2,10 @@
 package csp
 
 import (
-	"crypto/sha256"
+	"crypto/rand"
+	"crypto/subtle"
 	"encoding/base32"
+	"fmt"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -57,13 +59,16 @@ func (c *CSP) BundleAuthToken(bID, uID internal.HexBytes, to string,
 			return nil, errors.ErrAttemptCoolDownTime.WithData(map[string]any{"coolDownTime": remainingTime.Milliseconds()})
 		}
 	}
-	// generate a new token, secret and code from the attempt number
-	token, code, err := c.generateToken(uID, bID)
+	// generate a new token, a cryptographically random per-token challenge
+	// secret and the OTP code derived from it
+	challenge, err := c.generateToken(uID, bID)
 	if err != nil {
 		return nil, err
 	}
-	// create the new token
-	if err := c.Storage.SetCSPAuth(token, uID, bID); err != nil {
+	token, code := challenge.token, challenge.code
+	// create the new token storing its challenge secret and expiration
+	expiresAt := time.Now().Add(db.CSPAuthTokenValidity)
+	if err := c.Storage.SetCSPAuthChallenge(token, uID, bID, challenge.secret, expiresAt); err != nil {
 		log.Warnw("error setting new token",
 			"userID", uID,
 			"bundleID", bID,
@@ -141,15 +146,9 @@ func (c *CSP) ResendChallenge(token internal.HexBytes, to string,
 		Name:    orgName,
 		Logo:    orgLogo,
 	}
-	code, err := c.regenerateTokenCode(authTokenData.UserID, authTokenData.BundleID)
-	if err != nil {
-		log.Warnw("error regenerating token code",
-			"userID", authTokenData.UserID,
-			"bundleID", authTokenData.BundleID,
-			"token", token,
-			"error", err)
-		return ErrChallengeCodeFailure
-	}
+	// recompute the same code from the token's stored challenge secret so the
+	// resent challenge matches the original one
+	code := challengeCode(authTokenData.ChallengeSecret)
 	ch, err := notifications.NewNotificationChallenge(
 		ctype,
 		lang,
@@ -203,13 +202,35 @@ func (c *CSP) VerifyBundleAuthToken(token internal.HexBytes, solution string) er
 			"error", err)
 		return ErrInvalidAuthToken
 	}
-	// verify the solution, and if the solution is not correct, return an error
-	if !c.verifySolution(authTokenData.UserID, authTokenData.BundleID, solution) {
-		log.Warnw("challenge code do not match",
+	// reject expired challenge codes
+	if !authTokenData.ExpiresAt.IsZero() && time.Now().After(authTokenData.ExpiresAt) {
+		log.Warnw("challenge code expired",
+			"userID", authTokenData.UserID,
+			"bundleID", authTokenData.BundleID,
+			"token", token)
+		return ErrTokenExpired
+	}
+	// reject tokens that exhausted the maximum number of attempts
+	if authTokenData.Attempts >= MaxChallengeAttempts {
+		log.Warnw("too many challenge attempts",
 			"userID", authTokenData.UserID,
 			"bundleID", authTokenData.BundleID,
 			"token", token,
-			"solution", solution)
+			"attempts", authTokenData.Attempts)
+		return ErrTooManyAttempts
+	}
+	// verify the solution, and if the solution is not correct, count the failed
+	// attempt and return an error
+	if !verifySolution(authTokenData.ChallengeSecret, solution) {
+		log.Warnw("challenge code do not match",
+			"userID", authTokenData.UserID,
+			"bundleID", authTokenData.BundleID,
+			"token", token)
+		if err := c.Storage.IncrementCSPAuthAttempts(token); err != nil {
+			log.Warnw("error incrementing challenge attempts",
+				"token", token,
+				"error", err)
+		}
 		return ErrChallengeCodeFailure
 	}
 	// set the token as verified
@@ -224,19 +245,37 @@ func (c *CSP) VerifyBundleAuthToken(token internal.HexBytes, solution string) er
 	return nil
 }
 
+// MaxChallengeAttempts is the maximum number of failed challenge-code
+// verification attempts allowed for a single authentication token before it is
+// rejected.
+const MaxChallengeAttempts = 5
+
+// challengeSecretSize is the number of random bytes used to build a per-token
+// challenge secret.
+const challengeSecretSize = 20
+
+// authChallenge holds a freshly generated authentication token together with
+// its per-token challenge secret and the OTP code derived from it.
+type authChallenge struct {
+	token  internal.HexBytes
+	secret string
+	code   string
+}
+
 // generateToken method generates a new authentication token for a user in a
-// process. It checks if the process is already consumed for this user. It
-// generates a new challenge secret, challenge token and OTP code for the
-// secret and the attempt number. It returns the token, the secret and the
-// code respectively.
-func (*CSP) generateToken(uID, bID internal.HexBytes) (
-	internal.HexBytes, string, error,
-) {
-	// generate a new challenge secret and challenge token
-	secret := otpSecret(uID, bID)
-	// generate the OTP code for the secret and the attempt number
-	otp := gotp.NewDefaultHOTP(secret)
-	code := otp.At(0)
+// process. It generates a cryptographically random per-token challenge secret
+// and the OTP code derived from it, plus a random token. The uID and bID
+// parameters are only used for logging context.
+func (*CSP) generateToken(uID, bID internal.HexBytes) (authChallenge, error) {
+	// generate a cryptographically random per-token challenge secret
+	secret, err := generateChallengeSecret()
+	if err != nil {
+		log.Warnw("error generating challenge secret",
+			"error", err,
+			"userID", uID,
+			"bundleID", bID)
+		return authChallenge{}, ErrChallengeCodeFailure
+	}
 	// generate a new token and convert it to HexBytes
 	bToken, err := uuid.New().MarshalBinary()
 	if err != nil {
@@ -244,31 +283,33 @@ func (*CSP) generateToken(uID, bID internal.HexBytes) (
 			"error", err,
 			"userID", uID,
 			"bundleID", bID)
-		return nil, "", ErrInvalidAuthToken
+		return authChallenge{}, ErrInvalidAuthToken
 	}
-	return bToken, code, nil
+	// derive the OTP code from the secret
+	return authChallenge{token: bToken, secret: secret, code: challengeCode(secret)}, nil
 }
 
-func (*CSP) regenerateTokenCode(uID, bID internal.HexBytes) (
-	string, error,
-) {
-	secret := otpSecret(uID, bID)
-	otp := gotp.NewDefaultHOTP(secret)
-	code := otp.At(0)
-	return code, nil
+// verifySolution verifies the provided solution against the OTP code derived
+// from the token's stored challenge secret using a constant-time comparison. It
+// returns true if the solution is correct, false otherwise.
+func verifySolution(secret, solution string) bool {
+	code := challengeCode(secret)
+	return subtle.ConstantTimeCompare([]byte(code), []byte(solution)) == 1
 }
 
-// verifySolution method verifies the solution for a user process. It generates
-// the OTP code for the process secret and the attempt number and compares it
-// with the solution. It returns true if the solution is correct, false
-// otherwise.
-func (*CSP) verifySolution(uID, bID internal.HexBytes, solution string) bool {
-	secret := otpSecret(uID, bID)
-	// generate the OTP code for the secret and the attempt number
-	otp := gotp.NewDefaultHOTP(secret)
-	code := otp.At(0)
-	// compare the generated code with the solution
-	return code == solution
+// challengeCode derives the OTP code for the given challenge secret.
+func challengeCode(secret string) string {
+	return gotp.NewDefaultHOTP(secret).At(0)
+}
+
+// generateChallengeSecret returns a cryptographically random base32-encoded
+// secret suitable for use as an HOTP secret.
+func generateChallengeSecret() (string, error) {
+	b := make([]byte, challengeSecretSize)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("could not generate random challenge secret: %w", err)
+	}
+	return base32.StdEncoding.EncodeToString(b), nil
 }
 
 // createAuthOnlyToken creates a pre-verified token for auth-only censuses
@@ -310,13 +351,4 @@ func (c *CSP) createAuthOnlyToken(bID, uID internal.HexBytes) (internal.HexBytes
 		"token", bToken)
 
 	return bToken, nil
-}
-
-// otpSecret method generates a new OTP secret for a user and a bundle. The
-// secret is generated by hashing the user ID and the bundle ID with SHA-256.
-// It returns the secret as HexBytes.
-func otpSecret(uID, bID internal.HexBytes) string {
-	hash := sha256.Sum256(append(uID, bID...))
-	// encode the secret in base32 and return it
-	return base32.StdEncoding.EncodeToString(hash[:])
 }

--- a/csp/auth_test.go
+++ b/csp/auth_test.go
@@ -2,7 +2,6 @@ package csp
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/base32"
 	"io"
 	"regexp"
@@ -17,7 +16,6 @@ import (
 	"github.com/vocdoni/saas-backend/internal"
 	"github.com/vocdoni/saas-backend/notifications/mailtemplates"
 	"github.com/vocdoni/saas-backend/test"
-	"github.com/xlzd/gotp"
 )
 
 func TestBundleAuthToken(t *testing.T) {
@@ -140,13 +138,13 @@ func TestBundleAuthToken(t *testing.T) {
 		)
 		c.Assert(err, qt.IsNil)
 		c.Assert(token, qt.Not(qt.IsNil))
-		// calculate expected code and token
-		_, expectedCode, err := csp.generateToken(testUserID, bundleID)
-		c.Assert(err, qt.IsNil)
+		// the expected code is derived from the token's stored random secret
 		authTokenResult, err := csp.Storage.CSPAuth(token)
 		c.Assert(err, qt.IsNil)
 		c.Assert(authTokenResult.BundleID.Bytes(), qt.DeepEquals, bundleID.Bytes())
 		c.Assert(authTokenResult.UserID.Bytes(), qt.DeepEquals, testUserID.Bytes())
+		c.Assert(authTokenResult.ChallengeSecret, qt.Not(qt.Equals), "")
+		expectedCode := challengeCode(authTokenResult.ChallengeSecret)
 		// wait to dequeue the notification
 		time.Sleep(time.Second * 3)
 		// get the verification code from the email
@@ -214,16 +212,46 @@ func TestVerifyBundleAuthToken(t *testing.T) {
 		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
 		// create the token
 		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
-		// generate the code
-		_, code, err := csp.generateToken(testUserID, testBundleID)
+		// derive the code from the token's stored challenge secret
+		auth, err := csp.Storage.CSPAuth(testToken)
 		c.Assert(err, qt.IsNil)
-		// try to verify an valid solution
+		code := challengeCode(auth.ChallengeSecret)
+		// try to verify a valid solution
 		err = csp.VerifyBundleAuthToken(testToken, code)
 		c.Assert(err, qt.IsNil)
 		// check that the token is verified
 		authTokenResult, err := csp.Storage.CSPAuth(testToken)
 		c.Assert(err, qt.IsNil)
 		c.Assert(authTokenResult.Verified, qt.IsTrue)
+	})
+
+	c.Run("expired token", func(c *qt.C) {
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		// create a token that already expired
+		secret, err := generateChallengeSecret()
+		c.Assert(err, qt.IsNil)
+		c.Assert(csp.Storage.SetCSPAuthChallenge(
+			testToken, testUserID, testBundleID, secret, time.Now().Add(-time.Minute),
+		), qt.IsNil)
+		code := challengeCode(secret)
+		err = csp.VerifyBundleAuthToken(testToken, code)
+		c.Assert(err, qt.ErrorIs, ErrTokenExpired)
+	})
+
+	c.Run("too many attempts", func(c *qt.C) {
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
+		auth, err := csp.Storage.CSPAuth(testToken)
+		c.Assert(err, qt.IsNil)
+		validCode := challengeCode(auth.ChallengeSecret)
+		// exhaust the allowed attempts with wrong codes
+		for range MaxChallengeAttempts {
+			err = csp.VerifyBundleAuthToken(testToken, "000000")
+			c.Assert(err, qt.ErrorIs, ErrChallengeCodeFailure)
+		}
+		// even the valid code is now rejected because attempts are exhausted
+		err = csp.VerifyBundleAuthToken(testToken, validCode)
+		c.Assert(err, qt.ErrorIs, ErrTooManyAttempts)
 	})
 }
 
@@ -330,8 +358,9 @@ func TestResendChallenge(t *testing.T) {
 		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
 		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID), qt.IsNil)
 
-		expectedCode, err := csp.regenerateTokenCode(testUserID, testBundleID)
+		auth, err := csp.Storage.CSPAuth(testToken)
 		c.Assert(err, qt.IsNil)
+		expectedCode := challengeCode(auth.ChallengeSecret)
 
 		err = csp.ResendChallenge(
 			testToken,
@@ -381,8 +410,9 @@ func TestBundleAuthTokenResendAndVerifyFlow(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(token, qt.Not(qt.IsNil))
 
-	expectedFirstCode, err := csp.regenerateTokenCode(testUserID, testBundleID)
+	firstAuth, err := csp.Storage.CSPAuth(token)
 	c.Assert(err, qt.IsNil)
+	expectedFirstCode := challengeCode(firstAuth.ChallengeSecret)
 	firstCode := fetchOTPCodeFromEmail(c, testUserEmail)
 	c.Assert(firstCode, qt.Equals, expectedFirstCode)
 
@@ -413,8 +443,9 @@ func TestBundleAuthTokenResendAndVerifyFlow(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(secondToken, qt.Not(qt.IsNil))
 
-	expectedSecondCode, err := csp.regenerateTokenCode(testUserID, secondBundleID)
+	secondAuth, err := csp.Storage.CSPAuth(secondToken)
 	c.Assert(err, qt.IsNil)
+	expectedSecondCode := challengeCode(secondAuth.ChallengeSecret)
 	secondCode := fetchOTPCodeFromEmail(c, testUserEmail)
 	c.Assert(secondCode, qt.Equals, expectedSecondCode)
 	c.Assert(secondCode, qt.Not(qt.Equals), resendCode)
@@ -434,35 +465,52 @@ func TestBundleAuthTokenResendAndVerifyFlow(t *testing.T) {
 
 func TestGenerateToken(t *testing.T) {
 	c := qt.New(t)
-	secret := otpSecret(testUserID, testBundleID)
-	otp := gotp.NewDefaultHOTP(secret)
-	token, code, err := new(CSP).generateToken(testUserID, testBundleID)
+	challenge, err := new(CSP).generateToken(testUserID, testBundleID)
 	c.Assert(err, qt.IsNil)
-	c.Assert(token, qt.Not(qt.IsNil))
-	c.Assert(code, qt.Equals, otp.At(0))
+	c.Assert(challenge.token, qt.Not(qt.IsNil))
+	c.Assert(challenge.secret, qt.Not(qt.Equals), "")
+	// the code is deterministically derived from the secret
+	c.Assert(challenge.code, qt.Equals, challengeCode(challenge.secret))
+
+	// two tokens for the SAME user and bundle must yield different secrets and
+	// codes, proving codes are no longer deterministic from (userID, bundleID)
+	challenge2, err := new(CSP).generateToken(testUserID, testBundleID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(challenge2.token.Bytes(), qt.Not(qt.DeepEquals), challenge.token.Bytes())
+	c.Assert(challenge2.secret, qt.Not(qt.Equals), challenge.secret)
+	c.Assert(challenge2.code, qt.Not(qt.Equals), challenge.code)
 }
 
 func TestVerifySolution(t *testing.T) {
 	c := qt.New(t)
 
-	secret := otpSecret(testUserID, testBundleID)
-	otp := gotp.NewDefaultHOTP(secret)
-	code := otp.At(0)
+	challenge, err := new(CSP).generateToken(testUserID, testBundleID)
+	c.Assert(err, qt.IsNil)
 
-	ok := new(CSP).verifySolution(testUserID, testBundleID, code)
-	c.Assert(ok, qt.IsTrue)
-
-	ok = new(CSP).verifySolution(testUserID, testBundleID, "invalid")
-	c.Assert(ok, qt.IsFalse)
+	c.Assert(verifySolution(challenge.secret, challenge.code), qt.IsTrue)
+	c.Assert(verifySolution(challenge.secret, "invalid"), qt.IsFalse)
+	c.Assert(verifySolution(challenge.secret, ""), qt.IsFalse)
+	// a different secret must not validate the same code (overwhelmingly likely)
+	other, err := new(CSP).generateToken(testUserID, testBundleID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(verifySolution(other.secret, challenge.code), qt.IsFalse)
 }
 
-func TestOTPSecret(t *testing.T) {
+func TestGenerateChallengeSecret(t *testing.T) {
 	c := qt.New(t)
 
-	expectedSecret := sha256.Sum256(append(testUserID, testBundleID...))
-	encodedSecret := base32.StdEncoding.EncodeToString(expectedSecret[:])
-	secret := otpSecret(testUserID, testBundleID)
-	c.Assert(secret, qt.Equals, encodedSecret)
+	seen := make(map[string]bool)
+	for range 100 {
+		s, err := generateChallengeSecret()
+		c.Assert(err, qt.IsNil)
+		c.Assert(s, qt.Not(qt.Equals), "")
+		// secrets must be unique
+		c.Assert(seen[s], qt.IsFalse)
+		seen[s] = true
+		// secrets must be valid base32 so they can be used as HOTP secrets
+		_, err = base32.StdEncoding.DecodeString(s)
+		c.Assert(err, qt.IsNil)
+	}
 }
 
 func fetchOTPCodeFromEmail(c *qt.C, email string) string {

--- a/db/csp.go
+++ b/db/csp.go
@@ -2,7 +2,9 @@ package db
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base32"
 	"errors"
 	"fmt"
 	"time"
@@ -16,13 +18,24 @@ import (
 
 // CSPAuth represents a user authentication information for a bundle of processes
 type CSPAuth struct {
-	Token      internal.HexBytes `json:"token" bson:"_id"`
-	UserID     internal.HexBytes `json:"userID" bson:"userid"`
-	BundleID   internal.HexBytes `json:"bundleID" bson:"bundleid"`
-	CreatedAt  time.Time         `json:"createdAt" bson:"createdat"`
-	Verified   bool              `json:"verified" bson:"verified"`
-	VerifiedAt time.Time         `json:"verifiedAt" bson:"verifiedat"`
+	Token    internal.HexBytes `json:"token" bson:"_id"`
+	UserID   internal.HexBytes `json:"userID" bson:"userid"`
+	BundleID internal.HexBytes `json:"bundleID" bson:"bundleid"`
+	// ChallengeSecret is a cryptographically random per-token secret used to
+	// derive the challenge (OTP) code. It is never exposed through the JSON API.
+	ChallengeSecret string    `json:"-" bson:"challengesecret"`
+	CreatedAt       time.Time `json:"createdAt" bson:"createdat"`
+	// ExpiresAt is the moment after which the challenge code is no longer valid.
+	ExpiresAt time.Time `json:"expiresAt" bson:"expiresat"`
+	// Attempts counts the number of failed verification attempts for the token.
+	Attempts   int       `json:"attempts" bson:"attempts"`
+	Verified   bool      `json:"verified" bson:"verified"`
+	VerifiedAt time.Time `json:"verifiedAt" bson:"verifiedat"`
 }
+
+// CSPAuthTokenValidity is the default lifetime of a CSP challenge code created
+// through SetCSPAuth. After this period the code can no longer be verified.
+const CSPAuthTokenValidity = 5 * time.Minute
 
 // CSPProcess is the status of a process in a bundle of processes for a user
 type CSPProcess struct {
@@ -37,10 +50,27 @@ type CSPProcess struct {
 }
 
 // SetCSPAuth method stores a new CSP authentication token for a user and a
-// bundle of processes. It returns an error if the token, user ID or bundle
-// ID are nil.
+// bundle of processes. It generates a cryptographically random per-token
+// challenge secret and a default expiration (CSPAuthTokenValidity). It returns
+// an error if the token, user ID or bundle ID are nil.
 func (ms *MongoStorage) SetCSPAuth(token, userID, bundleID internal.HexBytes) error {
+	secret, err := randomChallengeSecret()
+	if err != nil {
+		return errors.Join(ErrStoreToken, err)
+	}
+	return ms.SetCSPAuthChallenge(token, userID, bundleID, secret, time.Now().Add(CSPAuthTokenValidity))
+}
+
+// SetCSPAuthChallenge method stores a new CSP authentication token together with
+// its per-token challenge secret and expiration. It returns an error if the
+// token, user ID or bundle ID are nil, or if the secret is empty.
+func (ms *MongoStorage) SetCSPAuthChallenge(
+	token, userID, bundleID internal.HexBytes, secret string, expiresAt time.Time,
+) error {
 	if token == nil || userID == nil || bundleID == nil {
+		return ErrBadInputs
+	}
+	if secret == "" {
 		return ErrBadInputs
 	}
 	ms.keysLock.Lock()
@@ -50,15 +80,48 @@ func (ms *MongoStorage) SetCSPAuth(token, userID, bundleID internal.HexBytes) er
 	defer cancel()
 	// insert the token
 	if _, err := ms.cspTokens.InsertOne(ctx, CSPAuth{
-		Token:     token,
-		UserID:    userID,
-		BundleID:  bundleID,
-		CreatedAt: time.Now(),
-		Verified:  false,
+		Token:           token,
+		UserID:          userID,
+		BundleID:        bundleID,
+		ChallengeSecret: secret,
+		CreatedAt:       time.Now(),
+		ExpiresAt:       expiresAt,
+		Verified:        false,
 	}); err != nil {
 		return errors.Join(ErrStoreToken, err)
 	}
 	return nil
+}
+
+// IncrementCSPAuthAttempts increments the failed-attempt counter for the given
+// CSP authentication token. It returns an error if the token is nil or does not
+// exist.
+func (ms *MongoStorage) IncrementCSPAuthAttempts(token internal.HexBytes) error {
+	if token == nil {
+		return ErrBadInputs
+	}
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	res, err := ms.cspTokens.UpdateOne(ctx, bson.M{"_id": token}, bson.M{"$inc": bson.M{"attempts": 1}})
+	if err != nil {
+		return errors.Join(ErrStoreToken, err)
+	}
+	if res.MatchedCount == 0 {
+		return ErrTokenNotFound
+	}
+	return nil
+}
+
+// randomChallengeSecret returns a cryptographically random base32-encoded secret
+// suitable for use as an HOTP/TOTP secret.
+func randomChallengeSecret() (string, error) {
+	b := make([]byte, 20)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("could not generate random challenge secret: %w", err)
+	}
+	return base32.StdEncoding.EncodeToString(b), nil
 }
 
 // CSPAuth method returns the CSP authentication data for a given token. It


### PR DESCRIPTION
## Summary

Fixes issue **#527 (3) — High: CSP 2FA challenge codes are deterministic and do not expire**.

CSP challenge codes were generated as `HOTP(sha256(userID || bundleID), counter=0)` — no server secret, no per-token randomness, no expiry, no attempt counter. Verification recomputed the same deterministic code. Anyone who could infer a member/participant ID and bundle ID (both reachable via existing org/member APIs and the voting flow) could compute the email/SMS code **offline** and verify a token without ever receiving the challenge. Static codes also stayed valid indefinitely.

## Changes

**`csp/auth.go`**
- Generate a cryptographically random per-token challenge secret (`crypto/rand`, 20 bytes, base32) and derive the OTP code from it.
- Removed the deterministic `otpSecret(userID, bundleID)` derivation.
- `VerifyBundleAuthToken` now enforces **expiry** (`ErrTokenExpired`) and **max failed attempts** (`MaxChallengeAttempts`, `ErrTooManyAttempts`), and compares the solution in **constant time** (`crypto/subtle`).
- Failed attempts are counted in storage.
- `generateToken` results packed into a struct (style guide: >3 returns).

**`db/csp.go`**
- `CSPAuth` gains `ChallengeSecret` (json:`-`), `ExpiresAt`, `Attempts`.
- New `SetCSPAuthChallenge(token, userID, bundleID, secret, expiresAt)` and `IncrementCSPAuthAttempts(token)`.
- `SetCSPAuth` now auto-generates a random secret + default expiry (`CSPAuthTokenValidity = 5m`), so existing callers/tests keep working.

## Testing

- `go test ./csp/... ./db/`, plus API CSP voting/bundle tests ✅
- New/updated tests prove: codes **differ between tokens for the same user/bundle**, expired tokens fail, over-attempt tokens fail (valid code rejected once attempts exhausted), and challenge secrets are unique/valid base32.

Refs #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)