### PR TITLE
feat(apikeys): scoped API keys for organizations

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -319,6 +319,9 @@ func (a *API) initRouter() http.Handler {
 		handle(r, http.MethodPost, managedOrganizationsEndpoint, a.createManagedOrganizationHandler)
 		handle(r, http.MethodGet, managedOrganizationsEndpoint, a.managedOrganizationsHandler)
 		handle(r, http.MethodGet, integratorEndpoint, a.integratorInfoHandler)
+		handle(r, http.MethodPost, organizationAPIKeysEndpoint, a.createAPIKeyHandler)
+		handle(r, http.MethodGet, organizationAPIKeysEndpoint, a.apiKeysHandler)
+		handle(r, http.MethodDelete, organizationAPIKeyEndpoint, a.revokeAPIKeyHandler)
 		handle(r, http.MethodPost, subscriptionsCheckout, a.stripeHandlers.CreateSubscriptionCheckout)
 		handle(r, http.MethodGet, subscriptionsCheckoutSession, a.stripeHandlers.GetCheckoutSession)
 		handle(r, http.MethodGet, subscriptionsPortal, func(w http.ResponseWriter, r *http.Request) {

--- a/api/apicommon/apikeys.go
+++ b/api/apicommon/apikeys.go
@@ -1,0 +1,61 @@
+package apicommon
+
+import (
+	"time"
+
+	"github.com/vocdoni/saas-backend/db"
+)
+
+// CreateAPIKeyRequest is the body of POST /organizations/{address}/apikeys.
+type CreateAPIKeyRequest struct {
+	// Human-readable label to identify the key.
+	Label string `json:"label"`
+	// Scopes the key is allowed to use (must be a subset of the assignable scopes).
+	Scopes []string `json:"scopes"`
+	// Optional expiration; when set, the key stops working after this time.
+	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
+}
+
+// APIKeyInfo is the public (no-secret) representation of an API key.
+type APIKeyInfo struct {
+	ID         string     `json:"id"`
+	Label      string     `json:"label"`
+	Prefix     string     `json:"prefix"`
+	Scopes     []string   `json:"scopes"`
+	CreatedBy  string     `json:"createdBy"`
+	CreatedAt  time.Time  `json:"createdAt"`
+	LastUsedAt *time.Time `json:"lastUsedAt,omitempty"`
+	ExpiresAt  *time.Time `json:"expiresAt,omitempty"`
+	Revoked    bool       `json:"revoked"`
+}
+
+// CreateAPIKeyResponse is returned once at creation and includes the plaintext secret, which is
+// never retrievable again.
+type CreateAPIKeyResponse struct {
+	APIKeyInfo
+	// Secret is the full API key, shown only at creation time.
+	Secret string `json:"secret"`
+}
+
+// ListAPIKeysResponse is the list of an organization's API keys.
+type ListAPIKeysResponse struct {
+	APIKeys []APIKeyInfo `json:"apiKeys"`
+}
+
+// APIKeyInfoFromDB converts a db.APIKey to its public representation.
+func APIKeyInfoFromDB(k *db.APIKey) APIKeyInfo {
+	if k == nil {
+		return APIKeyInfo{}
+	}
+	return APIKeyInfo{
+		ID:         k.ID,
+		Label:      k.Label,
+		Prefix:     k.Prefix,
+		Scopes:     k.Scopes,
+		CreatedBy:  k.CreatedBy,
+		CreatedAt:  k.CreatedAt,
+		LastUsedAt: k.LastUsedAt,
+		ExpiresAt:  k.ExpiresAt,
+		Revoked:    k.Revoked,
+	}
+}

--- a/api/apicommon/const.go
+++ b/api/apicommon/const.go
@@ -12,6 +12,10 @@ type MetadataKey string
 // UserMetadataKey is the key used to store the user in the context.
 const UserMetadataKey MetadataKey = "user"
 
+// APIKeyMetadataKey is the key used to store the authenticating API key (when a request is
+// authenticated via an API key rather than a JWT) in the context.
+const APIKeyMetadataKey MetadataKey = "apikey"
+
 // LangMetadataKey is the key used to store the language in the context.
 const LangMetadataKey MetadataKey = "lang"
 

--- a/api/apikeys.go
+++ b/api/apikeys.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// APIKeyPrefix is the public, non-secret prefix every API key secret starts with. It lets the
+// authenticator route a credential to the API-key path (vs. JWT) and helps users recognize a key.
+const APIKeyPrefix = "vsk_"
+
+// apiKeyDisplayPrefixLen is how many characters of the secret are kept (in clear) for display.
+const apiKeyDisplayPrefixLen = 12
+
+// API key scopes. Keys are deny-by-default: a scope only grants the endpoints mapped to it in
+// apiKeyAllowlist, and any endpoint not in that allowlist rejects API-key auth entirely.
+const (
+	ScopeQuotaRead    = "quota:read"    // read integrator quota & usage
+	ScopeManagedRead  = "managed:read"  // list managed organizations
+	ScopeManagedWrite = "managed:write" // create managed organizations
+	ScopeVotingWrite  = "voting:write"  // create/publish processes, censuses and bundles
+	ScopeMembersWrite = "members:write" // manage members and groups
+)
+
+// AllAPIKeyScopes is the canonical set of assignable scopes, used to validate key creation.
+var AllAPIKeyScopes = []string{
+	ScopeQuotaRead,
+	ScopeManagedRead,
+	ScopeManagedWrite,
+	ScopeVotingWrite,
+	ScopeMembersWrite,
+}
+
+// IsValidAPIKeyScope reports whether s is a known, assignable scope.
+func IsValidAPIKeyScope(s string) bool {
+	for _, sc := range AllAPIKeyScopes {
+		if sc == s {
+			return true
+		}
+	}
+	return false
+}
+
+// apiKeyAllowlist maps "<METHOD> <chi route pattern>" to the scope required to call it with an
+// API key. Endpoints absent from this map cannot be called with an API key at all (deny by
+// default), which keeps account-sensitive endpoints (auth, password, OAuth, team/invites,
+// tickets, checkout, etc.) JWT-only. The patterns must match the constants used at registration
+// so they equal chi's RoutePattern().
+var apiKeyAllowlist = map[string]string{
+	// integrator
+	"GET " + integratorEndpoint:            ScopeQuotaRead,
+	"GET " + managedOrganizationsEndpoint:  ScopeManagedRead,
+	"POST " + managedOrganizationsEndpoint: ScopeManagedWrite,
+
+	// members & groups (of managed organizations)
+	"GET " + organizationMembersEndpoint:             ScopeMembersWrite,
+	"POST " + organizationAddMembersEndpoint:         ScopeMembersWrite,
+	"PUT " + organizationUpsertMemberEndpoint:        ScopeMembersWrite,
+	"DELETE " + organizationDeleteMembersEndpoint:    ScopeMembersWrite,
+	"GET " + organizationAddMembersJobStatusEndpoint: ScopeMembersWrite,
+	"POST " + organizationGroupsEndpoint:             ScopeMembersWrite,
+	"GET " + organizationGroupsEndpoint:              ScopeMembersWrite,
+	"GET " + organizationGroupEndpoint:               ScopeMembersWrite,
+	"PUT " + organizationGroupEndpoint:               ScopeMembersWrite,
+	"DELETE " + organizationGroupEndpoint:            ScopeMembersWrite,
+	"GET " + organizationGroupMembersEndpoint:        ScopeMembersWrite,
+	"POST " + organizationGroupValidateEndpoint:      ScopeMembersWrite,
+
+	// voting: processes, censuses, bundles (for managed organizations)
+	"POST " + processCreateEndpoint:                ScopeVotingWrite,
+	"POST " + processPublishEndpoint:               ScopeVotingWrite,
+	"POST " + processStatusEndpoint:                ScopeVotingWrite,
+	"GET " + organizationListProcessDraftsEndpoint: ScopeVotingWrite,
+	"GET " + organizationCensusesEndpoint:          ScopeVotingWrite,
+	"GET " + organizationBundlesEndpoint:           ScopeVotingWrite,
+	"POST " + censusEndpoint:                       ScopeVotingWrite,
+	"POST " + censusPublishEndpoint:                ScopeVotingWrite,
+	"POST " + censusGroupPublishEndpoint:           ScopeVotingWrite,
+	"POST " + censusParticipantsEndpoint:           ScopeVotingWrite,
+	"POST " + processBundleEndpoint:                ScopeVotingWrite,
+	"PUT " + processBundleUpdateEndpoint:           ScopeVotingWrite,
+}
+
+// requiredScopeForRoute returns the scope required to call (method, pattern) with an API key and
+// whether the endpoint allows API-key auth at all.
+func requiredScopeForRoute(method, pattern string) (string, bool) {
+	scope, ok := apiKeyAllowlist[method+" "+pattern]
+	return scope, ok
+}
+
+// looksLikeAPIKey reports whether the given bearer credential is an API key (vs. a JWT).
+func looksLikeAPIKey(token string) bool {
+	return strings.HasPrefix(token, APIKeyPrefix)
+}
+
+// hashAPIKey returns the hex-encoded SHA-256 of an API key secret. The hash (never the secret) is
+// what gets stored and looked up.
+func hashAPIKey(secret string) string {
+	sum := sha256.Sum256([]byte(secret))
+	return hex.EncodeToString(sum[:])
+}
+
+// generatedAPIKey holds the parts of a freshly generated key: the plaintext secret (shown once),
+// its display prefix, and the hash to store.
+type generatedAPIKey struct {
+	secret string
+	prefix string
+	hash   string
+}
+
+// generateAPIKey creates a new random API key.
+func generateAPIKey() (generatedAPIKey, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return generatedAPIKey{}, err
+	}
+	secret := APIKeyPrefix + hex.EncodeToString(buf)
+	return generatedAPIKey{
+		secret: secret,
+		prefix: secret[:apiKeyDisplayPrefixLen],
+		hash:   hashAPIKey(secret),
+	}, nil
+}

--- a/api/apikeys_api_test.go
+++ b/api/apikeys_api_test.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/api/apicommon"
+	"github.com/vocdoni/saas-backend/db"
+)
+
+// TestAPIKeysAPI exercises the API-key lifecycle and the auth/scope/allowlist enforcement:
+// an admin creates a scoped key, the key can call allowlisted endpoints within its scopes,
+// is rejected for missing scopes and for non-allowlisted endpoints, and stops working once revoked.
+func TestAPIKeysAPI(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "apikeypass123")
+	orgAddr := testCreateOrganization(t, token)
+
+	// make the org an integrator (override) so the integrator endpoints are usable
+	org, err := testDB.Organization(orgAddr)
+	c.Assert(err, qt.IsNil)
+	org.IntegratorLimits = &db.IntegratorLimits{MaxManagedOrgs: 2, MaxManagedProcesses: 5, MaxManagedCensusSize: 100}
+	c.Assert(testDB.SetOrganization(org), qt.IsNil)
+
+	// create a key scoped to quota:read + managed:read
+	createBody := &apicommon.CreateAPIKeyRequest{Label: "ci", Scopes: []string{ScopeQuotaRead, ScopeManagedRead}}
+	data, code := testRequest(t, http.MethodPost, token, createBody, "organizations", orgAddr.String(), "apikeys")
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("resp: %s", data))
+	var created apicommon.CreateAPIKeyResponse
+	c.Assert(json.Unmarshal(data, &created), qt.IsNil)
+	c.Assert(strings.HasPrefix(created.Secret, APIKeyPrefix), qt.IsTrue)
+	c.Assert(created.ID, qt.Not(qt.Equals), "")
+	apiKey := created.Secret // testRequest puts this in the Bearer header
+
+	// invalid scope is rejected at creation
+	_, code = testRequest(t, http.MethodPost, token,
+		&apicommon.CreateAPIKeyRequest{Label: "bad", Scopes: []string{"bogus:scope"}},
+		"organizations", orgAddr.String(), "apikeys")
+	c.Assert(code, qt.Equals, http.StatusBadRequest)
+
+	// the key works on allowlisted endpoints within its scopes
+	_, code = testRequest(t, http.MethodGet, apiKey, nil, "organizations", orgAddr.String(), "integrator")
+	c.Assert(code, qt.Equals, http.StatusOK) // quota:read
+	_, code = testRequest(t, http.MethodGet, apiKey, nil, "organizations", orgAddr.String(), "managed")
+	c.Assert(code, qt.Equals, http.StatusOK) // managed:read
+
+	// missing scope → 403 (key lacks managed:write)
+	mbody := &apicommon.CreateManagedOrganizationRequest{
+		OrganizationInfo: apicommon.OrganizationInfo{Type: string(db.CompanyType)},
+	}
+	_, code = testRequest(t, http.MethodPost, apiKey, mbody, "organizations", orgAddr.String(), "managed")
+	c.Assert(code, qt.Equals, http.StatusForbidden)
+
+	// non-allowlisted endpoint → 403 (API keys can't manage API keys)
+	_, code = testRequest(t, http.MethodGet, apiKey, nil, "organizations", orgAddr.String(), "apikeys")
+	c.Assert(code, qt.Equals, http.StatusForbidden)
+
+	// listing with the JWT shows the key (no secret)
+	data, code = testRequest(t, http.MethodGet, token, nil, "organizations", orgAddr.String(), "apikeys")
+	c.Assert(code, qt.Equals, http.StatusOK)
+	var list apicommon.ListAPIKeysResponse
+	c.Assert(json.Unmarshal(data, &list), qt.IsNil)
+	c.Assert(list.APIKeys, qt.HasLen, 1)
+	c.Assert(list.APIKeys[0].ID, qt.Equals, created.ID)
+	c.Assert(list.APIKeys[0].Prefix, qt.Equals, created.Prefix)
+
+	// revoke with the JWT
+	_, code = testRequest(t, http.MethodDelete, token, nil, "organizations", orgAddr.String(), "apikeys", created.ID)
+	c.Assert(code, qt.Equals, http.StatusOK)
+
+	// the revoked key no longer authenticates
+	_, code = testRequest(t, http.MethodGet, apiKey, nil, "organizations", orgAddr.String(), "integrator")
+	c.Assert(code, qt.Equals, http.StatusUnauthorized)
+}

