### PR TITLE
feat(plans): sync integrator limits from Stripe metadata + expose in /plans

### DIFF
--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -554,6 +554,9 @@ type SubscriptionPlan struct {
 
 	// Features available in this plan
 	Features SubscriptionFeatures `json:"features"`
+
+	// Integrator limits for this plan (zero when the plan is not an integrator plan)
+	IntegratorLimits SubscriptionIntegratorLimits `json:"integratorLimits"`
 }
 
 // SubscriptionPlanFromDB converts a db.Plan to a SubscriptionPlan.
@@ -573,6 +576,7 @@ func SubscriptionPlanFromDB(plan *db.Plan) SubscriptionPlan {
 		Organization:         SubscriptionPlanLimits(plan.Organization),
 		VotingTypes:          SubscriptionVotingTypes(plan.VotingTypes),
 		Features:             SubscriptionFeatures(plan.Features),
+		IntegratorLimits:     SubscriptionIntegratorLimits(plan.IntegratorLimits),
 	}
 }
 
@@ -603,6 +607,21 @@ type SubscriptionPlanLimits struct {
 
 	// Whether this is a custom plan
 	CustomPlan bool `json:"customPlan"`
+}
+
+// SubscriptionIntegratorLimits represents the integrator limits of a subscription plan.
+// It is the mirror struct of db.IntegratorLimits. All-zero means the plan is not an
+// integrator plan.
+// swagger:model SubscriptionIntegratorLimits
+type SubscriptionIntegratorLimits struct {
+	// Maximum number of organizations the integrator may manage
+	MaxManagedOrgs int `json:"maxManagedOrgs"`
+
+	// Maximum number of voting processes across managed organizations
+	MaxManagedProcesses int `json:"maxManagedProcesses"`
+
+	// Maximum total census size across managed organizations
+	MaxManagedCensusSize int `json:"maxManagedCensusSize"`
 }
 
 // SubscriptionVotingTypes represents the voting types available in a subscription plan.

--- a/stripe/service.go
+++ b/stripe/service.go
@@ -145,15 +145,26 @@ func processProductToPlan(planID uint64, product *stripeapi.Product, prices []st
 		return nil, err
 	}
 
