### PR TITLE
feat(integrator): free tier on org creation + Stripe integrator-plan support

### DIFF
--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -560,6 +560,9 @@ type SubscriptionPlan struct {
 
 	// Features available in this plan
 	Features SubscriptionFeatures `json:"features"`
+
+	// Integrator limits for this plan (zero when the plan is not an integrator plan)
+	IntegratorLimits SubscriptionIntegratorLimits `json:"integratorLimits"`
 }
 
 // SubscriptionPlanFromDB converts a db.Plan to a SubscriptionPlan.
@@ -579,6 +582,7 @@ func SubscriptionPlanFromDB(plan *db.Plan) SubscriptionPlan {
 		Organization:         SubscriptionPlanLimits(plan.Organization),
 		VotingTypes:          SubscriptionVotingTypes(plan.VotingTypes),
 		Features:             SubscriptionFeatures(plan.Features),
+		IntegratorLimits:     SubscriptionIntegratorLimits(plan.IntegratorLimits),
 	}
 }
 
@@ -609,6 +613,21 @@ type SubscriptionPlanLimits struct {
 
 	// Whether this is a custom plan
 	CustomPlan bool `json:"customPlan"`
+}
+
+// SubscriptionIntegratorLimits represents the integrator limits of a subscription plan.
+// It is the mirror struct of db.IntegratorLimits. All-zero means the plan is not an
+// integrator plan.
+// swagger:model SubscriptionIntegratorLimits
+type SubscriptionIntegratorLimits struct {
+	// Maximum number of organizations the integrator may manage
+	MaxManagedOrgs int `json:"maxManagedOrgs"`
+
+	// Maximum number of voting processes across managed organizations
+	MaxManagedProcesses int `json:"maxManagedProcesses"`
+
+	// Maximum total census size across managed organizations
+	MaxManagedCensusSize int `json:"maxManagedCensusSize"`
 }
 
 // SubscriptionVotingTypes represents the voting types available in a subscription plan.

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -90,6 +90,12 @@ type OrganizationInfo struct {
 	// Whether to provision the organization's on-chain account at creation
 	// time (opt-in, eager). Default false preserves the legacy two-step flow.
 	ProvisionAccount bool `json:"provisionAccount,omitempty"`
+
+	// Whether to subscribe the new organization to the free integrator plan at
+	// creation time (opt-in). Used by the integrator portal so a newly created org
+	// becomes an integrator on the free tier with no checkout. Default false uses
+	// the regular default plan.
+	Integrator bool `json:"integrator,omitempty"`
 }
 
 // OrganizationUsers represents a list of users of an organization.

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -65,6 +65,17 @@ func (a *API) createOrganizationHandler(w http.ResponseWriter, r *http.Request) 
 		errors.ErrNoDefaultPlan.WithErr((err)).Write(w)
 		return
 	}
+	// integrator portal opt-in: subscribe the new org to the free integrator plan so it
+	// becomes an integrator on the free tier with no checkout (see Subscriptions.IsIntegrator).
+	selectedPlan := defaultPlan
+	if orgInfo.Integrator {
+		freePlan, err := a.db.FreeIntegratorPlan()
+		if err != nil || freePlan == nil {
+			errors.ErrPlanNotFound.Withf("free integrator plan not available").Write(w)
+			return
+		}
+		selectedPlan = freePlan
+	}
 	// check if the user has permission to create new organizations
 	hasPermission, err := a.subscriptions.HasDBPermission(user.Email, common.Address{}, subscriptions.CreateOrg)
 	if !hasPermission || err != nil {
@@ -131,7 +142,7 @@ func (a *API) createOrganizationHandler(w http.ResponseWriter, r *http.Request) 
 		TokensRemaining: 0,
 		Parent:          parentOrg,
 		Subscription: db.OrganizationSubscription{
-			PlanID:    defaultPlan.ID,
+			PlanID:    selectedPlan.ID,
 			StartDate: time.Now(),
 			Active:    true,
 		},

--- a/api/plans.go
+++ b/api/plans.go
@@ -6,8 +6,16 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/vocdoni/saas-backend/api/apicommon"
+	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
 )
+
+// isFreeIntegratorPlan reports whether a plan is the internal free integrator plan: a zero-priced
+// plan that grants managed-org capacity. It is auto-assigned at org creation (see
+// createOrganizationHandler) and must not be listed publicly as a purchasable plan.
+func isFreeIntegratorPlan(p *db.Plan) bool {
+	return p != nil && p.MonthlyPrice == 0 && p.YearlyPrice == 0 && p.IntegratorLimits.MaxManagedOrgs > 0
+}
 
 // plansHandler godoc
 //
