### PR TITLE
feat(subscriptions): derive integrator status from integrator limits (self-serve enablement)

### DIFF
--- a/api/integrator_subscription_test.go
+++ b/api/integrator_subscription_test.go
@@ -46,14 +46,12 @@ func TestIntegratorPlanSubscription(t *testing.T) {
 		}
 	}()
 
-	// Subscribe the org to the integrator plan and flag it as an integrator, WITHOUT
-	// setting an IntegratorLimits override, so the limits must resolve from the plan.
+	// Subscribe the org to the integrator plan WITHOUT setting an IntegratorLimits
+	// override, so both enablement and limits must resolve from the (active) plan.
 	setOrganizationSubscription(t, integratorAddr, integratorPlanID)
 	integratorOrg, err := testDB.Organization(integratorAddr)
 	c.Assert(err, qt.IsNil)
-	integratorOrg.IsIntegrator = true
 	c.Assert(integratorOrg.IntegratorLimits, qt.IsNil) // override path must be out of play
-	c.Assert(testDB.SetOrganization(integratorOrg), qt.IsNil)
 
 	// Integrator info: enabled, and the limits are exactly the plan's.
 	info := requestAndParse[apicommon.IntegratorInfoResponse](

--- a/api/integrator_test.go
+++ b/api/integrator_test.go
@@ -33,7 +33,6 @@ func TestIntegratorManagedOrgs(t *testing.T) {
 	// MaxManagedOrgs 2, MaxManagedProcesses 1, MaxManagedCensusSize 1000
 	integratorOrg, err := testDB.Organization(integratorAddr)
 	c.Assert(err, qt.IsNil)
-	integratorOrg.IsIntegrator = true
 	integratorOrg.IntegratorLimits = &db.IntegratorLimits{
 		MaxManagedOrgs:       2,
 		MaxManagedProcesses:  1,

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -129,7 +129,8 @@ func setIntegrator(database *db.MongoStorage, orgAddress string, maxOrgs, maxPro
 	if err != nil {
 		return fmt.Errorf("could not get organization: %w", err)
 	}
-	org.IsIntegrator = true
+	// Setting a per-organization limits override both enables integrator status and
+	// caps its managed resources (see Subscriptions.IsIntegrator).
 	org.IntegratorLimits = &db.IntegratorLimits{
 		MaxManagedOrgs:       maxOrgs,
 		MaxManagedProcesses:  maxProcesses,

--- a/db/types.go
+++ b/db/types.go
@@ -72,28 +72,30 @@ type OrganizationUser struct {
 }
 
 type Organization struct {
-	Address          common.Address           `json:"address" bson:"_id"` // common.Address is serialized as bytes in the db
-	Website          string                   `json:"website" bson:"website"`
-	Type             OrganizationType         `json:"type" bson:"type"`
-	Creator          string                   `json:"creator" bson:"creator"`
-	CreatedAt        time.Time                `json:"createdAt" bson:"createdAt"`
-	Nonce            string                   `json:"nonce" bson:"nonce"`
-	Size             string                   `json:"size" bson:"size"`
-	Color            string                   `json:"color" bson:"color"`
-	Subdomain        string                   `json:"subdomain" bson:"subdomain"`
-	Country          string                   `json:"country" bson:"country"`
-	Timezone         string                   `json:"timezone" bson:"timezone"`
-	Active           bool                     `json:"active" bson:"active"`
-	Communications   bool                     `json:"communications" bson:"communications"`
-	TokensPurchased  uint64                   `json:"tokensPurchased" bson:"tokensPurchased"`
-	TokensRemaining  uint64                   `json:"tokensRemaining" bson:"tokensRemaining"`
-	Parent           common.Address           `json:"parent" bson:"parent"`
-	Meta             map[string]any           `json:"meta" bson:"meta"`
-	Subscription     OrganizationSubscription `json:"subscription" bson:"subscription"`
-	Counters         OrganizationCounters     `json:"counters" bson:"counters"`
-	ManagedBy        common.Address           `json:"managedBy,omitempty" bson:"managedBy,omitempty"`
-	IsIntegrator     bool                     `json:"isIntegrator" bson:"isIntegrator"`
-	IntegratorLimits *IntegratorLimits        `json:"integratorLimits,omitempty" bson:"integratorLimits,omitempty"`
+	Address         common.Address           `json:"address" bson:"_id"` // common.Address is serialized as bytes in the db
+	Website         string                   `json:"website" bson:"website"`
+	Type            OrganizationType         `json:"type" bson:"type"`
+	Creator         string                   `json:"creator" bson:"creator"`
+	CreatedAt       time.Time                `json:"createdAt" bson:"createdAt"`
+	Nonce           string                   `json:"nonce" bson:"nonce"`
+	Size            string                   `json:"size" bson:"size"`
+	Color           string                   `json:"color" bson:"color"`
+	Subdomain       string                   `json:"subdomain" bson:"subdomain"`
+	Country         string                   `json:"country" bson:"country"`
+	Timezone        string                   `json:"timezone" bson:"timezone"`
+	Active          bool                     `json:"active" bson:"active"`
+	Communications  bool                     `json:"communications" bson:"communications"`
+	TokensPurchased uint64                   `json:"tokensPurchased" bson:"tokensPurchased"`
+	TokensRemaining uint64                   `json:"tokensRemaining" bson:"tokensRemaining"`
+	Parent          common.Address           `json:"parent" bson:"parent"`
+	Meta            map[string]any           `json:"meta" bson:"meta"`
+	Subscription    OrganizationSubscription `json:"subscription" bson:"subscription"`
+	Counters        OrganizationCounters     `json:"counters" bson:"counters"`
+	ManagedBy       common.Address           `json:"managedBy,omitempty" bson:"managedBy,omitempty"`
+	// IntegratorLimits, when set, is a per-organization override that both enables
+	// integrator status (manual/admin path) and caps its managed resources. When unset,
+	// integrator status and limits derive from the active subscription plan instead.
+	IntegratorLimits *IntegratorLimits `json:"integratorLimits,omitempty" bson:"integratorLimits,omitempty"`
 }
 
 // IntegratorLimits caps the resources an integrator organization may consume

--- a/subscriptions/subscriptions.go
+++ b/subscriptions/subscriptions.go
@@ -324,8 +324,29 @@ func (p *Subscriptions) OrgCanAddCensusParticipants(orgAddress common.Address, c
 }
 
 // IsIntegrator reports whether the given organization is enabled as an integrator.
-func (*Subscriptions) IsIntegrator(org *db.Organization) bool {
-	return org != nil && org.IsIntegrator
+//
+// Enablement is derived entirely from integrator limits — there is no separate flag:
+//   - a per-organization IntegratorLimits override (the manual/admin path) grants
+//     integrator status regardless of subscription state; and
+//   - otherwise the organization's subscription plan grants it, but only while the
+//     subscription is active.
+//
+// In both cases "integrator" means the effective limits allow at least one managed org.
+func (p *Subscriptions) IsIntegrator(org *db.Organization) bool {
+	if org == nil {
+		return false
+	}
+	if org.IntegratorLimits != nil {
+		return org.IntegratorLimits.MaxManagedOrgs > 0
+	}
+	if !org.Subscription.Active || org.Subscription.PlanID == 0 {
+		return false
+	}
+	plan, err := p.db.Plan(org.Subscription.PlanID)
+	if err != nil || plan == nil {
+		return false
+	}
+	return plan.IntegratorLimits.MaxManagedOrgs > 0
 }
 
 // EffectiveIntegratorLimits returns the integrator limits in force for the org: the

--- a/subscriptions/subscriptions_test.go
+++ b/subscriptions/subscriptions_test.go
@@ -166,10 +166,43 @@ func TestHasDBPermission(t *testing.T) {
 
 func TestIsIntegrator(t *testing.T) {
 	c := qt.New(t)
-	subs := &Subscriptions{}
+	mockDB := &mockMongoStorage{
+		plans: map[uint64]*db.Plan{
+			1: {ID: 1, IntegratorLimits: db.IntegratorLimits{MaxManagedOrgs: 5}}, // integrator plan
+			2: {ID: 2, IntegratorLimits: db.IntegratorLimits{MaxManagedOrgs: 0}}, // regular plan
+		},
+	}
+	subs := &Subscriptions{db: mockDB}
+
 	c.Assert(subs.IsIntegrator(nil), qt.IsFalse)
-	c.Assert(subs.IsIntegrator(&db.Organization{IsIntegrator: false}), qt.IsFalse)
-	c.Assert(subs.IsIntegrator(&db.Organization{IsIntegrator: true}), qt.IsTrue)
+
+	// no override and no plan
+	c.Assert(subs.IsIntegrator(&db.Organization{}), qt.IsFalse)
+
+	// a per-org override (manual/admin path) enables regardless of subscription state
+	c.Assert(subs.IsIntegrator(&db.Organization{
+		IntegratorLimits: &db.IntegratorLimits{MaxManagedOrgs: 2},
+	}), qt.IsTrue)
+
+	// an override of zero managed orgs is not an integrator
+	c.Assert(subs.IsIntegrator(&db.Organization{
+		IntegratorLimits: &db.IntegratorLimits{MaxManagedOrgs: 0},
+	}), qt.IsFalse)
+
+	// self-serve via an active subscription to an integrator plan
+	c.Assert(subs.IsIntegrator(&db.Organization{
+		Subscription: db.OrganizationSubscription{PlanID: 1, Active: true},
+	}), qt.IsTrue)
+
+	// the same plan with a lapsed (inactive) subscription is not an integrator
+	c.Assert(subs.IsIntegrator(&db.Organization{
+		Subscription: db.OrganizationSubscription{PlanID: 1, Active: false},
+	}), qt.IsFalse)
+
+	// an active subscription to a non-integrator plan is not an integrator
+	c.Assert(subs.IsIntegrator(&db.Organization{
+		Subscription: db.OrganizationSubscription{PlanID: 2, Active: true},
+	}), qt.IsFalse)
 }
 
 func TestEffectiveIntegratorLimits(t *testing.T) {
@@ -221,13 +254,12 @@ func TestCanCreateManagedOrg(t *testing.T) {
 	subs := &Subscriptions{}
 	limits := &db.IntegratorLimits{MaxManagedOrgs: 3}
 
-	// a non-integrator org is refused
-	err := subs.CanCreateManagedOrg(&db.Organization{IsIntegrator: false, IntegratorLimits: limits})
+	// a non-integrator org (no override, no plan) is refused
+	err := subs.CanCreateManagedOrg(&db.Organization{})
 	c.Assert(err, qt.ErrorIs, errors.ErrNotAnIntegrator)
 
 	// one under the limit is allowed
 	err = subs.CanCreateManagedOrg(&db.Organization{
-		IsIntegrator:     true,
 		IntegratorLimits: limits,
 		Counters:         db.OrganizationCounters{ManagedOrgs: 2},
 	})
@@ -235,7 +267,6 @@ func TestCanCreateManagedOrg(t *testing.T) {
 
 	// at the limit is rejected
 	err = subs.CanCreateManagedOrg(&db.Organization{
-		IsIntegrator:     true,
 		IntegratorLimits: limits,
 		Counters:         db.OrganizationCounters{ManagedOrgs: 3},
 	})
@@ -245,17 +276,16 @@ func TestCanCreateManagedOrg(t *testing.T) {
 func TestCanPublishForManagedOrg(t *testing.T) {
 	c := qt.New(t)
 	subs := &Subscriptions{}
-	limits := &db.IntegratorLimits{MaxManagedProcesses: 5, MaxManagedCensusSize: 100}
+	limits := &db.IntegratorLimits{MaxManagedOrgs: 5, MaxManagedProcesses: 5, MaxManagedCensusSize: 100}
 	integrator := func(processes, censusSize int) *db.Organization {
 		return &db.Organization{
-			IsIntegrator:     true,
 			IntegratorLimits: limits,
 			Counters:         db.OrganizationCounters{ManagedProcesses: processes, ManagedCensusSize: censusSize},
 		}
 	}
 
-	// a non-integrator org is refused
-	err := subs.CanPublishForManagedOrg(&db.Organization{IsIntegrator: false, IntegratorLimits: limits}, 10)
+	// a non-integrator org (no override, no plan) is refused
+	err := subs.CanPublishForManagedOrg(&db.Organization{}, 10)
 	c.Assert(err, qt.ErrorIs, errors.ErrNotAnIntegrator)
 
 	// within quota (census exactly at the limit) is allowed


### PR DESCRIPTION
## What

Makes integrator enablement **self-serve** and removes the redundant `Organization.IsIntegrator` boolean.

An organization is now an integrator when its **effective integrator limits allow at least one managed org** (`MaxManagedOrgs > 0`), from either source:

- a per-organization `IntegratorLimits` **override** (the manual/admin path, set via the CLI) — enables regardless of subscription state; or
- the organization's **subscription plan** — but only while the subscription is **active**.

So subscribing to an integrator-capable plan grants integrator access with no manual step, and letting it lapse revokes it. The per-org override remains the admin/comp path.

```go
func (p *Subscriptions) IsIntegrator(org *db.Organization) bool {
    if org == nil {
        return false
    }
    if org.IntegratorLimits != nil { // manual/admin override
        return org.IntegratorLimits.MaxManagedOrgs > 0
    }
    if !org.Subscription.Active || org.Subscription.PlanID == 0 {
        return false
    }
    plan, err := p.db.Plan(org.Subscription.PlanID)
    if err != nil || plan == nil {
        return false
    }
    return plan.IntegratorLimits.MaxManagedOrgs > 0
}
```

## Why

`IsIntegrator` previously gated on `Organization.IsIntegrator`, which was only ever set by the admin CLI — so becoming an integrator required manual Vocdoni intervention even though the data model already supported plan-based limits. This collapses "is integrator" onto the single source of truth (`IntegratorLimits`), mirroring @p4u's recent cleanup in `199c0ff` that dropped the redundant `Plan.Integrator` flag.

> @p4u — flagging you since this lands on the integrator model you just touched. This *extends* that direction (one source of truth = limits) rather than reverting it; the manual-override path you set in the CLI is preserved. Two decisions baked in that I'd like you to confirm:
> 1. **Lapsed subscriptions revoke plan-derived integrator access** (`&& Subscription.Active`). The override path intentionally ignores subscription state.
> 2. **`MaxManagedOrgs > 0` is the enablement signal** (an integrator that can manage zero orgs is a contradiction).

## Changes

- `subscriptions/subscriptions.go` — `IsIntegrator` derives from limits (override or active plan).
- `db/types.go` — remove the now-redundant `Organization.IsIntegrator` field.
- `cmd/cli/main.go` — `setIntegrator` enables via the limits override only (drops the boolean).
- Tests updated: `TestIsIntegrator` now covers override / active-plan / lapsed-plan / non-integrator-plan; the managed-org and publish tests express enablement via limits.

## Migration

**None.** Every currently-enabled org was enabled via the CLI, which always set the `IntegratorLimits` override — so all remain integrators. The stale `isIntegrator` field in stored documents is simply ignored.

## Verification

- `go build ./...` ✅
- `go test ./subscriptions/...` ✅
- `go vet` + api/cmd test packages compile ✅ (api integration tests require a DB and were not run here)

## Frontend

Pairs with the integrator portal (`vocdoni/vocdoni-integrator-app`): with this change, subscribing to an integrator plan there enables the dashboard with no manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)