+	// integratorLimits is optional: only integrator plans carry it. Skip parsing when the
+	// product has no such metadata so non-integrator plans don't fail to sync.
+	var integratorLimitsData db.IntegratorLimits
+	if raw := product.Metadata["integratorLimits"]; raw != "" {
+		integratorLimitsData, err = extractPlanMetadata[db.IntegratorLimits](raw)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	plan := &db.Plan{
-		ID:            planID,
-		Name:          product.Name,
-		StripeID:      product.ID,
-		Default:       isDefaultPlan(product),
-		Organization:  organizationData,
-		VotingTypes:   votingTypesData,
-		Features:      featuresData,
-		FreeTrialDays: 0,
+		ID:               planID,
+		Name:             product.Name,
+		StripeID:         product.ID,
+		Default:          isDefaultPlan(product),
+		Organization:     organizationData,
+		VotingTypes:      votingTypesData,
+		Features:         featuresData,
+		IntegratorLimits: integratorLimitsData,
+		FreeTrialDays:    0,
 	}
 
 	for _, price := range prices {

--- a/stripe/service_test.go
+++ b/stripe/service_test.go
@@ -1,0 +1,73 @@
+package stripe
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	stripeapi "github.com/stripe/stripe-go/v82"
+)
+
+func testPrices() []stripeapi.Price {
+	return []stripeapi.Price{
+		{ID: "price_m", UnitAmount: 1000, Recurring: &stripeapi.PriceRecurring{Interval: stripeapi.PriceRecurringIntervalMonth}},
+		{ID: "price_y", UnitAmount: 10000, Recurring: &stripeapi.PriceRecurring{Interval: stripeapi.PriceRecurringIntervalYear}},
+	}
+}
+
+func TestProcessProductToPlanIntegratorLimits(t *testing.T) {
+	c := qt.New(t)
+
+	baseMetadata := func() map[string]string {
+		return map[string]string{
+			"organization": `{}`,
+			"votingTypes":  `{}`,
+			"features":     `{}`,
+		}
+	}
+
+	t.Run("parses integrator limits when present", func(_ *testing.T) {
+		md := baseMetadata()
+		md["integratorLimits"] = `{"maxManagedOrgs":3,"maxManagedProcesses":30,"maxManagedCensusSize":300}`
+		product := &stripeapi.Product{
+			ID:           "prod_integrator",
+			Name:         "Integrator",
+			Metadata:     md,
+			DefaultPrice: &stripeapi.Price{Metadata: map[string]string{"Default": "false"}},
+		}
+
+		plan, err := processProductToPlan(1, product, testPrices())
+		c.Assert(err, qt.IsNil)
+		c.Assert(plan.IntegratorLimits.MaxManagedOrgs, qt.Equals, 3)
+		c.Assert(plan.IntegratorLimits.MaxManagedProcesses, qt.Equals, 30)
+		c.Assert(plan.IntegratorLimits.MaxManagedCensusSize, qt.Equals, 300)
+	})
+
+	t.Run("leaves zero limits when metadata is absent", func(_ *testing.T) {
+		product := &stripeapi.Product{
+			ID:           "prod_regular",
+			Name:         "Regular",
+			Metadata:     baseMetadata(),
+			DefaultPrice: &stripeapi.Price{Metadata: map[string]string{"Default": "false"}},
+		}
+
+		plan, err := processProductToPlan(2, product, testPrices())
+		c.Assert(err, qt.IsNil)
+		c.Assert(plan.IntegratorLimits.MaxManagedOrgs, qt.Equals, 0)
+		c.Assert(plan.IntegratorLimits.MaxManagedProcesses, qt.Equals, 0)
+		c.Assert(plan.IntegratorLimits.MaxManagedCensusSize, qt.Equals, 0)
+	})
+
+	t.Run("errors on malformed integrator limits", func(_ *testing.T) {
+		md := baseMetadata()
+		md["integratorLimits"] = `{not json}`
+		product := &stripeapi.Product{
+			ID:           "prod_bad",
+			Name:         "Bad",
+			Metadata:     md,
+			DefaultPrice: &stripeapi.Price{Metadata: map[string]string{"Default": "false"}},
+		}
+
+		_, err := processProductToPlan(3, product, testPrices())
+		c.Assert(err, qt.IsNotNil)
+	})
+}


### PR DESCRIPTION
## What

Makes **paid integrator plans** possible by wiring integrator limits through the Stripe plan sync and the plans API. Companion to #531 (plan-derived integrator status, merged) and #532 (free integrator tier).

## Changes

- **`processProductToPlan`** now reads an optional `integratorLimits` Stripe **product-metadata** JSON into `Plan.IntegratorLimits`. It's optional: products without it sync unchanged (zero limits), so non-integrator plans are unaffected.
- **`GET /plans`** exposes `integratorLimits` via a new `SubscriptionIntegratorLimits` mirror, so the frontend can identify integrator plans and offer them for checkout.
- Added `stripe` package unit tests for the metadata parsing (present / absent / malformed).

With #531, subscribing to a plan whose `integratorLimits.maxManagedOrgs > 0` (via the existing Stripe embedded checkout) makes the org an integrator with that plan's limits.

## Stripe product config (for the agent creating the products)

Add a **product metadata** key `integratorLimits` whose value is JSON:

```json
{"maxManagedOrgs": 25, "maxManagedProcesses": 250, "maxManagedCensusSize": 5000}
```

(Same convention as the existing `organization` / `votingTypes` / `features` metadata keys. Products still need both a monthly and a yearly recurring price, per the existing sync rules. The free tier does **not** go through Stripe — it's the seeded plan in #532.)

## Verification

- `go build ./...`, `go vet`, `go test ./stripe/... ./subscriptions/...` ✅
- All test packages compile.

## Note

Touches `api/apicommon/types.go` in a different region than #532; if #532 merges first a trivial rebase may be needed (or vice-versa).

## Frontend follow-up

With this, the portal can fetch `GET /plans`, filter to `integratorLimits.maxManagedOrgs > 0`, and run the Stripe embedded checkout to upgrade. I'll wire that UI once the products + publishable key exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)