@@ -26,8 +34,17 @@ func (a *API) plansHandler(w http.ResponseWriter, _ *http.Request) {
 		errors.ErrGenericInternalServerError.Withf("could not get plans: %v", err).Write(w)
 		return
 	}
+	// hide the internal free integrator plan from the public listing (it's auto-assigned, not
+	// purchasable). Paid integrator plans remain visible so the integrator portal can offer them.
+	visible := make([]*db.Plan, 0, len(plans))
+	for _, p := range plans {
+		if isFreeIntegratorPlan(p) {
+			continue
+		}
+		visible = append(visible, p)
+	}
 	// send the plans back to the user
-	apicommon.HTTPWriteJSON(w, plans)
+	apicommon.HTTPWriteJSON(w, visible)
 }
 
 // planInfoHandler godoc

--- a/db/plans.go
+++ b/db/plans.go
@@ -115,6 +115,30 @@ func (ms *MongoStorage) DefaultPlan() (*Plan, error) {
 	return plan, nil
 }
 
+// FreeIntegratorPlan returns the free integrator plan: a zero-priced plan that grants
+// managed-organization capacity. It is the plan assigned to organizations created through
+// the integrator portal so they become integrators on the free tier without a checkout.
+func (ms *MongoStorage) FreeIntegratorPlan() (*Plan, error) {
+	// create a context with a timeout
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	// a free plan (no recurring price) that grants at least one managed org
+	filter := bson.M{
+		"integratorLimits.maxManagedOrgs": bson.M{"$gt": 0},
+		"monthlyPrice":                    int64(0),
+		"yearlyPrice":                     int64(0),
+	}
+	plan := &Plan{}
+	err := ms.plans.FindOne(ctx, filter).Decode(plan)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, ErrNotFound
+		}
+		return nil, errors.New("failed to get free integrator plan")
+	}
+	return plan, nil
+}
+
 // Plans method returns all plans from the database.
 func (ms *MongoStorage) Plans() ([]*Plan, error) {
 	// create a context with a timeout

--- a/db/plans_test.go
+++ b/db/plans_test.go
@@ -61,4 +61,37 @@ func TestPlans(t *testing.T) {
 		_, err = testDB.Plan(id)
 		c.Assert(err, qt.Equals, ErrNotFound)
 	})
+
+	t.Run("FreeIntegratorPlan", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+
+		// nothing seeded yet
+		_, err := testDB.FreeIntegratorPlan()
+		c.Assert(err, qt.Equals, ErrNotFound)
+
+		// a paid integrator plan must not be selected
+		_, err = testDB.SetPlan(&Plan{
+			Name:             "Paid Integrator",
+			MonthlyPrice:     1000,
+			YearlyPrice:      10000,
+			IntegratorLimits: IntegratorLimits{MaxManagedOrgs: 10},
+		})
+		c.Assert(err, qt.IsNil)
+
+		// a free non-integrator plan must not be selected
+		_, err = testDB.SetPlan(&Plan{Name: "Free Basic"})
+		c.Assert(err, qt.IsNil)
+
+		// the free integrator plan: zero-priced and grants managed-org capacity
+		freeID, err := testDB.SetPlan(&Plan{
+			Name:             "Free Integrator",
+			IntegratorLimits: IntegratorLimits{MaxManagedOrgs: 1, MaxManagedProcesses: 5, MaxManagedCensusSize: 100},
+		})
+		c.Assert(err, qt.IsNil)
+
+		plan, err := testDB.FreeIntegratorPlan()
+		c.Assert(err, qt.IsNil)
+		c.Assert(plan.ID, qt.Equals, freeID)
+		c.Assert(plan.IntegratorLimits.MaxManagedOrgs, qt.Equals, 1)
+	})
 }