--- a/api/apikeys_handlers.go
+++ b/api/apikeys_handlers.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/vocdoni/saas-backend/api/apicommon"
+	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/errors"
+)
+
+// createAPIKeyHandler godoc
+//
+//	@Summary		Create an API key for an organization
+//	@Description	Create a new API key owned by the organization at the given address. The caller
+//	@Description	must be an admin of the organization. The plaintext secret is returned ONCE and
+//	@Description	cannot be retrieved again.
+//	@Tags			apikeys
+//	@Accept			json
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			address	path		string							true	"Organization address"
+//	@Param			request	body		apicommon.CreateAPIKeyRequest	true	"API key information"
+//	@Success		200		{object}	apicommon.CreateAPIKeyResponse
+//	@Failure		400		{object}	errors.Error	"Invalid input data"
+//	@Failure		401		{object}	errors.Error	"Unauthorized"
+//	@Failure		500		{object}	errors.Error	"Internal server error"
+//	@Router			/organizations/{address}/apikeys [post]
+func (a *API) createAPIKeyHandler(w http.ResponseWriter, r *http.Request) {
+	user, ok := apicommon.UserFromContext(r.Context())
+	if !ok {
+		errors.ErrUnauthorized.Write(w)
+		return
+	}
+	orgAddr := common.HexToAddress(chi.URLParam(r, "address"))
+	if !user.HasRoleFor(orgAddr, db.AdminRole) {
+		errors.ErrUnauthorized.Withf("user is not admin of the organization").Write(w)
+		return
+	}
+	req := &apicommon.CreateAPIKeyRequest{}
+	if err := json.NewDecoder(r.Body).Decode(req); err != nil {
+		errors.ErrMalformedBody.Write(w)
+		return
+	}
+	if req.Label == "" {
+		errors.ErrMalformedBody.Withf("label is required").Write(w)
+		return
+	}
+	if len(req.Scopes) == 0 {
+		errors.ErrMalformedBody.Withf("at least one scope is required").Write(w)
+		return
+	}
+	for _, s := range req.Scopes {
+		if !IsValidAPIKeyScope(s) {
+			errors.ErrInvalidAPIKeyScope.Withf("unknown scope %q", s).Write(w)
+			return
+		}
+	}
+	if req.ExpiresAt != nil && !req.ExpiresAt.After(time.Now()) {
+		errors.ErrMalformedBody.Withf("expiresAt must be in the future").Write(w)
+		return
+	}
+	gen, err := generateAPIKey()
+	if err != nil {
+		errors.ErrGenericInternalServerError.Withf("could not generate API key: %v", err).Write(w)
+		return
+	}
+	key := &db.APIKey{
+		ID:         uuid.NewString(),
+		OrgAddress: orgAddr,
+		Label:      req.Label,
+		Prefix:     gen.prefix,
+		Hash:       gen.hash,
+		Scopes:     req.Scopes,
+		CreatedBy:  user.Email,
+		CreatedAt:  time.Now(),
+		ExpiresAt:  req.ExpiresAt,
+		Revoked:    false,
+	}
+	if err := a.db.SetAPIKey(key); err != nil {
+		errors.ErrGenericInternalServerError.Withf("could not store API key: %v", err).Write(w)
+		return
+	}
+	apicommon.HTTPWriteJSON(w, &apicommon.CreateAPIKeyResponse{
+		APIKeyInfo: apicommon.APIKeyInfoFromDB(key),
+		Secret:     gen.secret,
+	})
+}
+
+// apiKeysHandler godoc
+//
+//	@Summary		List an organization's API keys
+//	@Description	Returns the metadata of all API keys owned by the organization (never the secret).
+//	@Description	The caller must be an admin of the organization.
+//	@Tags			apikeys
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			address	path		string	true	"Organization address"
+//	@Success		200		{object}	apicommon.ListAPIKeysResponse
+//	@Failure		401		{object}	errors.Error	"Unauthorized"
+//	@Failure		500		{object}	errors.Error	"Internal server error"
+//	@Router			/organizations/{address}/apikeys [get]
+func (a *API) apiKeysHandler(w http.ResponseWriter, r *http.Request) {
+	user, ok := apicommon.UserFromContext(r.Context())
+	if !ok {
+		errors.ErrUnauthorized.Write(w)
+		return
+	}
+	orgAddr := common.HexToAddress(chi.URLParam(r, "address"))
+	if !user.HasRoleFor(orgAddr, db.AdminRole) {
+		errors.ErrUnauthorized.Withf("user is not admin of the organization").Write(w)
+		return
+	}
+	keys, err := a.db.APIKeysByOrg(orgAddr)
+	if err != nil {
+		errors.ErrGenericInternalServerError.Withf("could not list API keys: %v", err).Write(w)
+		return
+	}
+	list := make([]apicommon.APIKeyInfo, 0, len(keys))
+	for _, k := range keys {
+		list = append(list, apicommon.APIKeyInfoFromDB(k))
+	}
+	apicommon.HTTPWriteJSON(w, &apicommon.ListAPIKeysResponse{APIKeys: list})
+}
+
+// revokeAPIKeyHandler godoc
+//
+//	@Summary		Revoke an organization's API key
+//	@Description	Revokes (permanently disables) the API key with the given ID. The caller must be
+//	@Description	an admin of the organization.
+//	@Tags			apikeys
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			address	path		string			true	"Organization address"
+//	@Param			keyID	path		string			true	"API key ID"
+//	@Success		200		{string}	string			"OK"
+//	@Failure		401		{object}	errors.Error	"Unauthorized"
+//	@Failure		404		{object}	errors.Error	"API key not found"
+//	@Failure		500		{object}	errors.Error	"Internal server error"
+//	@Router			/organizations/{address}/apikeys/{keyID} [delete]
+func (a *API) revokeAPIKeyHandler(w http.ResponseWriter, r *http.Request) {
+	user, ok := apicommon.UserFromContext(r.Context())
+	if !ok {
+		errors.ErrUnauthorized.Write(w)
+		return
+	}
+	orgAddr := common.HexToAddress(chi.URLParam(r, "address"))
+	if !user.HasRoleFor(orgAddr, db.AdminRole) {
+		errors.ErrUnauthorized.Withf("user is not admin of the organization").Write(w)
+		return
+	}
+	keyID := chi.URLParam(r, "keyID")
+	if keyID == "" {
+		errors.ErrMalformedURLParam.Withf("keyID is required").Write(w)
+		return
+	}
+	if err := a.db.RevokeAPIKey(orgAddr, keyID); err != nil {
+		if err == db.ErrNotFound {
+			errors.ErrAPIKeyNotFound.Write(w)
+			return
+		}
+		errors.ErrGenericInternalServerError.Withf("could not revoke API key: %v", err).Write(w)
+		return
+	}
+	apicommon.HTTPWriteOK(w)
+}

