### PR TITLE
fix(testutil): delete only matched email in FindEmail to fix flaky integration tests

### DIFF
--- a/csp/testutil/smtp.go
+++ b/csp/testutil/smtp.go
@@ -26,8 +26,8 @@ var _ notifications.NotificationService = &SMTP{}
 
 const (
 	//revive:disable:unsecure-url-scheme
-	searchInboxEndpoint = "http://%s:%d/api/v2/search?kind=to&query=%s"
-	clearInboxEndpoint  = "http://%s:%d/api/v1/messages"
+	searchInboxEndpoint   = "http://%s:%d/api/v2/search?kind=to&query=%s"
+	deleteMessageEndpoint = "http://%s:%d/api/v1/messages/%s"
 )
 
 // New initializes the SMTP email service with the configuration. It sets the
@@ -45,10 +45,19 @@ func (sm *SMTP) New(rawConfig any) error {
 
 // FindEmail searches for an email in the test API service. It sends a GET
 // request to the search endpoint with the recipient's email address as a query
-// parameter. If the email is found, it returns the email body and clears the
-// inbox. If the email is not found, it returns an EOF error. If the request
-// fails, it returns an error with the status code. This method is used for
-// testing the email service.
+// parameter. If a message is found, it returns the body of the first match and
+// deletes ONLY that message from the inbox. If no message is found, it returns
+// an EOF error. If the request fails, it returns an error with the status code.
+// This method is used for testing the email service.
+//
+// Only the matched message is deleted (by its ID), never the whole inbox. The
+// tests share a single MailHog inbox across many concurrent senders (notably the
+// CSP notification queue's worker pool, which delivers OTP emails in the
+// background). Wiping the entire inbox here would race against those concurrent
+// deliveries: clearing all messages on behalf of one recipient could delete
+// another recipient's in-flight email before the test waiting on it ever
+// retrieves it, making that wait time out with EOF. Deleting only the matched
+// message keeps each recipient's lookups independent.
 func (sm *SMTP) FindEmail(ctx context.Context, to string) (string, error) {
 	searchEndpoint := fmt.Sprintf(searchInboxEndpoint, sm.config.SMTPServer, sm.config.TestAPIPort, to)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, searchEndpoint, nil)
@@ -69,6 +78,7 @@ func (sm *SMTP) FindEmail(ctx context.Context, to string) (string, error) {
 	//revive:disable:nested-structs
 	type mailResponse struct {
 		Items []struct {
+			ID      string `json:"ID"`
 			Content struct {
 				Body string `json:"Body"`
 			} `json:"Content"`
@@ -81,12 +91,19 @@ func (sm *SMTP) FindEmail(ctx context.Context, to string) (string, error) {
 	if len(mailResults.Items) == 0 {
 		return "", io.EOF
 	}
-	return mailResults.Items[0].Content.Body, sm.clearInbox()
+	match := mailResults.Items[0]
+	return match.Content.Body, sm.deleteMessage(ctx, match.ID)
 }
 
-func (sm *SMTP) clearInbox() error {
-	clearEndpoint := fmt.Sprintf(clearInboxEndpoint, sm.config.SMTPServer, sm.config.TestAPIPort)
-	req, err := http.NewRequest(http.MethodDelete, clearEndpoint, nil)
+// deleteMessage removes a single message from the test inbox by its ID. A blank
+// id is a no-op so a successful match with an unexpected (empty) ID does not
+// fail the caller.
+func (sm *SMTP) deleteMessage(ctx context.Context, id string) error {
+	if id == "" {
+		return nil
+	}
+	deleteEndpoint := fmt.Sprintf(deleteMessageEndpoint, sm.config.SMTPServer, sm.config.TestAPIPort, id)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, deleteEndpoint, nil)
 	if err != nil {
 		return fmt.Errorf("could not create request: %v", err)
 	}


### PR DESCRIPTION
## Root cause

Multiple API integration tests intermittently failed with the same symptom: an email never arrived at the test mail service, so `waitForEmail` returned `io.EOF` after 10 attempts (`failed to receive email after N attempts`). Seen on `TestRelayVote` and `TestOrganizationWithOptionalFields`, but it can hit any test that calls `waitForEmail`.

The culprit is the shared test mail inbox combined with a **global inbox wipe** in the test helper:

- `csp/testutil/smtp.go` `FindEmail` cleared the **entire** MailHog inbox on every successful match via `DELETE /api/v1/messages` (the old `clearInbox`).
- The `api` test binary creates `testCSP` in `TestMain`, and `csp.New` → `queue.Start()` launches **16 concurrent worker goroutines** (`csp/notifications/queue.go`, `DefaultQueueWorkers = 16`) that deliver CSP OTP emails into the **same single MailHog inbox** in the background, throughout the whole run.
- So when any test matched its own email and wiped the inbox, it could delete **another recipient's freshly delivered email** before the test waiting on it ever retrieved it. That waiter then polled `FindEmail` 10× → `io.EOF` → failure.

The `notification enqueued ... queue.go:133` line seen right before the failure is from one of those background CSP workers (interleaved log noise), not the failing path itself — the failing email is the synchronous user-verification mail sent directly via `a.mail.SendNotification`.

Why it started flaking recently: the global wipe has existed for a long time, but the race window was small while sends were effectively serial. Commit `988b981` ("feat(csp): drain notification queue with a concurrent worker pool") moved delivery to a 16-worker pool with circuit-breaker retries, sharply increasing concurrent background deliveries and widening the window.

## The fix

`FindEmail` now deletes **only the matched message by its ID** (`DELETE /api/v1/messages/{id}`) instead of wiping the whole inbox. Each recipient's lookups are now independent and can never clobber another test's in-flight mail. The MailHog v2 search response already exposes the per-message `ID` field; we just parse and use it.

Single-file change: `csp/testutil/smtp.go` (+27 / -10).

## Verification (run locally with Docker/testcontainers)

- Reproduced the flake first: under a load run of the email-heavy subset, `waitForEmail` failed with the EOF symptom on the unfixed helper.
- With the fix:
  - `go build ./...` and `go vet ./...` pass.
  - Full `go test ./api/ -count=1` passes (285s).
  - Full `go test ./csp/...` passes (all sub-packages).
  - Previously-flaky `TestOrganizationWithOptionalFields` and the email-heavy `TestLanguageParameter*` pass.
- One full-suite run failed during `TestMain` with `failed to start voconed container: ... container exited with code 1` — an unrelated testcontainer/infra flake, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)