--- a/db/plans_test.go
+++ b/db/plans_test.go
@@ -63,27 +63,25 @@ func TestPlans(t *testing.T) {
 	})
 
 	t.Run("FreeIntegratorPlan", func(_ *testing.T) {
+		// Note: DeleteAllDocuments intentionally preserves the `plans` collection, and migration
+		// 0012 seeds a free integrator plan, so we don't assume an empty slate here. We seed an
+		// explicit one too and assert the selector returns a zero-priced, managed-org-granting plan
+		// (robust to which matching plan FindOne returns).
 		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
 
-		// nothing seeded yet
-		_, err := testDB.FreeIntegratorPlan()
-		c.Assert(err, qt.Equals, ErrNotFound)
-
-		// a paid integrator plan must not be selected
-		_, err = testDB.SetPlan(&Plan{
+		// non-matching plans must never be selected
+		_, err := testDB.SetPlan(&Plan{
 			Name:             "Paid Integrator",
 			MonthlyPrice:     1000,
 			YearlyPrice:      10000,
 			IntegratorLimits: IntegratorLimits{MaxManagedOrgs: 10},
 		})
 		c.Assert(err, qt.IsNil)
-
-		// a free non-integrator plan must not be selected
 		_, err = testDB.SetPlan(&Plan{Name: "Free Basic"})
 		c.Assert(err, qt.IsNil)
 
-		// the free integrator plan: zero-priced and grants managed-org capacity
-		freeID, err := testDB.SetPlan(&Plan{
+		// a free integrator plan: zero-priced and grants managed-org capacity
+		_, err = testDB.SetPlan(&Plan{
 			Name:             "Free Integrator",
 			IntegratorLimits: IntegratorLimits{MaxManagedOrgs: 1, MaxManagedProcesses: 5, MaxManagedCensusSize: 100},
 		})
@@ -91,7 +89,8 @@ func TestPlans(t *testing.T) {
 
 		plan, err := testDB.FreeIntegratorPlan()
 		c.Assert(err, qt.IsNil)
-		c.Assert(plan.ID, qt.Equals, freeID)
-		c.Assert(plan.IntegratorLimits.MaxManagedOrgs, qt.Equals, 1)
+		c.Assert(plan.MonthlyPrice, qt.Equals, int64(0))
+		c.Assert(plan.YearlyPrice, qt.Equals, int64(0))
+		c.Assert(plan.IntegratorLimits.MaxManagedOrgs > 0, qt.IsTrue)
 	})
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -162,6 +162,13 @@ definitions:
       createdAt:
         description: Creation timestamp in RFC3339 format
         type: string
+      integrator:
+        description: |-
+          Whether to subscribe the new organization to the free integrator plan at
+          creation time (opt-in). Used by the integrator portal so a newly created org
+          becomes an integrator on the free tier with no checkout. Default false uses
+          the regular default plan.
+        type: boolean
       meta:
         additionalProperties: {}
         description: Arbitrary key value fields with metadata regarding the organization
@@ -650,6 +657,13 @@ definitions:
       createdAt:
         description: Creation timestamp in RFC3339 format
         type: string
+      integrator:
+        description: |-
+          Whether to subscribe the new organization to the free integrator plan at
+          creation time (opt-in). Used by the integrator portal so a newly created org
+          becomes an integrator on the free tier with no checkout. Default false uses
+          the regular default plan.
+        type: boolean
       meta:
         additionalProperties: {}
         description: Arbitrary key value fields with metadata regarding the organization
@@ -1013,6 +1027,18 @@ definitions:
         description: Whether white labeling is available
         type: boolean
     type: object
+  apicommon.SubscriptionIntegratorLimits:
+    properties:
+      maxManagedCensusSize:
+        description: Maximum total census size across managed organizations
+        type: integer
+      maxManagedOrgs:
+        description: Maximum number of organizations the integrator may manage
+        type: integer
+      maxManagedProcesses:
+        description: Maximum number of voting processes across managed organizations
+        type: integer
+    type: object
   apicommon.SubscriptionPlan:
     properties:
       default:
@@ -1025,6 +1051,11 @@ definitions:
       id:
         description: Unique identifier for the plan
         type: integer
+      integratorLimits:
+        allOf:
+        - $ref: '#/definitions/apicommon.SubscriptionIntegratorLimits'
+        description: Integrator limits for this plan (zero when the plan is not an
+          integrator plan)
       monthlyPrice:
         description: Monthly price
         type: integer

--- a/migrations/0012_seed_free_integrator_plan.go
+++ b/migrations/0012_seed_free_integrator_plan.go
@@ -1,0 +1,69 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func init() {
+	AddMigration(12, "seed_free_integrator_plan", upSeedFreeIntegratorPlan, downSeedFreeIntegratorPlan)
+}
+
+// freeIntegratorPlanID is a fixed, high sentinel id so it never collides with the
+// (small, config-index based) ids that the Stripe plan sync assigns. nextPlanID is
+// max(_id)+1, so Stripe-synced plans keep using their explicit small ids via the update
+// path; only future auto-assigned ids would start past this sentinel.
+const freeIntegratorPlanID uint64 = 9001
+
+// freeIntegratorPlanDoc mirrors the bson shape of the relevant db.Plan fields. It is kept
+// local to the migration (rather than importing db) so historical migrations stay pinned to
+// the schema as it was when written.
+type freeIntegratorPlanLimits struct {
+	MaxManagedOrgs       int `bson:"maxManagedOrgs"`
+	MaxManagedProcesses  int `bson:"maxManagedProcesses"`
+	MaxManagedCensusSize int `bson:"maxManagedCensusSize"`
+}
+
+type freeIntegratorPlanDoc struct {
+	Name             string                   `bson:"name"`
+	Default          bool                     `bson:"default"`
+	MonthlyPrice     int64                    `bson:"monthlyPrice"`
+	YearlyPrice      int64                    `bson:"yearlyPrice"`
+	IntegratorLimits freeIntegratorPlanLimits `bson:"integratorLimits"`
+}
+
+// upSeedFreeIntegratorPlan seeds the free integrator plan: a zero-priced plan that grants a
+// small amount of managed-organization capacity. Organizations created through the integrator
+// portal subscribe to it, becoming integrators on the free tier with no checkout.
+//
+// $setOnInsert is used so the seed runs once and never clobbers limits an operator may later
+// tune directly in the database.
+func upSeedFreeIntegratorPlan(ctx context.Context, database *mongo.Database) error {
+	doc := freeIntegratorPlanDoc{
+		Name:         "Free Integrator",
+		Default:      false,
+		MonthlyPrice: 0,
+		YearlyPrice:  0,
+		IntegratorLimits: freeIntegratorPlanLimits{
+			MaxManagedOrgs:       1,
+			MaxManagedProcesses:  5,
+			MaxManagedCensusSize: 100,
+		},
+	}
+	filter := bson.M{"_id": freeIntegratorPlanID}
+	update := bson.M{"$setOnInsert": doc}
+	opts := options.Update().SetUpsert(true)
+	if _, err := database.Collection("plans").UpdateOne(ctx, filter, update, opts); err != nil {
+		return fmt.Errorf("failed to seed free integrator plan: %w", err)
+	}
+	return nil
+}
+
+func downSeedFreeIntegratorPlan(ctx context.Context, database *mongo.Database) error {
+	_, err := database.Collection("plans").DeleteOne(ctx, bson.M{"_id": freeIntegratorPlanID})
+	return err
+}

--- a/stripe/service.go
+++ b/stripe/service.go
@@ -145,15 +145,26 @@ func processProductToPlan(planID uint64, product *stripeapi.Product, prices []st
 		return nil, err
 	}
 
+	// integratorLimits is optional: only integrator plans carry it. Skip parsing when the
+	// product has no such metadata so non-integrator plans don't fail to sync.
+	var integratorLimitsData db.IntegratorLimits
+	if raw := product.Metadata["integratorLimits"]; raw != "" {
+		integratorLimitsData, err = extractPlanMetadata[db.IntegratorLimits](raw)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	plan := &db.Plan{
-		ID:            planID,
-		Name:          product.Name,
-		StripeID:      product.ID,
-		Default:       isDefaultPlan(product),
-		Organization:  organizationData,
-		VotingTypes:   votingTypesData,
-		Features:      featuresData,
-		FreeTrialDays: 0,
+		ID:               planID,
+		Name:             product.Name,
+		StripeID:         product.ID,
+		Default:          isDefaultPlan(product),
+		Organization:     organizationData,
+		VotingTypes:      votingTypesData,
+		Features:         featuresData,
+		IntegratorLimits: integratorLimitsData,
+		FreeTrialDays:    0,
 	}
 
 	for _, price := range prices {

--- a/stripe/service_test.go
+++ b/stripe/service_test.go
@@ -1,0 +1,73 @@
+package stripe
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	stripeapi "github.com/stripe/stripe-go/v82"
+)
+
+func testPrices() []stripeapi.Price {
+	return []stripeapi.Price{
+		{ID: "price_m", UnitAmount: 1000, Recurring: &stripeapi.PriceRecurring{Interval: stripeapi.PriceRecurringIntervalMonth}},
+		{ID: "price_y", UnitAmount: 10000, Recurring: &stripeapi.PriceRecurring{Interval: stripeapi.PriceRecurringIntervalYear}},
+	}
+}
+
+func TestProcessProductToPlanIntegratorLimits(t *testing.T) {
+	c := qt.New(t)
+
+	baseMetadata := func() map[string]string {
+		return map[string]string{
+			"organization": `{}`,
+			"votingTypes":  `{}`,
+			"features":     `{}`,
+		}
+	}
+
+	t.Run("parses integrator limits when present", func(_ *testing.T) {
+		md := baseMetadata()
+		md["integratorLimits"] = `{"maxManagedOrgs":3,"maxManagedProcesses":30,"maxManagedCensusSize":300}`
+		product := &stripeapi.Product{
+			ID:           "prod_integrator",
+			Name:         "Integrator",
+			Metadata:     md,
+			DefaultPrice: &stripeapi.Price{Metadata: map[string]string{"Default": "false"}},
+		}
+
+		plan, err := processProductToPlan(1, product, testPrices())
+		c.Assert(err, qt.IsNil)
+		c.Assert(plan.IntegratorLimits.MaxManagedOrgs, qt.Equals, 3)
+		c.Assert(plan.IntegratorLimits.MaxManagedProcesses, qt.Equals, 30)
+		c.Assert(plan.IntegratorLimits.MaxManagedCensusSize, qt.Equals, 300)
+	})
+
+	t.Run("leaves zero limits when metadata is absent", func(_ *testing.T) {
+		product := &stripeapi.Product{
+			ID:           "prod_regular",
+			Name:         "Regular",
+			Metadata:     baseMetadata(),
+			DefaultPrice: &stripeapi.Price{Metadata: map[string]string{"Default": "false"}},
+		}
+
+		plan, err := processProductToPlan(2, product, testPrices())
+		c.Assert(err, qt.IsNil)
+		c.Assert(plan.IntegratorLimits.MaxManagedOrgs, qt.Equals, 0)
+		c.Assert(plan.IntegratorLimits.MaxManagedProcesses, qt.Equals, 0)
+		c.Assert(plan.IntegratorLimits.MaxManagedCensusSize, qt.Equals, 0)
+	})
+
+	t.Run("errors on malformed integrator limits", func(_ *testing.T) {
+		md := baseMetadata()
+		md["integratorLimits"] = `{not json}`
+		product := &stripeapi.Product{
+			ID:           "prod_bad",
+			Name:         "Bad",
+			Metadata:     md,
+			DefaultPrice: &stripeapi.Price{Metadata: map[string]string{"Default": "false"}},
+		}
+
+		_, err := processProductToPlan(3, product, testPrices())
+		c.Assert(err, qt.IsNotNil)
+	})
+}


### PR DESCRIPTION
## What

Two related changes for self-serve integrators (combined into one PR for a single review). Builds on #531 (plan-derived integrator status, merged).

### 1. Free integrator tier on org creation
- Seed a zero-priced **"Free Integrator"** plan (migration `0012`): `MaxManagedOrgs: 1`, `MaxManagedProcesses: 5`, `MaxManagedCensusSize: 100`. `$setOnInsert` so it seeds once and stays tunable.
- **`db.FreeIntegratorPlan()`** resolves it (free plan granting managed-org capacity).
- **`POST /organizations` accepts `integrator: true`** → subscribes the new org to the free plan (active) instead of the default. The creator becomes admin and the org is an integrator immediately — **no checkout**.

### 2. Stripe integrator-plan support (paid tiers)
- **`processProductToPlan`** reads an optional `integratorLimits` Stripe **product-metadata** JSON into `Plan.IntegratorLimits` (optional — non-integrator products sync unchanged).
- **`GET /plans`** exposes `integratorLimits` via a new `SubscriptionIntegratorLimits` mirror, so clients can identify integrator plans for checkout.

Together: free tier needs no Stripe; paid upgrade = subscribe to a Stripe plan whose `integratorLimits.maxManagedOrgs > 0` via the existing embedded checkout, and (with #531) the org becomes an integrator with the plan's limits.

## Stripe product config (for the agent creating the products)
Add a **product metadata** key `integratorLimits` (same convention as `organization`/`votingTypes`/`features`):
```json
{"maxManagedOrgs": 25, "maxManagedProcesses": 250, "maxManagedCensusSize": 5000}
```
Products still need both a monthly and a yearly recurring price. The **free tier is not a Stripe product** — it's the seeded plan above.

## Design notes for review (@p4u)
1. **Free-tier quota** `1 / 5 / 100` — tune as you like (migration + in-DB).
2. **Seeded plan id** `9001` (sentinel; won't collide with Stripe's small config-index ids since `nextPlanID` is `max(_id)+1`).
3. **`FreeIntegratorPlan` selector** identifies by "free + grants managed orgs" rather than a hardcoded id.

## Verification
- `go build ./...`, `go vet`, `go test ./stripe/... ./subscriptions/...` ✅
- `db`/`api`/`migrations` test packages compile; `TestPlans/FreeIntegratorPlan` + stripe metadata-parsing tests added.

## Frontend
Pairs with `vocdoni/vocdoni-integrator-app`: org creation sends `integrator: true` (free tier, live); the embedded-checkout upgrade UI will use `GET /plans` + `POST /subscriptions/checkout` once the Stripe products + publishable key exist.

(Supersedes #533, folded in here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)