--- a/api/apikeys_test.go
+++ b/api/apikeys_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestGenerateAPIKey(t *testing.T) {
+	c := qt.New(t)
+
+	gen, err := generateAPIKey()
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.HasPrefix(gen.secret, APIKeyPrefix), qt.IsTrue)
+	c.Assert(looksLikeAPIKey(gen.secret), qt.IsTrue)
+	c.Assert(gen.prefix, qt.Equals, gen.secret[:apiKeyDisplayPrefixLen])
+	// the hash is the SHA-256 of the full secret and never the secret itself
+	c.Assert(gen.hash, qt.Equals, hashAPIKey(gen.secret))
+	c.Assert(gen.hash, qt.Not(qt.Contains), gen.secret)
+	c.Assert(gen.hash, qt.HasLen, 64) // hex-encoded sha256
+
+	// two keys differ
+	gen2, err := generateAPIKey()
+	c.Assert(err, qt.IsNil)
+	c.Assert(gen2.secret, qt.Not(qt.Equals), gen.secret)
+	c.Assert(gen2.hash, qt.Not(qt.Equals), gen.hash)
+}
+
+func TestLooksLikeAPIKey(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(looksLikeAPIKey("vsk_abcdef"), qt.IsTrue)
+	c.Assert(looksLikeAPIKey("eyJhbGciOi.jwt.token"), qt.IsFalse)
+	c.Assert(looksLikeAPIKey(""), qt.IsFalse)
+}
+
+func TestIsValidAPIKeyScope(t *testing.T) {
+	c := qt.New(t)
+	for _, s := range AllAPIKeyScopes {
+		c.Assert(IsValidAPIKeyScope(s), qt.IsTrue)
+	}
+	c.Assert(IsValidAPIKeyScope("bogus:scope"), qt.IsFalse)
+	c.Assert(IsValidAPIKeyScope(""), qt.IsFalse)
+}
+
+func TestRequiredScopeForRoute(t *testing.T) {
+	c := qt.New(t)
+
+	// allowlisted integrator endpoints map to their scopes
+	scope, ok := requiredScopeForRoute("GET", integratorEndpoint)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(scope, qt.Equals, ScopeQuotaRead)
+
+	scope, ok = requiredScopeForRoute("POST", managedOrganizationsEndpoint)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(scope, qt.Equals, ScopeManagedWrite)
+
+	scope, ok = requiredScopeForRoute("GET", managedOrganizationsEndpoint)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(scope, qt.Equals, ScopeManagedRead)
+
+	// account-sensitive / unmapped endpoints reject API keys (deny by default)
+	_, ok = requiredScopeForRoute("POST", organizationAPIKeysEndpoint)
+	c.Assert(ok, qt.IsFalse)
+	_, ok = requiredScopeForRoute("GET", usersMeEndpoint)
+	c.Assert(ok, qt.IsFalse)
+
+	// every allowlisted scope is a valid, assignable scope
+	for route, sc := range apiKeyAllowlist {
+		c.Assert(IsValidAPIKeyScope(sc), qt.IsTrue, qt.Commentf("route %q maps to unknown scope %q", route, sc))
+	}
+}

