### PR TITLE
feat(api): expose Vocdoni chainID to voters and clients

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -76,6 +76,11 @@ func New(privateKey string, apiEndpoint string) (*Account, error) {
 	}, nil
 }
 
+// ChainID returns the identifier of the Vocdoni chain the account is connected to.
+func (a *Account) ChainID() string {
+	return a.client.ChainID()
+}
+
 // FaucetPackage generates a faucet package for the given address and amount.
 func (a *Account) FaucetPackage(toAddr common.Address, amount uint64) (*models.FaucetPackage, error) {
 	log.Infow("generating faucet package",

--- a/api/api.go
+++ b/api/api.go
@@ -350,6 +350,7 @@ func (a *API) initRouter() http.Handler {
 				log.Warnw("failed to write ping response", "error", err)
 			}
 		})
+		handle(r, http.MethodGet, infoEndpoint, a.InfoHandler)
 
 		handle(r, http.MethodPost, authLoginEndpoint, a.authLoginHandler)
 		handle(r, http.MethodPost, oauthLoginEndpoint, a.oauthLoginHandler)

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -39,6 +39,20 @@ type PaginationParams struct {
 	Limit int64 `json:"limit,omitempty"`
 }
 
+// ProcessInfo is the voter-facing response for a single voting process. It embeds the
+// stored process and adds the Vocdoni chain ID the process lives on.
+type ProcessInfo struct {
+	*db.Process
+	ChainID string `json:"chainId"`
+}
+
+// ProcessBundleInfo is the voter-facing response for a process bundle. It embeds the
+// stored bundle and adds the Vocdoni chain ID the bundle's processes live on.
+type ProcessBundleInfo struct {
+	*db.ProcessesBundle
+	ChainID string `json:"chainId"`
+}
+
 // OrganizationInfo represents an organization in the API.
 // swagger:model OrganizationInfo
 type OrganizationInfo struct {

--- a/api/health.go
+++ b/api/health.go
@@ -7,34 +7,35 @@ import (
 	"github.com/vocdoni/saas-backend/api/apicommon"
 )
 
-// VersionInfo contains build and version information for the service.
-type VersionInfo struct {
+// InfoResponse contains build, version and chain information for the service.
+type InfoResponse struct {
 	Version   string `json:"version"`
 	GoVersion string `json:"goVersion"`
+	ChainID   string `json:"chainId"`
 }
 
-// defaultVersionInfo is returned when build info is unavailable.
-var defaultVersionInfo = VersionInfo{
+// defaultInfoResponse holds the values returned when build info is unavailable.
+var defaultInfoResponse = InfoResponse{
 	Version:   "unknown",
 	GoVersion: "unknown",
 }
 
-// VersionHandler godoc
+// InfoHandler godoc
 //
-//	@Summary		Get service version
-//	@Description	Returns the service version and build information
+//	@Summary		Get service information
+//	@Description	Returns the service version, build information and the Vocdoni chain ID.
 //	@Tags			health
 //	@Produce		json
-//	@Success		200	{object}	VersionInfo
-//	@Router			/version [get]
-func (*API) VersionHandler(w http.ResponseWriter, _ *http.Request) {
-	v, _ := debug.ReadBuildInfo()
-	if v == nil {
-		apicommon.HTTPWriteJSON(w, defaultVersionInfo)
-		return
+//	@Success		200	{object}	InfoResponse
+//	@Router			/info [get]
+func (a *API) InfoHandler(w http.ResponseWriter, _ *http.Request) {
+	info := defaultInfoResponse
+	if v, _ := debug.ReadBuildInfo(); v != nil {
+		info.Version = v.Main.Version
+		info.GoVersion = v.GoVersion
 	}
-	apicommon.HTTPWriteJSON(w, VersionInfo{
-		Version:   v.Main.Version,
-		GoVersion: v.GoVersion,
-	})
+	if a.account != nil {
+		info.ChainID = a.account.ChainID()
+	}
+	apicommon.HTTPWriteJSON(w, info)
 }

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -10,34 +10,35 @@ import (
 	"github.com/vocdoni/saas-backend/api/apicommon"
 )
 
-// TestVersionHandler verifies that VersionHandler returns HTTP 200 with valid JSON version info.
-func TestVersionHandler(t *testing.T) {
+// TestInfoHandler verifies that InfoHandler returns HTTP 200 with valid JSON service info.
+func TestInfoHandler(t *testing.T) {
 	c := qt.New(t)
 	w := httptest.NewRecorder()
-	r, err := http.NewRequest(http.MethodGet, "/version", nil)
+	r, err := http.NewRequest(http.MethodGet, "/info", nil)
 	c.Assert(err, qt.IsNil)
 
+	// account is nil here, so ChainID stays empty; the build info fields are still populated.
 	var a API
-	a.VersionHandler(w, r)
+	a.InfoHandler(w, r)
 
 	c.Assert(w.Code, qt.Equals, http.StatusOK)
-	var info VersionInfo
+	var info InfoResponse
 	c.Assert(json.Unmarshal(w.Body.Bytes(), &info), qt.IsNil)
 	c.Assert(info.GoVersion, qt.Not(qt.Equals), "")
 }
 
-// TestVersionHandlerNilBuildInfo verifies the nil-guard path: when build info is unavailable,
-// the handler writes defaultVersionInfo instead of panicking.
-func TestVersionHandlerNilBuildInfo(t *testing.T) {
+// TestInfoHandlerNilBuildInfo verifies the nil-guard path: when build info is unavailable,
+// the handler writes defaultInfoResponse instead of panicking.
+func TestInfoHandlerNilBuildInfo(t *testing.T) {
 	c := qt.New(t)
 	w := httptest.NewRecorder()
 
-	// Directly exercise the nil-guard branch that VersionHandler takes when
+	// Directly exercise the nil-guard branch that InfoHandler takes when
 	// debug.ReadBuildInfo returns nil.
-	apicommon.HTTPWriteJSON(w, defaultVersionInfo)
+	apicommon.HTTPWriteJSON(w, defaultInfoResponse)
 
 	c.Assert(w.Code, qt.Equals, http.StatusOK)
-	var info VersionInfo
+	var info InfoResponse
 	c.Assert(json.Unmarshal(w.Body.Bytes(), &info), qt.IsNil)
 	c.Assert(info.Version, qt.Equals, "unknown")
 	c.Assert(info.GoVersion, qt.Equals, "unknown")

--- a/api/process.go
+++ b/api/process.go
@@ -223,7 +223,7 @@ func (a *API) updateProcessHandler(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Param			processId	path		string	true	"Process ID"
-//	@Success		200			{object}	db.Process
+//	@Success		200			{object}	apicommon.ProcessInfo
 //	@Failure		400			{object}	errors.Error	"Invalid process ID"
 //	@Failure		404			{object}	errors.Error	"Process not found"
 //	@Failure		500			{object}	errors.Error	"Internal server error"
@@ -250,7 +250,10 @@ func (a *API) processInfoHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	apicommon.HTTPWriteJSON(w, process)
+	apicommon.HTTPWriteJSON(w, &apicommon.ProcessInfo{
+		Process: process,
+		ChainID: a.account.ChainID(),
+	})
 }
 
 // organizationListProcessDraftsHandler godoc

--- a/api/process_bundles.go
+++ b/api/process_bundles.go
@@ -278,7 +278,7 @@ func (a *API) updateProcessBundleHandler(w http.ResponseWriter, r *http.Request)
 //	@Accept			json
 //	@Produce		json
 //	@Param			bundleId	path		string	true	"Bundle ID"
-//	@Success		200			{object}	db.ProcessesBundle
+//	@Success		200			{object}	apicommon.ProcessBundleInfo
 //	@Failure		400			{object}	errors.Error	"Invalid bundle ID"
 //	@Failure		404			{object}	errors.Error	"Bundle not found"
 //	@Failure		500			{object}	errors.Error	"Internal server error"
@@ -306,7 +306,10 @@ func (a *API) processBundleInfoHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	apicommon.HTTPWriteJSON(w, bundle)
+	apicommon.HTTPWriteJSON(w, &apicommon.ProcessBundleInfo{
+		ProcessesBundle: bundle,
+		ChainID:         a.account.ChainID(),
+	})
 }
 
 // processBundleParticipantInfoHandler godoc

--- a/api/routes.go
+++ b/api/routes.go
@@ -4,6 +4,8 @@ const (
 	// ping route
 	// GET /ping to check the server status
 	pingEndpoint = "/ping"
+	// GET /info to get service version, build and chain information
+	infoEndpoint = "/info"
 
 	// auth routes
 

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -8,8 +8,10 @@ definitions:
           type: string
         type: array
     type: object
-  api.VersionInfo:
+  api.InfoResponse:
     properties:
+      chainId:
+        type: string
       goVersion:
         type: string
       version:
@@ -953,6 +955,57 @@ definitions:
       totalItems:
         type: integer
     type: object
+  apicommon.ProcessBundleInfo:
+    properties:
+      census:
+        allOf:
+        - $ref: '#/definitions/db.Census'
+        description: The census associated with this bundle
+      chainId:
+        type: string
+      id:
+        description: Unique identifier for the bundle
+        type: string
+      orgAddress:
+        description: The organization that owns this bundle
+        items:
+          type: integer
+        type: array
+      processes:
+        description: Array of process addresses included in this bundle
+        example:
+        - deadbeef
+        items:
+          format: hex
+          type: string
+        type: array
+    type: object
+  apicommon.ProcessInfo:
+    properties:
+      address:
+        example: deadbeef
+        format: hex
+        type: string
+      census:
+        $ref: '#/definitions/db.Census'
+      chainId:
+        type: string
+      electionParams:
+        $ref: '#/definitions/db.ElectionParams'
+      id:
+        type: string
+      metadata:
+        additionalProperties: {}
+        type: object
+      orgAdress:
+        items:
+          type: integer
+        type: array
+      publishedAt:
+        type: string
+      status:
+        type: string
+    type: object
   apicommon.ProcessResultsResponse:
     properties:
       endDate:
@@ -1628,29 +1681,6 @@ definitions:
       status:
         type: string
     type: object
-  db.ProcessesBundle:
-    properties:
-      census:
-        allOf:
-        - $ref: '#/definitions/db.Census'
-        description: The census associated with this bundle
-      id:
-        description: Unique identifier for the bundle
-        type: string
-      orgAddress:
-        description: The organization that owns this bundle
-        items:
-          type: integer
-        type: array
-      processes:
-        description: Array of process addresses included in this bundle
-        example:
-        - deadbeef
-        items:
-          format: hex
-          type: string
-        type: array
-    type: object
   db.PublishedCensus:
     properties:
       createdAt:
@@ -2255,6 +2285,20 @@ paths:
       summary: Publish a census for voting
       tags:
       - census
+  /info:
+    get:
+      description: Returns the service version, build information and the Vocdoni
+        chain ID.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.InfoResponse'
+      summary: Get service information
+      tags:
+      - health
   /jobs/{jobId}:
     get:
       description: |-
@@ -4232,7 +4276,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/db.Process'
+            $ref: '#/definitions/apicommon.ProcessInfo'
         "400":
           description: Invalid process ID
           schema:
@@ -4629,7 +4673,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/db.ProcessesBundle'
+            $ref: '#/definitions/apicommon.ProcessBundleInfo'
         "400":
           description: Invalid bundle ID
           schema:
@@ -5645,19 +5689,6 @@ paths:
       summary: Resend verification code
       tags:
       - users
-  /version:
-    get:
-      description: Returns the service version and build information
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/api.VersionInfo'
-      summary: Get service version
-      tags:
-      - health
 schemes:
 - http
 - https


### PR DESCRIPTION
## Why

Voters need to know which Vocdoni chain a process lives on. The `chainID` existed internally (used for signing transactions and faucet packages, logged at startup) but was **never exposed by any API endpoint**.

## What

- **`Account.ChainID()`** — new exported accessor over the underlying API client.
- **`/info`** (renamed from `/version`) — the old `/version` endpoint was defined but never registered in the router, so it 404'd. Renamed to `/info`, wired into the public route group, and now returns `chainId` alongside `version`/`goVersion`. This is the natural global place for it (chainID is per-backend).
- **Voter-facing process endpoints** — `GET /process/{processId}` and `GET /process/bundle/{bundleId}` now include `chainId`, so voters get it in the same request they already make before casting. Implemented via thin `apicommon.ProcessInfo` / `apicommon.ProcessBundleInfo` wrappers that embed the stored structs — the `db` structs are untouched, so bson/storage is unaffected and the existing JSON shape only gains one field.
- Regenerated `docs/swagger.yaml`.

## Notes

- `/version` → `/info` is a breaking rename, but the old route was never registered, so nothing was consuming it.
- Existing tests that unmarshal the process/bundle responses into `db.Process` / `db.ProcessesBundle` keep working — embedded fields stay flattened, they just ignore the new `chainId`.

## Test

- `go build ./...` ✓
- `TestInfoHandler` / `TestInfoHandlerNilBuildInfo` pass; full `./api/` package passes ✓
- `make swagger` regenerated; `/info` + `chainId` fields present ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)