### PR TITLE
fix(api): prevent demoting the last admin of an organization

### DIFF
--- a/api/organization_users.go
+++ b/api/organization_users.go
@@ -603,6 +603,24 @@ func (a *API) updateOrganizationUserHandler(w http.ResponseWriter, r *http.Reque
 		errors.ErrInvalidUserData.Withf("invalid role").Write(w)
 		return
 	}
+	// prevent demoting the last admin, which would orphan the organization
+	if db.UserRole(update.Role) != db.AdminRole && uint64(userIDInt) == user.ID {
+		users, err := a.db.OrganizationUsers(org.Address)
+		if err != nil {
+			errors.ErrGenericInternalServerError.Withf("could not get organization users: %v", err).Write(w)
+			return
+		}
+		otherAdmins := 0
+		for _, u := range users {
+			if u.ID != user.ID && u.HasRoleFor(org.Address, db.AdminRole) {
+				otherAdmins++
+			}
+		}
+		if otherAdmins == 0 {
+			errors.ErrInvalidUserData.With("cannot demote the last admin of the organization").Write(w)
+			return
+		}
+	}
 	if err := a.db.UpdateOrganizationUserRole(org.Address, uint64(userIDInt), db.UserRole(update.Role)); err != nil {
 		errors.ErrInvalidUserData.Withf("user not found: %v", err).Write(w)
 		return

--- a/api/organization_users_test.go
+++ b/api/organization_users_test.go
@@ -333,6 +333,44 @@ func TestOrganizationUsers(t *testing.T) {
 		c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 	})
 
+	t.Run("LastAdminCannotBeDemoted", func(t *testing.T) {
+		// Fresh org whose creator is the sole admin.
+		soleAdminToken := testCreateUser(t, "soleadminpassword123")
+		soleOrgAddress := testCreateOrganization(t, soleAdminToken)
+
+		resp, code := testRequest(t, http.MethodGet, soleAdminToken, nil, usersMeEndpoint)
+		c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+		var soleAdminInfo apicommon.UserInfo
+		c.Assert(json.Unmarshal(resp, &soleAdminInfo), qt.IsNil)
+
+		// Demoting the only admin must be rejected, otherwise the org is orphaned.
+		demote := &apicommon.UpdateOrganizationUserRoleRequest{Role: string(db.ViewerRole)}
+		errResp := requestAndParseWithAssertCode[errors.Error](http.StatusBadRequest,
+			t,
+			http.MethodPut,
+			soleAdminToken,
+			demote,
+			"organizations",
+			soleOrgAddress.String(),
+			"users",
+			fmt.Sprintf("%d", soleAdminInfo.ID),
+		)
+		c.Assert(errResp.Code, qt.Equals, errors.ErrInvalidUserData.Code)
+
+		// The admin role must be unchanged.
+		role, ok := db.UserRole(""), false
+		users, err := testDB.OrganizationUsers(soleOrgAddress)
+		c.Assert(err, qt.IsNil)
+		for _, u := range users {
+			if u.ID == soleAdminInfo.ID {
+				role, ok = u.RoleFor(soleOrgAddress)
+				break
+			}
+		}
+		c.Assert(ok, qt.IsTrue)
+		c.Assert(role, qt.Equals, db.AdminRole)
+	})
+
 	t.Run("RemoveOrganizationUser", func(t *testing.T) {
 		// Create a new organization and user for this test
 		newOrgAddress := testCreateOrganization(t, adminToken)


### PR DESCRIPTION
## Root cause

`updateOrganizationUserHandler` (`api/organization_users.go`) lets an admin change any member's role with no check that an admin remains. The **sole admin of an org can change their own role to `viewer`**, leaving the organization with **zero admins**.

That state is unrecoverable: only admins can change roles, invite users, or manage the org, and there is no super-admin / recovery path — so the org is permanently orphaned. It's worst for **integrator** orgs (introduced recently), which manage sub-orgs and cannot be re-bootstrapped.

The **remove** path (`removeOrganizationUserHandler`) is already safe: it blocks self-removal (`api/organization_users.go:662`), and since the caller must be an admin, a non-self removal always leaves the caller as admin. So only the demote/update path needed a fix.

## The fix

One guard in `updateOrganizationUserHandler`, before the `UpdateOrganizationUserRole` call: if the new role isn't `AdminRole`, count the org's **other** admins (reusing the existing `db.OrganizationUsers` + `User.HasRoleFor`); if none remain, reject with `ErrInvalidUserData` (`400`).

Why the condition is correct: the caller is always an admin. If the target is anyone other than the caller, the caller still counts as `otherAdmins ≥ 1` → never blocks. It only blocks the sole-admin self-demotion — exactly the orphan case.

`// ponytail:` it lists all org users to count admins instead of a dedicated count query, and accepts a negligible TOCTOU window (two admins demoting simultaneously) rather than a transaction — role changes are rare and admin-only. Add a `CountOrganizationAdmins` query only if profiling demands.

Net diff: 1 handler + 1 regression test, +56/-0.

## Verification

- `go build ./...`, `go vet ./api/`, and `go test -c ./api/` — clean.
- Added `LastAdminCannotBeDemoted` subtest in `api/organization_users_test.go`: a fresh org whose creator is the sole admin → demoting them to `viewer` returns `400` / `ErrInvalidUserData` and the admin role is unchanged. The positive case (demotion succeeds when another admin exists) is already covered by the existing `UpdateOrganizationUserRole` subtest.
- The Docker-backed integration test was **not run locally** (Docker daemon unavailable in this environment); it will run in CI.