--- a/api/middlewares.go
+++ b/api/middlewares.go
@@ -3,6 +3,9 @@ package api
 import (
 	"context"
 	"net/http"
+	"slices"
+	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/jwtauth/v5"
@@ -10,14 +13,34 @@ import (
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
+	"go.vocdoni.io/dvote/log"
 )
+
+// bearerToken extracts the bearer credential from the Authorization header, or "" if absent.
+func bearerToken(r *http.Request) string {
+	const prefix = "Bearer "
+	h := r.Header.Get("Authorization")
+	if len(h) > len(prefix) && strings.EqualFold(h[:len(prefix)], prefix) {
+		return h[len(prefix):]
+	}
+	return ""
+}
 
 // authenticator is a middleware that authenticates the user and returns a JWT
 // token. If successful, the decodes the user identifier (its email) from the
 // JWT token and gets the user information from the database, then adds the user
 // data to the request context and passes it to the next handler.
+//
+// It also accepts API keys: a Bearer credential with the API-key prefix is resolved against the
+// apiKeys collection (instead of being parsed as a JWT), enforcing the per-route allowlist and
+// the key's scopes. On success the owning user is placed in the context exactly as for a JWT, so
+// downstream role checks are unchanged.
 func (a *API) authenticator(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if raw := bearerToken(r); looksLikeAPIKey(raw) {
+			a.authenticateAPIKey(w, r, next, raw)
+			return
+		}
 		token, claims, err := jwtauth.FromContext(r.Context())
 		if err != nil {
 			errors.ErrUnauthorized.Write(w)
@@ -59,6 +82,45 @@ func (a *API) authenticator(next http.Handler) http.Handler {
 		// user information
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// authenticateAPIKey resolves a request authenticated with an API key. It validates the key,
+// enforces the per-route allowlist and the key's scopes, then loads the key's owning user into
+// the context (so existing role checks work) before delegating to the next handler.
+func (a *API) authenticateAPIKey(w http.ResponseWriter, r *http.Request, next http.Handler, raw string) {
+	key, err := a.db.APIKeyByHash(hashAPIKey(raw))
+	if err != nil {
+		errors.ErrInvalidAPIKey.Write(w)
+		return
+	}
+	// deny-by-default: the endpoint must opt into API-key access, and the key must hold its scope
+	pattern := chi.RouteContext(r.Context()).RoutePattern()
+	scope, allowed := requiredScopeForRoute(r.Method, pattern)
+	if !allowed {
+		errors.ErrAPIKeyNotAllowed.Write(w)
+		return
+	}
+	if !slices.Contains(key.Scopes, scope) {
+		errors.ErrInsufficientAPIKeyScope.Withf("endpoint requires the %q scope", scope).Write(w)
+		return
+	}
+	// the key acts as its creating user, reusing the existing per-organization role checks
+	user, err := a.db.UserByEmail(key.CreatedBy)
+	if err != nil {
+		errors.ErrInvalidAPIKey.Withf("key owner no longer exists").Write(w)
+		return
+	}
+	if !user.Verified {
+		errors.ErrUserNoVerified.With("user account not verified").Write(w)
+		return
+	}
+	// best-effort last-used tracking; never block the request on it
+	if err := a.db.TouchAPIKey(key.ID, time.Now()); err != nil {
+		log.Warnw("could not update API key last-used time", "keyID", key.ID, "error", err)
+	}
+	ctx := context.WithValue(r.Context(), apicommon.UserMetadataKey, *user)
+	ctx = context.WithValue(ctx, apicommon.APIKeyMetadataKey, *key)
+	next.ServeHTTP(w, r.WithContext(ctx))
 }
 
 // setLang is a middleware that sets the lang parameter in the request context

--- a/api/routes.go
+++ b/api/routes.go
@@ -111,6 +111,10 @@ const (
 	managedOrganizationsEndpoint = "/organizations/{address}/managed"
 	// GET /organizations/{address}/integrator to get integrator quota and usage
 	integratorEndpoint = "/organizations/{address}/integrator"
+	// POST /organizations/{address}/apikeys to create an API key; GET to list them
+	organizationAPIKeysEndpoint = "/organizations/{address}/apikeys"
+	// DELETE /organizations/{address}/apikeys/{keyID} to revoke an API key
+	organizationAPIKeyEndpoint = "/organizations/{address}/apikeys/{keyID}"
 
 	// subscription routes
 	// GET /subscriptions to get the subscriptions of an organization

--- a/db/apikeys.go
+++ b/db/apikeys.go
@@ -1,0 +1,121 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// APIKey is a programmatic credential owned by an (integrator) organization. Only the SHA-256
+// hash of the secret is stored; the plaintext secret is shown to the user once at creation.
+type APIKey struct {
+	ID         string         `json:"id" bson:"_id"`
+	OrgAddress common.Address `json:"orgAddress" bson:"orgAddress"`
+	Label      string         `json:"label" bson:"label"`
+	// Prefix is the first, non-secret part of the key (e.g. "vsk_1a2b3c4d"), kept for display so
+	// a user can identify a key without revealing the secret.
+	Prefix string `json:"prefix" bson:"prefix"`
+	// Hash is the hex-encoded SHA-256 of the full secret, used to resolve a presented key.
+	Hash string `json:"-" bson:"hash"`
+	// Scopes the key is allowed to use (see the api package for the canonical scope set).
+	Scopes []string `json:"scopes" bson:"scopes"`
+	// CreatedBy is the email of the user (admin) who created the key.
+	CreatedBy  string     `json:"createdBy" bson:"createdBy"`
+	CreatedAt  time.Time  `json:"createdAt" bson:"createdAt"`
+	LastUsedAt *time.Time `json:"lastUsedAt,omitempty" bson:"lastUsedAt,omitempty"`
+	ExpiresAt  *time.Time `json:"expiresAt,omitempty" bson:"expiresAt,omitempty"`
+	Revoked    bool       `json:"revoked" bson:"revoked"`
+}
+
+// SetAPIKey inserts a new API key. The key's ID and Hash must be set by the caller.
+func (ms *MongoStorage) SetAPIKey(key *APIKey) error {
+	if key.ID == "" || key.Hash == "" {
+		return ErrInvalidData
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	if _, err := ms.apiKeys.InsertOne(ctx, key); err != nil {
+		return err
+	}
+	return nil
+}
+
+// APIKeyByHash returns the non-revoked API key matching the given secret hash. A revoked or
+// expired key is treated as not found.
+func (ms *MongoStorage) APIKeyByHash(hash string) (*APIKey, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	key := &APIKey{}
+	if err := ms.apiKeys.FindOne(ctx, bson.M{"hash": hash, "revoked": false}).Decode(key); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	if key.ExpiresAt != nil && key.ExpiresAt.Before(time.Now()) {
+		return nil, ErrNotFound
+	}
+	return key, nil
+}
+
+// APIKeysByOrg returns all API keys owned by the given organization, most recent first.
+func (ms *MongoStorage) APIKeysByOrg(orgAddress common.Address) ([]*APIKey, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	cursor, err := ms.apiKeys.Find(ctx, bson.M{"orgAddress": orgAddress},
+		options.Find().SetSort(bson.D{{Key: "createdAt", Value: -1}}))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+	keys := []*APIKey{}
+	if err := cursor.All(ctx, &keys); err != nil {
+		return nil, err
+	}
+	return keys, nil
+}
+
+// APIKeyByID returns a single API key by its ID, scoped to the owning organization.
+func (ms *MongoStorage) APIKeyByID(orgAddress common.Address, id string) (*APIKey, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	key := &APIKey{}
+	if err := ms.apiKeys.FindOne(ctx, bson.M{"_id": id, "orgAddress": orgAddress}).Decode(key); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return key, nil
+}
+
+// RevokeAPIKey marks the org's API key as revoked. Returns ErrNotFound if no such key exists.
+func (ms *MongoStorage) RevokeAPIKey(orgAddress common.Address, id string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	res, err := ms.apiKeys.UpdateOne(ctx,
+		bson.M{"_id": id, "orgAddress": orgAddress},
+		bson.M{"$set": bson.M{"revoked": true}},
+	)
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// TouchAPIKey records the last time a key was used. Best-effort: errors are returned but callers
+// typically log and ignore them so auth is not blocked by a counter update.
+func (ms *MongoStorage) TouchAPIKey(id string, when time.Time) error {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	_, err := ms.apiKeys.UpdateOne(ctx, bson.M{"_id": id}, bson.M{"$set": bson.M{"lastUsedAt": when}})
+	return err
+}

--- a/db/apikeys_test.go
+++ b/db/apikeys_test.go
@@ -1,0 +1,76 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	qt "github.com/frankban/quicktest"
+)
+
+func TestAPIKeys(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+	c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+
+	org := common.HexToAddress("0x1111111111111111111111111111111111111111")
+
+	// unknown hash → not found
+	_, err := testDB.APIKeyByHash("missing")
+	c.Assert(err, qt.Equals, ErrNotFound)
+
+	// a key without ID/Hash is rejected
+	c.Assert(testDB.SetAPIKey(&APIKey{}), qt.Equals, ErrInvalidData)
+
+	key := &APIKey{
+		ID:         "key-1",
+		OrgAddress: org,
+		Label:      "first",
+		Prefix:     "vsk_aaaabbbb",
+		Hash:       "hash-1",
+		Scopes:     []string{"quota:read", "managed:read"},
+		CreatedBy:  "admin@example.com",
+		CreatedAt:  time.Now(),
+	}
+	c.Assert(testDB.SetAPIKey(key), qt.IsNil)
+
+	// lookup by hash
+	got, err := testDB.APIKeyByHash("hash-1")
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.ID, qt.Equals, "key-1")
+	c.Assert(got.Scopes, qt.DeepEquals, []string{"quota:read", "managed:read"})
+
+	// lookup by id (org-scoped)
+	got, err = testDB.APIKeyByID(org, "key-1")
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.Label, qt.Equals, "first")
+
+	// list by org
+	list, err := testDB.APIKeysByOrg(org)
+	c.Assert(err, qt.IsNil)
+	c.Assert(list, qt.HasLen, 1)
+
+	// last-used tracking
+	c.Assert(testDB.TouchAPIKey("key-1", time.Now()), qt.IsNil)
+	got, err = testDB.APIKeyByHash("hash-1")
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.LastUsedAt, qt.Not(qt.IsNil))
+
+	// an expired key is treated as not found
+	past := time.Now().Add(-time.Hour)
+	expired := &APIKey{ID: "key-exp", OrgAddress: org, Hash: "hash-exp", ExpiresAt: &past, CreatedAt: time.Now()}
+	c.Assert(testDB.SetAPIKey(expired), qt.IsNil)
+	_, err = testDB.APIKeyByHash("hash-exp")
+	c.Assert(err, qt.Equals, ErrNotFound)
+
+	// revoking makes the key unauthenticable but still listable
+	c.Assert(testDB.RevokeAPIKey(org, "key-1"), qt.IsNil)
+	_, err = testDB.APIKeyByHash("hash-1")
+	c.Assert(err, qt.Equals, ErrNotFound)
+	list, err = testDB.APIKeysByOrg(org)
+	c.Assert(err, qt.IsNil)
+	c.Assert(list, qt.HasLen, 2) // key-1 (revoked) + key-exp
+
+	// revoking a missing key → not found
+	c.Assert(testDB.RevokeAPIKey(org, "nope"), qt.Equals, ErrNotFound)
+}

--- a/db/helpers.go
+++ b/db/helpers.go
@@ -33,6 +33,7 @@ func (ms *MongoStorage) collectionsMap() map[string]**mongo.Collection {
 		"cspTokens":           &ms.cspTokens,
 		"cspTokensStatus":     &ms.cspTokensStatus,
 		"jobs":                &ms.jobs,
+		"apiKeys":             &ms.apiKeys,
 		"migrations":          &ms.migrations,
 	}
 }

--- a/db/mongo.go
+++ b/db/mongo.go
@@ -50,6 +50,7 @@ type MongoStorage struct {
 	cspTokens           *mongo.Collection
 	cspTokensStatus     *mongo.Collection
 	jobs                *mongo.Collection
+	apiKeys             *mongo.Collection
 	migrations          *mongo.Collection
 }
 

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -15,6 +15,29 @@ definitions:
       version:
         type: string
     type: object
+  apicommon.APIKeyInfo:
+    properties:
+      createdAt:
+        type: string
+      createdBy:
+        type: string
+      expiresAt:
+        type: string
+      id:
+        type: string
+      label:
+        type: string
+      lastUsedAt:
+        type: string
+      prefix:
+        type: string
+      revoked:
+        type: boolean
+      scopes:
+        items:
+          type: string
+        type: array
+    type: object
   apicommon.AcceptOrganizationInvitation:
     properties:
       code:
@@ -116,6 +139,48 @@ definitions:
       name:
         type: string
       surname:
+        type: string
+    type: object
+  apicommon.CreateAPIKeyRequest:
+    properties:
+      expiresAt:
+        description: Optional expiration; when set, the key stops working after this
+          time.
+        type: string
+      label:
+        description: Human-readable label to identify the key.
+        type: string
+      scopes:
+        description: Scopes the key is allowed to use (must be a subset of the assignable
+          scopes).
+        items:
+          type: string
+        type: array
+    type: object
+  apicommon.CreateAPIKeyResponse:
+    properties:
+      createdAt:
+        type: string
+      createdBy:
+        type: string
+      expiresAt:
+        type: string
+      id:
+        type: string
+      label:
+        type: string
+      lastUsedAt:
+        type: string
+      prefix:
+        type: string
+      revoked:
+        type: boolean
+      scopes:
+        items:
+          type: string
+        type: array
+      secret:
+        description: Secret is the full API key, shown only at creation time.
         type: string
     type: object
   apicommon.CreateCensusRequest:
@@ -391,6 +456,13 @@ definitions:
         allOf:
         - $ref: '#/definitions/apicommon.Pagination'
         description: Pagination fields
+    type: object
+  apicommon.ListAPIKeysResponse:
+    properties:
+      apiKeys:
+        items:
+          $ref: '#/definitions/apicommon.APIKeyInfo'
+        type: array
     type: object
   apicommon.ListManagedOrganizations:
     properties:
@@ -2378,6 +2450,120 @@ paths:
       summary: Update organization information
       tags:
       - organizations
+  /organizations/{address}/apikeys:
+    get:
+      description: |-
+        Returns the metadata of all API keys owned by the organization (never the secret).
+        The caller must be an admin of the organization.
+      parameters:
+      - description: Organization address
+        in: path
+        name: address
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apicommon.ListAPIKeysResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+      security:
+      - BearerAuth: []
+      summary: List an organization's API keys
+      tags:
+      - apikeys
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Create a new API key owned by the organization at the given address. The caller
+        must be an admin of the organization. The plaintext secret is returned ONCE and
+        cannot be retrieved again.
+      parameters:
+      - description: Organization address
+        in: path
+        name: address
+        required: true
+        type: string
+      - description: API key information
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/apicommon.CreateAPIKeyRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apicommon.CreateAPIKeyResponse'
+        "400":
+          description: Invalid input data
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+      security:
+      - BearerAuth: []
+      summary: Create an API key for an organization
+      tags:
+      - apikeys
+  /organizations/{address}/apikeys/{keyID}:
+    delete:
+      description: |-
+        Revokes (permanently disables) the API key with the given ID. The caller must be
+        an admin of the organization.
+      parameters:
+      - description: Organization address
+        in: path
+        name: address
+        required: true
+        type: string
+      - description: API key ID
+        in: path
+        name: keyID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: string
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "404":
+          description: API key not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+      security:
+      - BearerAuth: []
+      summary: Revoke an organization's API key
+      tags:
+      - apikeys
   /organizations/{address}/censuses:
     get:
       consumes:

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -100,6 +100,11 @@ var (
 	ErrNotAnIntegrator                        = Error{Code: 40153, HTTPstatus: http.StatusForbidden, Err: fmt.Errorf("organization is not an integrator")}
 	ErrMaxManagedOrgsReached                  = Error{Code: 40154, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("max managed organizations reached")}
 	ErrIntegratorQuotaExceeded                = Error{Code: 40155, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("integrator quota exceeded")}
+	ErrInvalidAPIKey                          = Error{Code: 40156, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("invalid, revoked or expired API key"), LogLevel: "info"}
+	ErrAPIKeyNotAllowed                       = Error{Code: 40157, HTTPstatus: http.StatusForbidden, Err: fmt.Errorf("API keys are not permitted for this endpoint"), LogLevel: "info"}
+	ErrInsufficientAPIKeyScope                = Error{Code: 40158, HTTPstatus: http.StatusForbidden, Err: fmt.Errorf("API key lacks the required scope"), LogLevel: "info"}
+	ErrInvalidAPIKeyScope                     = Error{Code: 40159, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid API key scope")}
+	ErrAPIKeyNotFound                         = Error{Code: 40160, HTTPstatus: http.StatusNotFound, Err: fmt.Errorf("API key not found")}
 
 	// CSP errors (408)
 	ErrZeroWeightVoter = Error{Code: 40801, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("voter weight cannot be zero")}

--- a/migrations/0013_api_keys.go
+++ b/migrations/0013_api_keys.go
@@ -1,0 +1,44 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func init() {
+	AddMigration(13, "api_keys", upAPIKeys, downAPIKeys)
+}
+
+// upAPIKeys creates the apiKeys collection and its indexes: a unique index on the secret hash
+// (for auth lookups) and an index on the owning organization address (for listing).
+func upAPIKeys(ctx context.Context, database *mongo.Database) error {
+	if err := database.CreateCollection(ctx, "apiKeys"); err != nil {
+		// ignore "collection already exists" so the migration is idempotent
+		if cmdErr, ok := err.(mongo.CommandError); !ok || cmdErr.Code != 48 {
+			return fmt.Errorf("failed to create apiKeys collection: %w", err)
+		}
+	}
+	coll := database.Collection("apiKeys")
+	if _, err := coll.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys:    bson.D{{Key: "hash", Value: 1}},
+			Options: options.Index().SetUnique(true),
+		},
+		{
+			Keys: bson.D{{Key: "orgAddress", Value: 1}},
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to create indexes on apiKeys: %w", err)
+	}
+	return nil
+}
+
+func downAPIKeys(context.Context, *mongo.Database) error {
+	// Dropping apiKeys would destroy live credentials; matching the repo policy for data-bearing
+	// collections we do nothing here. upAPIKeys is idempotent.
+	return nil
+}


### PR DESCRIPTION
## What

Adds **API keys** so integrators can call the API programmatically (no JWT session). Per-key **scopes**, **revoke**, **optional expiry**, and **last-used** tracking.

> ⚠️ Touches the core auth middleware — flagging @emmdim @lucasmenendez. Design summary below; happy to adjust the scope taxonomy or the enforcement approach.

## Model & storage
- New `apiKeys` collection (migration **0013**, unique index on the secret hash + index on org).
- Stores only the **SHA-256 hash** of the secret + a display **prefix** (`vsk_1a2b3c4d`), plus `scopes`, `createdBy`, `createdAt`, `lastUsedAt`, `expiresAt?`, `revoked`. The plaintext secret (`vsk_…`) is returned **once** at creation.

## Auth integration (minimal)
- `authenticator` detects a Bearer credential with the `vsk_` prefix and resolves it against `apiKeys` instead of parsing a JWT, then loads the key's **owning user** into the context — so every existing `user.HasRoleFor(org, role)` check works unchanged.
- `lastUsedAt` stamped best-effort (logged, never blocks the request).

## Authorization — deny by default
- API keys are accepted **only** on an explicit allowlist of integrator/managed-org endpoints. Everything else (auth, password, OAuth, team/invites, tickets, checkout, **and API-key management itself**) rejects API-key auth → keys can never touch account-sensitive surface.
- Within the allowlist, each route requires a scope the key must hold:

| scope | grants |
|---|---|
| `quota:read` | GET integrator quota/usage |
| `managed:read` | list managed orgs |
| `managed:write` | create managed orgs |
| `voting:write` | create/publish processes, censuses, bundles |
| `members:write` | manage members & groups |

## Endpoints (admin only)
- `POST /organizations/{address}/apikeys` → create (returns the secret once)
- `GET /organizations/{address}/apikeys` → list (metadata only)
- `DELETE /organizations/{address}/apikeys/{keyID}` → revoke

## Tests (all green locally, Docker-backed)
- `api`: key gen/hash, scope validation, route-allowlist mapping, and a full lifecycle integration test — create → use within scope → **403** for missing scope → **403** for non-allowlisted endpoint → revoke → **401**.
- `db`: storage incl. hash lookup ignoring revoked/expired keys, list, touch, revoke.
- `go build ./...`, `go vet`, swagger regenerated (additive only).

## Design notes for review
- **A key acts as its creating admin user.** This reuses the role model exactly; a key inherits that user's org memberships. If the creator is removed, the key fails closed. Tightening a key to *only* its owning integrator org + that org's managed orgs (rather than any org the user administers) is a natural follow-up — flagging in case you'd prefer that boundary in v1.
- Scope taxonomy is intentionally small/extensible; the allowlist is a single central map keyed by `"<METHOD> <route pattern>"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)