### PR TITLE
refactor: make Stripe the single source of truth for plans

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -367,7 +367,6 @@ func (a *API) initRouter() http.Handler {
 		handle(r, http.MethodGet, organizationRolesEndpoint, a.organizationRolesHandler)
 		handle(r, http.MethodGet, organizationTypesEndpoint, a.organizationsTypesHandler)
 		handle(r, http.MethodGet, plansEndpoint, a.plansHandler)
-		handle(r, http.MethodGet, planInfoEndpoint, a.planInfoHandler)
 		handle(r, http.MethodPost, subscriptionsWebhook, a.stripeHandlers.HandleWebhook)
 		handle(r, http.MethodGet, objectStorageDownloadTypedEndpoint, a.objectStorage.DownloadImageInlineHandler)
 		handle(r, http.MethodGet, censusIDEndpoint, a.censusInfoHandler)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -84,14 +84,14 @@ var (
 	mockPlans = []*db.Plan{mockFreePlan, mockEssentialPlan, mockPremiumPlan}
 
 	mockFreePlan = &db.Plan{
-		ID:                   1,
+		ID:                   "prod_test_free",
 		Name:                 "Free Plan",
-		StripeID:             "prod_test_free",
 		StripeMonthlyPriceID: "price_month_test_free",
 		MonthlyPrice:         0,
 		StripeYearlyPriceID:  "price_year_test_free",
 		YearlyPrice:          0,
 		Default:              true,
+		Public:               true,
 		Organization: db.PlanLimits{
 			Users:        1,
 			SubOrgs:      0,
@@ -124,14 +124,14 @@ var (
 		},
 	}
 	mockEssentialPlan = &db.Plan{
-		ID:                   2,
+		ID:                   "prod_test_essential",
 		Name:                 "Essential Annual Subscription Plan",
-		StripeID:             "prod_test_essential",
 		StripeMonthlyPriceID: "price_month_test_essential",
 		MonthlyPrice:         1990,
 		StripeYearlyPriceID:  "price_year_test_essential",
 		YearlyPrice:          19900,
 		Default:              false,
+		Public:               true,
 		Organization: db.PlanLimits{
 			Users:        5,
 			SubOrgs:      1,
@@ -164,14 +164,14 @@ var (
 		},
 	}
 	mockPremiumPlan = &db.Plan{
-		ID:                   3,
+		ID:                   "prod_test_premium",
 		Name:                 "Premium Annual Subscription Plan",
-		StripeID:             "prod_test_premium",
 		StripeMonthlyPriceID: "price_month_test_premium",
 		MonthlyPrice:         4990,
 		StripeYearlyPriceID:  "price_year_test_premium",
 		YearlyPrice:          49900,
 		Default:              false,
+		Public:               true,
 		Organization: db.PlanLimits{
 			Users:        10,
 			SubOrgs:      2,
@@ -333,7 +333,7 @@ func TestMain(m *testing.M) {
 				update := bson.M{"$set": p}
 				opts := options.Update().SetUpsert(true)
 				if _, err := database.Collection("plans").UpdateOne(ctx, filter, update, opts); err != nil {
-					return fmt.Errorf("failed to upsert plan with ID %d: %w", p.ID, err)
+					return fmt.Errorf("failed to upsert plan with ID %s: %w", p.ID, err)
 				}
 			}
 			return nil
@@ -1213,7 +1213,7 @@ func postGroupCensusAndExpectError(t *testing.T, loginToken string, censusID, gr
 	return requestAndExpectError(t, http.MethodPost, loginToken, request, censusGroupPublishURL(censusID, groupID))
 }
 
-func setOrganizationSubscription(t *testing.T, orgAddress common.Address, planID uint64) {
+func setOrganizationSubscription(t *testing.T, orgAddress common.Address, planID string) {
 	t.Helper()
 	err := testDB.SetOrganizationSubscription(orgAddress, &db.OrganizationSubscription{
 		PlanID:          planID,

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -557,14 +557,11 @@ type OrganizationSubscriptionInfo struct {
 // It is the mirror struct of db.Plan.
 // swagger:model SubscriptionPlan
 type SubscriptionPlan struct {
-	// Unique identifier for the plan
-	ID uint64 `json:"id"`
+	// Unique identifier for the plan (its Stripe product ID)
+	ID string `json:"id"`
 
 	// Human-readable name of the plan
 	Name string `json:"name"`
-
-	// Stripe product ID
-	StripeID string `json:"stripeId"`
 
 	// Stripe monthly price ID
 	StripeMonthlyPriceID string `json:"stripeMonthlyPriceId"`
@@ -602,7 +599,6 @@ func SubscriptionPlanFromDB(plan *db.Plan) SubscriptionPlan {
 	return SubscriptionPlan{
 		ID:                   plan.ID,
 		Name:                 plan.Name,
-		StripeID:             plan.StripeID,
 		StripeMonthlyPriceID: plan.StripeMonthlyPriceID,
 		MonthlyPrice:         plan.MonthlyPrice,
 		StripeYearlyPriceID:  plan.StripeYearlyPriceID,
@@ -721,8 +717,8 @@ type SubscriptionFeatures struct {
 // It is the mirror struct of db.OrganizationSubscription.
 // swagger:model SubscriptionDetails
 type SubscriptionDetails struct {
-	// ID of the subscription plan
-	PlanID uint64 `json:"planId"`
+	// ID of the subscription plan (its Stripe product ID)
+	PlanID string `json:"planId"`
 
 	// Date when the subscription started
 	StartDate time.Time `json:"startDate"`
@@ -792,8 +788,8 @@ func SubscriptionUsageFromDB(usage *db.OrganizationCounters) SubscriptionUsage {
 // SubscriptionCheckout represents the details required for a subscription checkout process.
 // swagger:model SubscriptionCheckout
 type SubscriptionCheckout struct {
-	// Plan lookup key
-	LookupKey uint64 `json:"lookupKey"`
+	// Plan lookup key (the plan's Stripe product ID)
+	LookupKey string `json:"lookupKey"`
 
 	// Billing period (e.g., "month" or "year")
 	BillingPeriod string `json:"billingPeriod"`

--- a/api/census_test.go
+++ b/api/census_test.go
@@ -290,9 +290,7 @@ func TestCensusSizeExceedsEmailAllowance(t *testing.T) {
 	// reduce limit of freePlan to allow exactly orgMembers
 	reducedFreePlan := *mockFreePlan
 	reducedFreePlan.Features.TwoFaEmail = len(orgMembers)
-	id, err := testDB.SetPlan(&reducedFreePlan)
-	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, id, qt.Equals, reducedFreePlan.ID)
+	qt.Assert(t, testDB.SetPlan(&reducedFreePlan), qt.IsNil)
 
 	censusID, _, _ := createGroupBasedCensus(t, adminToken, orgAddress, authFields, twoFaEmail,
 		memberIDs(orgMembers)...)
@@ -337,9 +335,7 @@ func TestCensusSizeExceedsSMSAllowance(t *testing.T) {
 	// reduce limit of freePlan to allow exactly orgMembers
 	reducedFreePlan := *mockFreePlan
 	reducedFreePlan.Features.TwoFaSms = len(orgMembers)
-	id, err := testDB.SetPlan(&reducedFreePlan)
-	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, id, qt.Equals, reducedFreePlan.ID)
+	qt.Assert(t, testDB.SetPlan(&reducedFreePlan), qt.IsNil)
 
 	censusID, _, _ := createGroupBasedCensus(t, adminToken, orgAddress, authFields, twoFaPhone,
 		memberIDs(orgMembers)...)

--- a/api/integrator_subscription_test.go
+++ b/api/integrator_subscription_test.go
@@ -24,19 +24,21 @@ func TestIntegratorPlanSubscription(t *testing.T) {
 	integratorAddr := testCreateOrganization(t, token)
 
 	// Seed an integrator-enabled plan; its IntegratorLimits are what the integrator
-	// should inherit. ID 0 => auto-assigned. The plans collection survives
-	// DeleteAllDocuments, so delete this plan on cleanup to keep the seeded set at 3.
+	// should inherit. The ID is the plan's Stripe product ID (SetPlan rejects empty IDs).
+	// The plans collection survives DeleteAllDocuments, so delete this plan on cleanup to
+	// keep the seeded set at 3.
 	const maxManagedOrgs = 2
-	integratorPlanID, err := testDB.SetPlan(&db.Plan{
-		Name:     "Integrator Plan",
-		StripeID: "prod_test_integrator",
+	integratorPlan := &db.Plan{
+		ID:   "prod_test_integrator",
+		Name: "Integrator Plan",
 		IntegratorLimits: db.IntegratorLimits{
 			MaxManagedOrgs:       maxManagedOrgs,
 			MaxManagedProcesses:  5,
 			MaxManagedCensusSize: 5000,
 		},
-	})
-	c.Assert(err, qt.IsNil)
+	}
+	c.Assert(testDB.SetPlan(integratorPlan), qt.IsNil)
+	integratorPlanID := integratorPlan.ID
 	defer func() {
 		if err := testDB.DelPlan(&db.Plan{ID: integratorPlanID}); err != nil {
 			c.Logf("cleanup plan: %v", err)

--- a/api/org_members_test.go
+++ b/api/org_members_test.go
@@ -546,9 +546,7 @@ func TestOrganizationMembers(t *testing.T) {
 	// reduce limit of freePlan to allow exactly orgMembers
 	reducedFreePlan := *mockFreePlan
 	reducedFreePlan.Organization.MaxCensus = len(membersResponse.Members)
-	id, err := testDB.SetPlan(&reducedFreePlan)
-	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, id, qt.Equals, reducedFreePlan.ID)
+	qt.Assert(t, testDB.SetPlan(&reducedFreePlan), qt.IsNil)
 	// Now try adding another member, should fail due to limit
 	overLimitMembers := &apicommon.AddMembersRequest{
 		Members: []apicommon.OrgMember{
@@ -566,9 +564,7 @@ func TestOrganizationMembers(t *testing.T) {
 		"organizations", orgAddress.String(), "members")
 
 	// revert plan changes
-	id, err = testDB.SetPlan(mockFreePlan)
-	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, id, qt.Equals, mockFreePlan.ID)
+	qt.Assert(t, testDB.SetPlan(mockFreePlan), qt.IsNil)
 }
 
 func TestUpsertOrganizationMember(t *testing.T) {

--- a/api/organization_groups_include_all_test.go
+++ b/api/organization_groups_include_all_test.go
@@ -203,9 +203,7 @@ func TestCreateGroupWithLargeNumberOfMembers(t *testing.T) {
 	// Adjust the free plan
 	increasedFreePlan := *mockFreePlan
 	increasedFreePlan.Organization.MaxCensus = len(testMembers)
-	id, err := testDB.SetPlan(&increasedFreePlan)
-	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, id, qt.Equals, increasedFreePlan.ID)
+	qt.Assert(t, testDB.SetPlan(&increasedFreePlan), qt.IsNil)
 
 	// Add members to the organization
 	addedResponse := requestAndParse[apicommon.AddMembersResponse](
@@ -233,7 +231,5 @@ func TestCreateGroupWithLargeNumberOfMembers(t *testing.T) {
 	c.Assert(groupDetails.MemberIDs, qt.HasLen, len(testMembers))
 
 	// revert plan changes
-	id, err = testDB.SetPlan(mockFreePlan)
-	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, id, qt.Equals, mockFreePlan.ID)
+	qt.Assert(t, testDB.SetPlan(mockFreePlan), qt.IsNil)
 }

--- a/api/organization_users_test.go
+++ b/api/organization_users_test.go
@@ -949,10 +949,10 @@ func TestOrganizationUsers(t *testing.T) {
 		org, err := testDB.Organization(orgAddress)
 		c.Assert(err, qt.IsNil)
 
-		// Set the organization's subscription plan to plan ID 1 (which has a user limit of 10)
-		// and set the user counter to the maximum allowed by the plan
-		org.Subscription.PlanID = 1
-		org.Counters.Users = 10 // Max users allowed by plan ID 1
+		// Set the organization's subscription plan to the free plan and set the user counter to
+		// the maximum allowed by the plan, so a further invite must be rejected.
+		org.Subscription.PlanID = mockFreePlan.ID
+		org.Counters.Users = 10
 		err = testDB.SetOrganization(org)
 		c.Assert(err, qt.IsNil)
 

--- a/api/plans.go
+++ b/api/plans.go
@@ -2,25 +2,16 @@ package api
 
 import (
 	"net/http"
-	"strconv"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
 )
 
-// isFreeIntegratorPlan reports whether a plan is the internal free integrator plan: a zero-priced
-// plan that grants managed-org capacity. It is auto-assigned at org creation (see
-// createOrganizationHandler) and must not be listed publicly as a purchasable plan.
-func isFreeIntegratorPlan(p *db.Plan) bool {
-	return p != nil && p.MonthlyPrice == 0 && p.YearlyPrice == 0 && p.IntegratorLimits.MaxManagedOrgs > 0
-}
-
 // plansHandler godoc
 //
 //	@Summary		Get all subscription plans
-//	@Description	Get the list of available subscription plans
+//	@Description	Get the list of publicly available subscription plans
 //	@Tags			plans
 //	@Accept			json
 //	@Produce		json
@@ -34,51 +25,15 @@ func (a *API) plansHandler(w http.ResponseWriter, _ *http.Request) {
 		errors.ErrGenericInternalServerError.Withf("could not get plans: %v", err).Write(w)
 		return
 	}
-	// hide the internal free integrator plan from the public listing (it's auto-assigned, not
-	// purchasable). Paid integrator plans remain visible so the integrator portal can offer them.
+	// only list public plans. Private plans (per-customer custom contracts and the internal
+	// free integrator tier) are hidden from the catalog; a subscriber still sees its own plan
+	// embedded in its subscription payload (see the organization subscription handler).
 	visible := make([]*db.Plan, 0, len(plans))
 	for _, p := range plans {
-		if isFreeIntegratorPlan(p) {
-			continue
+		if p != nil && p.Public {
+			visible = append(visible, p)
 		}
-		visible = append(visible, p)
 	}
 	// send the plans back to the user
 	apicommon.HTTPWriteJSON(w, visible)
-}
-
-// planInfoHandler godoc
-//
-//	@Summary		Get plan information
-//	@Description	Get detailed information about a specific subscription plan
-//	@Tags			plans
-//	@Accept			json
-//	@Produce		json
-//	@Param			planID	path		string	true	"Plan ID"
-//	@Success		200		{object}	db.Plan
-//	@Failure		400		{object}	errors.Error	"Invalid plan ID"
-//	@Failure		404		{object}	errors.Error	"Plan not found"
-//	@Failure		500		{object}	errors.Error	"Internal server error"
-//	@Router			/plans/{planID} [get]
-func (a *API) planInfoHandler(w http.ResponseWriter, r *http.Request) {
-	// get the plan ID from the URL
-	planID := chi.URLParam(r, "planID")
-	// check the the planID is not empty
-	if planID == "" {
-		errors.ErrMalformedURLParam.Withf("planID is required").Write(w)
-		return
-	}
-	// get the plan from the database
-	planIDUint, err := strconv.ParseUint(planID, 10, 64)
-	if err != nil {
-		errors.ErrMalformedURLParam.Withf("invalid planID: %v", err).Write(w)
-		return
-	}
-	plan, err := a.db.Plan(planIDUint)
-	if err != nil {
-		errors.ErrPlanNotFound.Withf("could not get plan: %v", err).Write(w)
-		return
-	}
-	// send the plan back to the user
-	apicommon.HTTPWriteJSON(w, plan)
 }

--- a/api/plans_test.go
+++ b/api/plans_test.go
@@ -6,11 +6,12 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/saas-backend/db"
-	"github.com/vocdoni/saas-backend/errors"
 )
 
-// TestPlansAPI covers the public plansHandler (GET /plans) and planInfoHandler
-// (GET /plans/{planID}) endpoints, including their error cases.
+// TestPlansAPI covers the public plansHandler (GET /plans). Plans are synced from Stripe and
+// keyed by their Stripe product ID; only public plans are listed (private custom/free-integrator
+// plans are hidden). The per-plan GET /plans/{planID} endpoint was removed: a subscriber reads
+// its own plan from its subscription payload instead.
 func TestPlansAPI(t *testing.T) {
 	c := qt.New(t)
 	defer func() {
@@ -19,18 +20,11 @@ func TestPlansAPI(t *testing.T) {
 		}
 	}()
 
-	// List all plans: TestMain seeds exactly 3 mock plans (IDs 1, 2, 3).
+	// List all plans: TestMain seeds exactly 3 public mock plans.
 	plans := requestAndParse[[]*db.Plan](t, http.MethodGet, "", nil, plansEndpoint)
 	c.Assert(plans, qt.HasLen, 3)
-
-	// Get a single plan by ID.
-	plan := requestAndParse[db.Plan](t, http.MethodGet, "", nil, "plans", "1")
-	c.Assert(plan.ID, qt.Equals, uint64(1))
-	c.Assert(plan.Name, qt.Equals, "Free Plan")
-
-	// Unknown plan ID returns 404 ErrPlanNotFound.
-	requestAndAssertError(errors.ErrPlanNotFound, t, http.MethodGet, "", nil, "plans", "999999")
-
-	// Non-numeric plan ID returns 400 ErrMalformedURLParam.
-	requestAndAssertError(errors.ErrMalformedURLParam, t, http.MethodGet, "", nil, "plans", "not-a-number")
+	for _, p := range plans {
+		c.Assert(p.Public, qt.IsTrue)
+		c.Assert(p.ID, qt.Not(qt.Equals), "")
+	}
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -119,10 +119,8 @@ const (
 	organizationAPIKeyEndpoint = "/organizations/{address}/apikeys/{keyID}"
 
 	// subscription routes
-	// GET /subscriptions to get the subscriptions of an organization
+	// GET /plans to get the public catalog of subscription plans
 	plansEndpoint = "/plans"
-	// GET /subscriptions/{planID} to get the plan information
-	planInfoEndpoint = "/plans/{planID}"
 	// POST /subscriptions/webhook to receive the subscription webhook from stripe
 	subscriptionsWebhook = "/subscriptions/webhook"
 	// POST /subscriptions/checkout to create a new subscription

--- a/api/stripe_handlers.go
+++ b/api/stripe_handlers.go
@@ -241,7 +241,7 @@ func (a *API) InitializeStripeService() error {
 
 	// Store plans in database
 	for _, plan := range plans {
-		if _, err := a.db.SetPlan(plan); err != nil {
+		if err := a.db.SetPlan(plan); err != nil {
 			return fmt.Errorf("failed to store plan %s: %w", plan.Name, err)
 		}
 	}

--- a/api/stripe_webhook_test.go
+++ b/api/stripe_webhook_test.go
@@ -141,7 +141,7 @@ func TestStripeWebhook(t *testing.T) {
 
 		// Mock a new subscription
 		{
-			s := mockStripeSubscription(orgAddress, mockEssentialPlan.StripeID)
+			s := mockStripeSubscription(orgAddress, mockEssentialPlan.ID)
 			err := service.HandleEvent(mockStripeEvent(stripeapi.EventTypeCustomerSubscriptionCreated, s))
 			c.Assert(err, qt.IsNil)
 		}
@@ -156,7 +156,7 @@ func TestStripeWebhook(t *testing.T) {
 
 		// Mock a subscription upgrade
 		{
-			s := mockStripeSubscription(orgAddress, mockPremiumPlan.StripeID)
+			s := mockStripeSubscription(orgAddress, mockPremiumPlan.ID)
 			err := service.HandleEvent(mockStripeEvent(stripeapi.EventTypeCustomerSubscriptionUpdated, s))
 			c.Assert(err, qt.IsNil)
 		}
@@ -171,7 +171,7 @@ func TestStripeWebhook(t *testing.T) {
 
 		// Cancel subscription
 		{
-			s := mockStripeSubscription(orgAddress, mockPremiumPlan.StripeID)
+			s := mockStripeSubscription(orgAddress, mockPremiumPlan.ID)
 			s.Status = stripeapi.SubscriptionStatusCanceled
 			s.CanceledAt = time.Now().Unix()
 			err := service.HandleEvent(mockStripeEvent(stripeapi.EventTypeCustomerSubscriptionDeleted, s))
@@ -189,14 +189,14 @@ func TestStripeWebhook(t *testing.T) {
 
 	t.Run("SubscriptionErrors", func(*testing.T) {
 		{
-			s := mockStripeSubscription(orgAddress, mockEssentialPlan.StripeID)
+			s := mockStripeSubscription(orgAddress, mockEssentialPlan.ID)
 			s.Metadata = nil
 			err := service.HandleEvent(mockStripeEvent(stripeapi.EventTypeCustomerSubscriptionCreated, s))
 			c.Assert(err, qt.ErrorMatches, ".* subscription missing address metadata")
 		}
 
 		{
-			s := mockStripeSubscription(orgAddress, mockEssentialPlan.StripeID)
+			s := mockStripeSubscription(orgAddress, mockEssentialPlan.ID)
 			s.Items.Data = nil
 			err := service.HandleEvent(mockStripeEvent(stripeapi.EventTypeCustomerSubscriptionCreated, s))
 			c.Assert(err, qt.ErrorMatches, ".* subscription has no items")
@@ -267,7 +267,7 @@ func TestStripeWebhook(t *testing.T) {
 	// TODO: needs refactoring, can't fetch stripeapi prices with mock API key
 	// t.Run("ProductUpdated", func(*testing.T) {
 	// 	{
-	// 		plan, err := testDB.PlanByStripeID(mockEssentialPlan.StripeID)
+	// 		plan, err := testDB.Plan(mockEssentialPlan.ID)
 	// 		c.Assert(err, qt.IsNil)
 	// 		c.Assert(plan.Name, qt.Equals, mockEssentialPlan.Name)
 	// 		c.Assert(plan.MonthlyPrice, qt.Equals, mockEssentialPlan.MonthlyPrice)
@@ -276,7 +276,7 @@ func TestStripeWebhook(t *testing.T) {
 	// 	}
 
 	// 	{
-	// 		s := mockStripeProduct(mockEssentialPlan.StripeID)
+	// 		s := mockStripeProduct(mockEssentialPlan.ID)
 	// 		s.Name = "New Name"
 	// 		s.DefaultPrice.UnitAmount = mockEssentialPlan.MonthlyPrice + 1000 // TODO: FIX
 	// 		s.Metadata["features"] = `{"personalization": false, "emailReminder": true, "smsNotification": false}`
@@ -285,7 +285,7 @@ func TestStripeWebhook(t *testing.T) {
 	// 	}
 
 	// 	{
-	// 		plan, err := testDB.PlanByStripeID(mockEssentialPlan.StripeID)
+	// 		plan, err := testDB.Plan(mockEssentialPlan.ID)
 	// 		c.Assert(err, qt.IsNil)
 	// 		c.Assert(plan.Name, qt.Equals, "New Name")
 	// 		c.Assert(plan.MonthlyPrice, qt.Equals, mockEssentialPlan.MonthlyPrice+1000) // TODO: FIX
@@ -296,7 +296,7 @@ func TestStripeWebhook(t *testing.T) {
 
 	// t.Run("ProductErrors", func(*testing.T) {
 	// 	{
-	// 		s := mockStripeProduct(mockEssentialPlan.StripeID)
+	// 		s := mockStripeProduct(mockEssentialPlan.ID)
 	// 		s.Metadata["features"] = `invalid-json`
 	// 		err := service.HandleEvent(mockStripeEvent(stripeapi.EventTypeProductUpdated, s))
 	// 		c.Assert(err, qt.ErrorMatches, ".* error parsing plan metadata JSON.*")

--- a/db/migrations_test.go
+++ b/db/migrations_test.go
@@ -79,17 +79,18 @@ func TestMigrations(t *testing.T) {
 				panic(fmt.Sprintf("failed to create new MongoDB connection: %v", err))
 			}
 
-			// Plans should be populated
+			// Plans are no longer seeded by migrations: they are synced from Stripe at runtime
+			// (the single source of truth). After migrations alone the collection is empty.
 			{
 				plans, err := testDB.Plans()
 				c.Assert(err, qt.IsNil)
-				c.Assert(plans, qt.Not(qt.HasLen), 0)
+				c.Assert(plans, qt.HasLen, 0)
 			}
 
 			err = testDB.RunMigrationsDown(len(migrations.SortedByVersionAsc()))
 			c.Assert(err, qt.IsNil)
 
-			// Plans should now be empty
+			// Plans should still be empty
 			{
 				plans, err := testDB.Plans()
 				c.Assert(err, qt.IsNil)
@@ -105,11 +106,11 @@ func TestMigrations(t *testing.T) {
 				panic(fmt.Sprintf("failed to create new MongoDB connection: %v", err))
 			}
 
-			// Plans should be populated again
+			// Plans remain empty after re-running migrations (sourced from Stripe at runtime).
 			{
 				plans, err := testDB.Plans()
 				c.Assert(err, qt.IsNil)
-				c.Assert(plans, qt.Not(qt.HasLen), 0)
+				c.Assert(plans, qt.HasLen, 0)
 			}
 
 			testDB.Close()

--- a/db/organizations.go
+++ b/db/organizations.go
@@ -466,7 +466,7 @@ func (ms *MongoStorage) fetchOrganizationAndPlan(orgAddress common.Address) (*Or
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get organization: %v", err)
 	}
-	if org.Subscription.PlanID == 0 {
+	if org.Subscription.PlanID == "" {
 		return nil, nil, fmt.Errorf("organization has no subscription plan")
 	}
 	plan, err := ms.Plan(org.Subscription.PlanID)

--- a/db/organizations_test.go
+++ b/db/organizations_test.go
@@ -202,20 +202,20 @@ func TestOrganizations(t *testing.T) {
 		active := true
 		stripeID := "stripeID"
 		orgSubscription := &OrganizationSubscription{
-			PlanID:    100,
+			PlanID:    "prod_nonexistent",
 			StartDate: startDate,
 			Active:    true,
 		}
 		// using a non existing subscription should fail
 		c.Assert(testDB.SetOrganizationSubscription(address, orgSubscription), qt.IsNotNil)
-		subscriptionID, err := testDB.SetPlan(&Plan{
-			Name:     subscriptionName,
-			StripeID: stripeID,
-		})
-		if err != nil {
+		plan := &Plan{
+			ID:   stripeID,
+			Name: subscriptionName,
+		}
+		if err := testDB.SetPlan(plan); err != nil {
 			t.Error(err)
 		}
-		orgSubscription.PlanID = subscriptionID
+		orgSubscription.PlanID = plan.ID
 		c.Assert(testDB.SetOrganizationSubscription(address, orgSubscription), qt.IsNil)
 		// retrieve the organization and check the subscription details
 		org, err := testDB.Organization(address)

--- a/db/plans.go
+++ b/db/plans.go
@@ -10,81 +10,35 @@ import (
 	"go.vocdoni.io/dvote/log"
 )
 
-// nextPlanID internal method returns the next available subsbscription ID. If an error
-// occurs, it returns the error. This method must be called with the keysLock
-// held.
-func (ms *MongoStorage) nextPlanID(ctx context.Context) (uint64, error) {
-	var plan Plan
-	opts := options.FindOne().SetSort(bson.D{{Key: "_id", Value: -1}})
-	if err := ms.plans.FindOne(ctx, bson.M{}, opts).Decode(&plan); err != nil {
-		if err == mongo.ErrNoDocuments {
-			return 1, nil
-		}
-		return 0, err
+// SetPlan creates or replaces the plan, keyed by its Stripe product ID (plan.ID). Plans are
+// synced from Stripe rather than authored locally: the caller always holds the complete plan,
+// so the whole document is replaced (a full ReplaceOne upsert, not a partial update). This
+// matters because zero-valued fields are meaningful here — e.g. a free plan's monthlyPrice/
+// yearlyPrice of 0 must be persisted so selectors like FreeIntegratorPlan can match on them.
+// An empty ID is rejected.
+func (ms *MongoStorage) SetPlan(plan *Plan) error {
+	if plan.ID == "" {
+		return ErrInvalidData
 	}
-	return plan.ID + 1, nil
-}
-
-// SetPlan method creates or updates the plan in the database.
-// If the plan already exists, it updates the fields that have changed.
-func (ms *MongoStorage) SetPlan(plan *Plan) (uint64, error) {
 	ms.keysLock.Lock()
 	defer ms.keysLock.Unlock()
 	// create a context with a timeout
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
-	nextID, err := ms.nextPlanID(ctx)
-	if err != nil {
-		return 0, err
+	if _, err := ms.plans.ReplaceOne(ctx, bson.M{"_id": plan.ID}, plan, options.Replace().SetUpsert(true)); err != nil {
+		return err
 	}
-	if plan.ID >= nextID {
-		return 0, ErrInvalidData
-	}
-	if plan.ID == 0 {
-		plan.ID = nextID
-		if _, err := ms.plans.InsertOne(ctx, plan); err != nil {
-			return 0, err
-		}
-		return plan.ID, nil
-	}
-	updateDoc, err := dynamicUpdateDocument(plan, []string{"freeTrialDays"})
-	if err != nil {
-		return 0, err
-	}
-	// set upsert to true to create the document if it doesn't exist
-	if _, err := ms.plans.UpdateOne(ctx, bson.M{"_id": plan.ID}, updateDoc); err != nil {
-		return 0, err
-	}
-	return plan.ID, nil
+	return nil
 }
 
-// Plan method returns the plan with the given ID. If the
+// Plan method returns the plan with the given ID (its Stripe product ID). If the
 // plan doesn't exist, it returns the specific error.
-func (ms *MongoStorage) Plan(planID uint64) (*Plan, error) {
+func (ms *MongoStorage) Plan(planID string) (*Plan, error) {
 	// create a context with a timeout
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 	// find the plan in the database
 	filter := bson.M{"_id": planID}
-	plan := &Plan{}
-	err := ms.plans.FindOne(ctx, filter).Decode(plan)
-	if err != nil {
-		if err == mongo.ErrNoDocuments {
-			return nil, ErrNotFound // Plan not found
-		}
-		return nil, errors.New("failed to get plan")
-	}
-	return plan, nil
-}
-
-// PlanByStripeID method returns the plan with the given stripe ID. If the
-// plan doesn't exist, it returns the specific error.
-func (ms *MongoStorage) PlanByStripeID(stripeID string) (*Plan, error) {
-	// create a context with a timeout
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-	defer cancel()
-	// find the plan in the database
-	filter := bson.M{"stripeID": stripeID}
 	plan := &Plan{}
 	err := ms.plans.FindOne(ctx, filter).Decode(plan)
 	if err != nil {

--- a/db/plans_test.go
+++ b/db/plans_test.go
@@ -13,31 +13,31 @@ func TestPlans(t *testing.T) {
 		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
 
 		plan := &Plan{
-			Name:     "Test Plan",
-			StripeID: "stripeID",
+			ID:   "prod_test",
+			Name: "Test Plan",
 		}
-		_, err := testDB.SetPlan(plan)
-		c.Assert(err, qt.IsNil)
+		c.Assert(testDB.SetPlan(plan), qt.IsNil)
+
+		// a plan without an ID is rejected
+		c.Assert(testDB.SetPlan(&Plan{Name: "No ID"}), qt.Equals, ErrInvalidData)
 	})
 
 	t.Run("GetPlan", func(_ *testing.T) {
 		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
 
-		planID := uint64(123)
 		// Test not found plan
-		plan, err := testDB.Plan(planID)
+		plan, err := testDB.Plan("prod_missing")
 		c.Assert(err, qt.Equals, ErrNotFound)
 		c.Assert(plan, qt.IsNil)
 
 		plan = &Plan{
-			Name:     "Test Plan",
-			StripeID: "stripeID",
+			ID:   "prod_test",
+			Name: "Test Plan",
 		}
-		planID, err = testDB.SetPlan(plan)
-		c.Assert(err, qt.IsNil)
+		c.Assert(testDB.SetPlan(plan), qt.IsNil)
 
 		// Test found plan
-		planDB, err := testDB.Plan(planID)
+		planDB, err := testDB.Plan(plan.ID)
 		c.Assert(err, qt.IsNil)
 		c.Assert(planDB, qt.Not(qt.IsNil))
 		c.Assert(planDB.ID, qt.Equals, plan.ID)
@@ -48,44 +48,40 @@ func TestPlans(t *testing.T) {
 
 		// Create a new plan and delete it
 		plan := &Plan{
-			Name:     "Test Plan",
-			StripeID: "stripeID",
+			ID:   "prod_test",
+			Name: "Test Plan",
 		}
-		id, err := testDB.SetPlan(plan)
-		c.Assert(err, qt.IsNil)
+		c.Assert(testDB.SetPlan(plan), qt.IsNil)
 
-		err = testDB.DelPlan(plan)
-		c.Assert(err, qt.IsNil)
+		c.Assert(testDB.DelPlan(plan), qt.IsNil)
 
 		// Test not found plan
-		_, err = testDB.Plan(id)
+		_, err := testDB.Plan(plan.ID)
 		c.Assert(err, qt.Equals, ErrNotFound)
 	})
 
 	t.Run("FreeIntegratorPlan", func(_ *testing.T) {
-		// Note: DeleteAllDocuments intentionally preserves the `plans` collection, and migration
-		// 0012 seeds a free integrator plan, so we don't assume an empty slate here. We seed an
-		// explicit one too and assert the selector returns a zero-priced, managed-org-granting plan
-		// (robust to which matching plan FindOne returns).
+		// FreeIntegratorPlan selects a zero-priced plan that grants managed-org capacity. We seed
+		// an explicit one and assert the selector returns it (robust to which matching plan FindOne
+		// returns), plus non-matching plans that must never be selected.
 		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
 
 		// non-matching plans must never be selected
-		_, err := testDB.SetPlan(&Plan{
+		c.Assert(testDB.SetPlan(&Plan{
+			ID:               "prod_paid_integrator",
 			Name:             "Paid Integrator",
 			MonthlyPrice:     1000,
 			YearlyPrice:      10000,
 			IntegratorLimits: IntegratorLimits{MaxManagedOrgs: 10},
-		})
-		c.Assert(err, qt.IsNil)
-		_, err = testDB.SetPlan(&Plan{Name: "Free Basic"})
-		c.Assert(err, qt.IsNil)
+		}), qt.IsNil)
+		c.Assert(testDB.SetPlan(&Plan{ID: "prod_free_basic", Name: "Free Basic"}), qt.IsNil)
 
 		// a free integrator plan: zero-priced and grants managed-org capacity
-		_, err = testDB.SetPlan(&Plan{
+		c.Assert(testDB.SetPlan(&Plan{
+			ID:               "prod_free_integrator",
 			Name:             "Free Integrator",
 			IntegratorLimits: IntegratorLimits{MaxManagedOrgs: 1, MaxManagedProcesses: 5, MaxManagedCensusSize: 100},
-		})
-		c.Assert(err, qt.IsNil)
+		}), qt.IsNil)
 
 		plan, err := testDB.FreeIntegratorPlan()
 		c.Assert(err, qt.IsNil)

--- a/db/types.go
+++ b/db/types.go
@@ -141,20 +141,26 @@ type Features struct {
 	PhoneSupport    bool `json:"phoneSupport" bson:"phoneSupport"`
 }
 
+// Plan is keyed by its Stripe product ID. Plans are not authored locally: they are synced
+// from Stripe, which is the single source of truth for plan definitions (see
+// stripe.Service.GetPlansFromStripe).
 type Plan struct {
-	ID                   uint64           `json:"id" bson:"_id"`
-	Name                 string           `json:"name" bson:"name"`
-	StripeID             string           `json:"stripeID" bson:"stripeID"`
-	StripeMonthlyPriceID string           `json:"stripeMonthlyPriceID" bson:"stripeMonthlyPriceID"`
-	MonthlyPrice         int64            `json:"monthlyPrice" bson:"monthlyPrice"`
-	StripeYearlyPriceID  string           `json:"stripeYearlyPriceID" bson:"stripeYearlyPriceID"`
-	YearlyPrice          int64            `json:"yearlyPrice" bson:"yearlyPrice"`
-	Default              bool             `json:"default" bson:"default"`
-	FreeTrialDays        int              `json:"freeTrialDays" bson:"freeTrialDays"`
-	Organization         PlanLimits       `json:"organization" bson:"organization"`
-	VotingTypes          VotingTypes      `json:"votingTypes" bson:"votingTypes"`
-	Features             Features         `json:"features" bson:"features"`
-	IntegratorLimits     IntegratorLimits `json:"integratorLimits" bson:"integratorLimits"`
+	ID                   string `json:"id" bson:"_id"`
+	Name                 string `json:"name" bson:"name"`
+	StripeMonthlyPriceID string `json:"stripeMonthlyPriceID" bson:"stripeMonthlyPriceID"`
+	MonthlyPrice         int64  `json:"monthlyPrice" bson:"monthlyPrice"`
+	StripeYearlyPriceID  string `json:"stripeYearlyPriceID" bson:"stripeYearlyPriceID"`
+	YearlyPrice          int64  `json:"yearlyPrice" bson:"yearlyPrice"`
+	Default              bool   `json:"default" bson:"default"`
+	// Public reports whether the plan is listed on the public /plans catalog. Private plans
+	// (custom per-customer contracts and the internal free integrator tier) are hidden from
+	// the listing but remain visible to their own subscriber via the subscription payload.
+	Public           bool             `json:"public" bson:"public"`
+	FreeTrialDays    int              `json:"freeTrialDays" bson:"freeTrialDays"`
+	Organization     PlanLimits       `json:"organization" bson:"organization"`
+	VotingTypes      VotingTypes      `json:"votingTypes" bson:"votingTypes"`
+	Features         Features         `json:"features" bson:"features"`
+	IntegratorLimits IntegratorLimits `json:"integratorLimits" bson:"integratorLimits"`
 }
 
 type BillingPeriod string
@@ -167,7 +173,7 @@ const (
 )
 
 type OrganizationSubscription struct {
-	PlanID               uint64        `json:"planID" bson:"planID"`
+	PlanID               string        `json:"planID" bson:"planID"`
 	StripeSubscriptionID string        `json:"stripeSubscriptionID" bson:"stripeSubscriptionID"`
 	BillingPeriod        BillingPeriod `json:"billingPeriod" bson:"billingPeriod"`
 	StartDate            time.Time     `json:"startDate" bson:"startDate"`

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1153,8 +1153,8 @@ definitions:
         description: Locale for the checkout page
         type: string
       lookupKey:
-        description: Plan lookup key
-        type: integer
+        description: Plan lookup key (the plan's Stripe product ID)
+        type: string
       returnURL:
         description: URL to return to after checkout
         type: string
@@ -1171,8 +1171,8 @@ definitions:
         description: Date of the last payment
         type: string
       planId:
-        description: ID of the subscription plan
-        type: integer
+        description: ID of the subscription plan (its Stripe product ID)
+        type: string
       renewalDate:
         description: Date when the subscription will renew
         type: string
@@ -1235,8 +1235,8 @@ definitions:
         - $ref: '#/definitions/apicommon.SubscriptionFeatures'
         description: Features available in this plan
       id:
-        description: Unique identifier for the plan
-        type: integer
+        description: Unique identifier for the plan (its Stripe product ID)
+        type: string
       integratorLimits:
         allOf:
         - $ref: '#/definitions/apicommon.SubscriptionIntegratorLimits'
@@ -1252,9 +1252,6 @@ definitions:
         allOf:
         - $ref: '#/definitions/apicommon.SubscriptionPlanLimits'
         description: Organization limits for this plan
-      stripeId:
-        description: Stripe product ID
-        type: string
       stripeMonthlyPriceId:
         description: Stripe monthly price ID
         type: string
@@ -1695,7 +1692,7 @@ definitions:
       freeTrialDays:
         type: integer
       id:
-        type: integer
+        type: string
       integratorLimits:
         $ref: '#/definitions/db.IntegratorLimits'
       monthlyPrice:
@@ -1704,8 +1701,12 @@ definitions:
         type: string
       organization:
         $ref: '#/definitions/db.PlanLimits'
-      stripeID:
-        type: string
+      public:
+        description: |-
+          Public reports whether the plan is listed on the public /plans catalog. Private plans
+          (custom per-customer contracts and the internal free integrator tier) are hidden from
+          the listing but remain visible to their own subscriber via the subscription payload.
+        type: boolean
       stripeMonthlyPriceID:
         type: string
       stripeYearlyPriceID:
@@ -4229,7 +4230,7 @@ paths:
     get:
       consumes:
       - application/json
-      description: Get the list of available subscription plans
+      description: Get the list of publicly available subscription plans
       produces:
       - application/json
       responses:
@@ -4244,39 +4245,6 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
       summary: Get all subscription plans
-      tags:
-      - plans
-  /plans/{planID}:
-    get:
-      consumes:
-      - application/json
-      description: Get detailed information about a specific subscription plan
-      parameters:
-      - description: Plan ID
-        in: path
-        name: planID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/db.Plan'
-        "400":
-          description: Invalid plan ID
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "404":
-          description: Plan not found
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "500":
-          description: Internal server error
-          schema:
-            $ref: '#/definitions/errors.Error'
-      summary: Get plan information
       tags:
       - plans
   /process:

--- a/migrations/0014_plan_ids_to_stripe_product_ids.go
+++ b/migrations/0014_plan_ids_to_stripe_product_ids.go
@@ -1,0 +1,162 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.vocdoni.io/dvote/log"
+)
+
+func init() {
+	AddMigration(14, "plan_ids_to_stripe_product_ids", upPlanIDsToStripeProductIDs, downPlanIDsToStripeProductIDs)
+}
+
+// defaultFreeIntegratorProductID is the Stripe product backing the free integrator tier in the
+// vocdoni sandbox. It can be overridden per environment via STRIPE_FREE_INTEGRATOR_PRODUCT_ID
+// (e.g. for production, where the product ID differs). It is only used to remap organizations
+// that were on the old Mongo-seeded free integrator plan (see migration 0012).
+const defaultFreeIntegratorProductID = "prod_UkaJ8hyy6juz5e"
+
+// oldFreeIntegratorPlanID is the sentinel integer _id that migration 0012 used for the
+// Mongo-seeded free integrator plan.
+const oldFreeIntegratorPlanID int64 = 9001
+
+// planIDMigrationOrgSubscription is the minimal projection of an organization's subscription
+// needed to rewrite its plan ID. PlanID is decoded as `any` because it may be either the old
+// integer value or, on an idempotent re-run, the new string value.
+type planIDMigrationOrgSubscription struct {
+	PlanID any `bson:"planID"`
+}
+
+// planIDMigrationOrg is the minimal projection of an organization needed by this migration.
+type planIDMigrationOrg struct {
+	ID           any                            `bson:"_id"`
+	Subscription planIDMigrationOrgSubscription `bson:"subscription"`
+}
+
+// planIDMigrationPlan is the minimal projection of a plan document used to build the
+// old-integer-ID -> Stripe product ID map.
+type planIDMigrationPlan struct {
+	ID       any    `bson:"_id"`
+	StripeID string `bson:"stripeID"`
+}
+
+// upPlanIDsToStripeProductIDs migrates plan identity from synthetic integer IDs to Stripe
+// product IDs (strings), making Stripe the single source of truth for plan definitions.
+//
+// It rewrites every organization's subscription.planID from its old integer value to the
+// corresponding Stripe product ID, then drops the now-stale integer-keyed plan documents. The
+// plans collection is repopulated with string-keyed documents by the Stripe sync that runs at
+// startup (stripe.Service.GetPlansFromStripe), so no plan documents are recreated here.
+func upPlanIDsToStripeProductIDs(ctx context.Context, database *mongo.Database) error {
+	plansColl := database.Collection("plans")
+	orgsColl := database.Collection("organizations")
+
+	// Build the old-integer-ID -> Stripe product ID map from the existing plan documents. A
+	// long-running database has the real stripeID on each synced plan; a fresh database only has
+	// stubs (no stripeID) but also has no subscribed organizations, so the map is simply empty.
+	idMap := map[int64]string{}
+	cursor, err := plansColl.Find(ctx, bson.D{})
+	if err != nil {
+		return fmt.Errorf("failed to list plans: %w", err)
+	}
+	for cursor.Next(ctx) {
+		var p planIDMigrationPlan
+		if err := cursor.Decode(&p); err != nil {
+			_ = cursor.Close(ctx)
+			return fmt.Errorf("failed to decode plan: %w", err)
+		}
+		id, ok := toInt64(p.ID)
+		if !ok || p.StripeID == "" {
+			continue
+		}
+		idMap[id] = p.StripeID
+	}
+	if err := cursor.Err(); err != nil {
+		_ = cursor.Close(ctx)
+		return fmt.Errorf("failed to iterate plans: %w", err)
+	}
+	if err := cursor.Close(ctx); err != nil {
+		return fmt.Errorf("failed to close plans cursor: %w", err)
+	}
+
+	// Map the old Mongo-seeded free integrator plan to its Stripe product (env-overridable).
+	freeProductID := os.Getenv("STRIPE_FREE_INTEGRATOR_PRODUCT_ID")
+	if freeProductID == "" {
+		freeProductID = defaultFreeIntegratorProductID
+	}
+	if freeProductID != "" {
+		idMap[oldFreeIntegratorPlanID] = freeProductID
+	}
+
+	// Rewrite each organization's subscription.planID to the new string value.
+	orgCursor, err := orgsColl.Find(ctx, bson.D{})
+	if err != nil {
+		return fmt.Errorf("failed to list organizations: %w", err)
+	}
+	defer func() { _ = orgCursor.Close(ctx) }()
+
+	for orgCursor.Next(ctx) {
+		var org planIDMigrationOrg
+		if err := orgCursor.Decode(&org); err != nil {
+			return fmt.Errorf("failed to decode organization: %w", err)
+		}
+
+		// Already a string (idempotent re-run) — nothing to do.
+		if _, isString := org.Subscription.PlanID.(string); isString {
+			continue
+		}
+
+		newPlanID := ""
+		if oldID, ok := toInt64(org.Subscription.PlanID); ok && oldID != 0 {
+			mapped, found := idMap[oldID]
+			if !found {
+				log.Warnw("migration 0014: organization subscription references an unknown plan; clearing it",
+					"org", fmt.Sprintf("%v", org.ID), "oldPlanID", oldID)
+			}
+			newPlanID = mapped
+		}
+
+		if _, err := orgsColl.UpdateOne(ctx,
+			bson.M{"_id": org.ID},
+			bson.M{"$set": bson.M{"subscription.planID": newPlanID}},
+		); err != nil {
+			return fmt.Errorf("failed to update organization %v subscription plan: %w", org.ID, err)
+		}
+	}
+	if err := orgCursor.Err(); err != nil {
+		return err
+	}
+
+	// Drop the stale integer-keyed plan documents (the initial stubs and the seeded free
+	// integrator plan). String-keyed plans are (re)created from Stripe at startup.
+	if _, err := plansColl.DeleteMany(ctx, bson.M{"_id": bson.M{"$type": []string{"int", "long"}}}); err != nil {
+		return fmt.Errorf("failed to delete integer-keyed plans: %w", err)
+	}
+
+	return nil
+}
+
+// downPlanIDsToStripeProductIDs is a no-op: this is a forward-only data migration. The original
+// integer plan IDs are not recoverable from the string product IDs, and the plans collection is
+// rebuilt from Stripe at startup regardless.
+func downPlanIDsToStripeProductIDs(_ context.Context, _ *mongo.Database) error {
+	return nil
+}
+
+// toInt64 converts a BSON numeric value (int32 or int64) to int64.
+func toInt64(v any) (int64, bool) {
+	switch n := v.(type) {
+	case int32:
+		return int64(n), true
+	case int64:
+		return n, true
+	case int:
+		return int64(n), true
+	default:
+		return 0, false
+	}
+}

--- a/scripts/defaultplan/main.go
+++ b/scripts/defaultplan/main.go
@@ -47,8 +47,12 @@ func main() {
 	}
 
 	plan := &db.Plan{
+		// Plans are keyed by their Stripe product ID; this local-dev plan has no Stripe
+		// product, so it uses a stable sentinel ID. It is listed publicly as the default plan.
+		ID:           "local-dev",
 		Name:         "Local Dev",
 		Default:      true,
+		Public:       true,
 		MonthlyPrice: 0,
 		YearlyPrice:  0,
 		Organization: db.PlanLimits{
@@ -83,9 +87,8 @@ func main() {
 		},
 	}
 
-	id, err := storage.SetPlan(plan)
-	if err != nil {
+	if err := storage.SetPlan(plan); err != nil {
 		log.Fatalf("failed to create default plan: %v", err)
 	}
-	log.Infow("default plan created", "id", id)
+	log.Infow("default plan created", "id", plan.ID)
 }

--- a/stripe/client.go
+++ b/stripe/client.go
@@ -100,6 +100,28 @@ func (*Client) GetProduct(productID string) (*stripeapi.Product, error) {
 	return product, nil
 }
 
+// ListProducts retrieves all active products, with each product's default price expanded so
+// callers can inspect default-price metadata (e.g. the default-plan marker).
+func (*Client) ListProducts() ([]stripeapi.Product, error) {
+	var products []stripeapi.Product
+
+	params := &stripeapi.ProductListParams{
+		Active: stripeapi.Bool(true),
+	}
+	params.AddExpand("data.default_price")
+	params.Filters.AddFilter("limit", "", "100")
+
+	i := stripeproduct.List(params)
+	for i.Next() {
+		products = append(products, *i.Product())
+	}
+	if err := i.Err(); err != nil {
+		return nil, errors.ErrStripeError.Withf("failed to list products: %v", err)
+	}
+
+	return products, nil
+}
+
 // GetPrice retrieves a price by lookup key
 func (*Client) GetPrice(lookupKey string) (*stripeapi.Price, error) {
 	params := &stripeapi.PriceSearchParams{

--- a/stripe/config.go
+++ b/stripe/config.go
@@ -5,29 +5,14 @@ import (
 	"os"
 )
 
-// PlanType represents the different subscription plan types
-type PlanType int
-
-const PlanCount = 5
-
-const (
-	PlanTypeNone = iota
-	PlanTypeEssential
-	PlanTypePremium
-	PlanTypeFree
-	PlanTypeCustom
-)
-
-// PlanConfig holds Stripe product and price configuration
-type PlanConfig struct {
-	ProductID string `yaml:"product_id" json:"product_id"`
-}
-
-// Config holds the complete Stripe configuration
+// Config holds the complete Stripe configuration.
+//
+// Plans are no longer enumerated here: the service discovers them dynamically from Stripe
+// (the single source of truth) by listing active products that carry our plan metadata. See
+// stripe.Service.GetPlansFromStripe.
 type Config struct {
-	APIKey        string                `yaml:"api_key" json:"api_key"`
-	WebhookSecret string                `yaml:"webhook_secret" json:"webhook_secret"`
-	Plans         [PlanCount]PlanConfig `yaml:"plans" json:"plans"`
+	APIKey        string `yaml:"api_key" json:"api_key"`
+	WebhookSecret string `yaml:"webhook_secret" json:"webhook_secret"`
 }
 
 // NewConfig creates a new Stripe configuration from environment variables
@@ -42,33 +27,8 @@ func NewConfig() (*Config, error) {
 		return nil, fmt.Errorf("VOCDONI_STRIPEWEBHOOKSECRET environment variable is required")
 	}
 
-	// Default plan configuration - can be overridden via environment
-	plans := [PlanCount]PlanConfig{
-		PlanTypeEssential: {
-			ProductID: getEnvOrDefault("STRIPE_ESSENTIAL_PRODUCT_ID", "prod_T7otvdbt7MpK8f"),
-		},
-		PlanTypePremium: {
-			ProductID: getEnvOrDefault("STRIPE_PREMIUM_PRODUCT_ID", "prod_T7p24o8zSFM26b"),
-		},
-		PlanTypeFree: {
-			ProductID: getEnvOrDefault("STRIPE_FREE_PRODUCT_ID", "prod_T7p0GQJLxXDxZT"),
-		},
-		PlanTypeCustom: {
-			ProductID: getEnvOrDefault("STRIPE_CUSTOM_PRODUCT_ID", "prod_T7pH46AnyE6ydC"),
-		},
-	}
-
 	return &Config{
 		APIKey:        apiKey,
 		WebhookSecret: webhookSecret,
-		Plans:         plans,
 	}, nil
-}
-
-// getEnvOrDefault returns the environment variable value or a default value
-func getEnvOrDefault(key, defaultValue string) string {
-	if value := os.Getenv(key); value != "" {
-		return value
-	}
-	return defaultValue
 }

--- a/stripe/service.go
+++ b/stripe/service.go
@@ -12,6 +12,7 @@ import (
 	stripeapi "github.com/stripe/stripe-go/v82"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
+	"go.vocdoni.io/dvote/log"
 )
 
 // Service provides the main business logic for Stripe operations
@@ -42,12 +43,12 @@ func NewService(config *Config, database *db.MongoStorage) (*Service, error) {
 
 // CreateCheckoutSessionWithLookupKey creates a new checkout session by resolving the lookup key to get the plan
 func (s *Service) CreateCheckoutSessionWithLookupKey(
-	lookupKey uint64, billingPeriod, returnURL string, orgAddress common.Address, locale string,
+	lookupKey string, billingPeriod, returnURL string, orgAddress common.Address, locale string,
 ) (*stripeapi.CheckoutSession, error) {
-	// Resolve the lookup key to get the plan
+	// Resolve the lookup key (the plan's Stripe product ID) to get the plan
 	plan, err := s.db.Plan(lookupKey)
 	if err != nil {
-		return nil, errors.ErrStripeError.Withf("plan with lookup key %d not found: %v", lookupKey, err)
+		return nil, errors.ErrStripeError.Withf("plan with lookup key %s not found: %v", lookupKey, err)
 	}
 
 	org, err := s.db.Organization(orgAddress)
@@ -77,7 +78,7 @@ func (s *Service) CreateCheckoutSessionWithLookupKey(
 	} else if billingPeriod == string(db.BillingPeriodAnnual) && plan.StripeYearlyPriceID != "" {
 		params.PriceID = plan.StripeYearlyPriceID
 	} else {
-		return nil, errors.ErrStripeError.Withf("invalid billing period %s for plan %d", billingPeriod, plan.ID)
+		return nil, errors.ErrStripeError.Withf("invalid billing period %s for plan %s", billingPeriod, plan.ID)
 	}
 
 	return s.client.CreateCheckoutSession(params)
@@ -98,38 +99,64 @@ func (s *Service) CreatePortalSession(customerEmail string) (*stripeapi.BillingP
 	return s.client.CreatePortalSession(customerEmail)
 }
 
-// GetPlansFromStripe retrieves plans from Stripe and converts them to database format
-func (s *Service) GetPlansFromStripe() ([]*db.Plan, error) {
-	var plans []*db.Plan
+// planProductMarkerKeys are the metadata keys every vocdoni plan product carries. A Stripe
+// product is treated as one of our plans only if it defines all of them. This is the marker
+// that lets the service discover plans dynamically, without a hardcoded product allowlist.
+var planProductMarkerKeys = []string{"organization", "votingTypes", "features"}
 
-	for i, p := range s.config.Plans {
-		if p.ProductID == "" {
+// isPlanProduct reports whether a Stripe product is one of our plan products, by checking it
+// carries the full plan-metadata marker.
+func isPlanProduct(product *stripeapi.Product) bool {
+	for _, k := range planProductMarkerKeys {
+		if _, ok := product.Metadata[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// GetPlansFromStripe discovers plans from Stripe and converts them to database format.
+//
+// Stripe is the single source of truth: every active product carrying our plan-metadata
+// marker becomes a plan, so adding a plan (including a per-customer "custom" plan) is just a
+// matter of creating the product in Stripe — no code or config change. A product that fails
+// to parse is skipped and logged rather than aborting the whole sync, so one malformed
+// product can never take down the entire catalog.
+func (s *Service) GetPlansFromStripe() ([]*db.Plan, error) {
+	products, err := s.client.ListProducts()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list products: %w", err)
+	}
+
+	var plans []*db.Plan
+	for i := range products {
+		product := &products[i]
+		if !isPlanProduct(product) {
 			continue
 		}
-
-		product, err := s.client.GetProduct(p.ProductID)
+		prices, err := s.client.GetProductPrices(product.ID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get product %s: %w", p.ProductID, err)
+			log.Warnw("skipping plan product: failed to get prices",
+				"product", product.ID, "name", product.Name, "error", err.Error())
+			continue
 		}
-
-		prices, err := s.client.GetProductPrices(p.ProductID)
-		if err != nil || len(prices) < 2 {
-			return nil, fmt.Errorf("failed to get prices for product %s: %w", p.ProductID, err)
-		}
-
-		plan, err := processProductToPlan(uint64(i), product, prices)
+		plan, err := processProductToPlan(product, prices)
 		if err != nil {
-			return nil, fmt.Errorf("failed to process product %s: %w", p.ProductID, err)
+			log.Warnw("skipping plan product: failed to process",
+				"product", product.ID, "name", product.Name, "error", err.Error())
+			continue
 		}
-
 		plans = append(plans, plan)
 	}
 
 	return plans, nil
 }
 
-// processProductToPlan converts a Stripe product to a database plan
-func processProductToPlan(planID uint64, product *stripeapi.Product, prices []stripeapi.Price) (*db.Plan, error) {
+// processProductToPlan converts a Stripe product to a database plan. The plan is keyed by the
+// Stripe product ID. Missing recurring prices are tolerated (a free, non-purchasable plan such
+// as the free integrator tier has none); the checkout path validates price availability per
+// billing period at purchase time.
+func processProductToPlan(product *stripeapi.Product, prices []stripeapi.Price) (*db.Plan, error) {
 	organizationData, err := extractPlanMetadata[db.PlanLimits](product.Metadata["organization"])
 	if err != nil {
 		return nil, err
@@ -156,10 +183,10 @@ func processProductToPlan(planID uint64, product *stripeapi.Product, prices []st
 	}
 
 	plan := &db.Plan{
-		ID:               planID,
+		ID:               product.ID,
 		Name:             product.Name,
-		StripeID:         product.ID,
 		Default:          isDefaultPlan(product),
+		Public:           isPublicPlan(product),
 		Organization:     organizationData,
 		VotingTypes:      votingTypesData,
 		Features:         featuresData,
@@ -168,6 +195,10 @@ func processProductToPlan(planID uint64, product *stripeapi.Product, prices []st
 	}
 
 	for _, price := range prices {
+		if price.Recurring == nil {
+			// Ignore one-time prices
+			continue
+		}
 		switch price.Recurring.Interval {
 		case stripeapi.PriceRecurringIntervalYear:
 			plan.StripeYearlyPriceID = price.ID
@@ -181,11 +212,8 @@ func processProductToPlan(planID uint64, product *stripeapi.Product, prices []st
 			plan.StripeMonthlyPriceID = price.ID
 			plan.MonthlyPrice = price.UnitAmount
 		default:
-			// Ignore non-recurring prices
+			// Ignore other recurring intervals
 		}
-	}
-	if plan.StripeMonthlyPriceID == "" || plan.StripeYearlyPriceID == "" {
-		return nil, fmt.Errorf("both monthly and yearly prices are required for plan %s", product.ID)
 	}
 
 	return plan, nil
@@ -202,5 +230,12 @@ func extractPlanMetadata[T any](metadataValue string) (T, error) {
 }
 
 func isDefaultPlan(product *stripeapi.Product) bool {
-	return product.DefaultPrice.Metadata["Default"] == "true"
+	return product.DefaultPrice != nil && product.DefaultPrice.Metadata["Default"] == "true"
+}
+
+// isPublicPlan reports whether a plan product is listed on the public /plans catalog. Plans
+// are public by default; a product opts out of the listing with metadata visibility="private"
+// (used for per-customer custom plans and the internal free integrator tier).
+func isPublicPlan(product *stripeapi.Product) bool {
+	return product.Metadata["visibility"] != "private"
 }

--- a/stripe/service_test.go
+++ b/stripe/service_test.go
@@ -35,7 +35,7 @@ func TestProcessProductToPlanIntegratorLimits(t *testing.T) {
 			DefaultPrice: &stripeapi.Price{Metadata: map[string]string{"Default": "false"}},
 		}
 
-		plan, err := processProductToPlan(1, product, testPrices())
+		plan, err := processProductToPlan(product, testPrices())
 		c.Assert(err, qt.IsNil)
 		c.Assert(plan.IntegratorLimits.MaxManagedOrgs, qt.Equals, 3)
 		c.Assert(plan.IntegratorLimits.MaxManagedProcesses, qt.Equals, 30)
@@ -50,7 +50,7 @@ func TestProcessProductToPlanIntegratorLimits(t *testing.T) {
 			DefaultPrice: &stripeapi.Price{Metadata: map[string]string{"Default": "false"}},
 		}
 
-		plan, err := processProductToPlan(2, product, testPrices())
+		plan, err := processProductToPlan(product, testPrices())
 		c.Assert(err, qt.IsNil)
 		c.Assert(plan.IntegratorLimits.MaxManagedOrgs, qt.Equals, 0)
 		c.Assert(plan.IntegratorLimits.MaxManagedProcesses, qt.Equals, 0)
@@ -67,7 +67,7 @@ func TestProcessProductToPlanIntegratorLimits(t *testing.T) {
 			DefaultPrice: &stripeapi.Price{Metadata: map[string]string{"Default": "false"}},
 		}
 
-		_, err := processProductToPlan(3, product, testPrices())
+		_, err := processProductToPlan(product, testPrices())
 		c.Assert(err, qt.IsNotNil)
 	})
 }

--- a/stripe/webhook.go
+++ b/stripe/webhook.go
@@ -2,6 +2,7 @@ package stripe
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -64,8 +65,11 @@ func (s *Service) HandleEvent(event *stripeapi.Event) error {
 		return s.handleSubscription(event)
 	case stripeapi.EventTypeInvoicePaymentSucceeded:
 		return s.handleInvoicePayment(event)
-	case stripeapi.EventTypeProductUpdated:
-		return s.handleProductUpdate(event)
+	case stripeapi.EventTypeProductCreated,
+		stripeapi.EventTypeProductUpdated:
+		return s.handleProductUpsert(event)
+	case stripeapi.EventTypeProductDeleted:
+		return s.handleProductDelete(event)
 	default:
 		log.Debugf("stripe webhook: received unhandled event type %s (id %s)", event.Type, event.ID)
 		return nil
@@ -105,8 +109,8 @@ func (s *Service) handleSubscription(event *stripeapi.Event) error {
 
 // handleSubscriptionCreateOrUpdate handles creating (or updating) a subscription.
 func (s *Service) handleSubscriptionCreateOrUpdate(subscriptionInfo *SubscriptionInfo, org *db.Organization) error {
-	// Get plan by Stripe product ID
-	plan, err := s.db.PlanByStripeID(subscriptionInfo.ProductID)
+	// Get plan by its ID (the Stripe product ID)
+	plan, err := s.db.Plan(subscriptionInfo.ProductID)
 	if err != nil || plan == nil {
 		return fmt.Errorf("plan with Stripe ID %s not found for subscription %s: %v",
 			subscriptionInfo.ProductID, subscriptionInfo.ID, err)
@@ -122,7 +126,7 @@ func (s *Service) handleSubscriptionCreateOrUpdate(subscriptionInfo *Subscriptio
 
 	// Save subscription
 	if err := s.db.SetOrganization(org); err != nil {
-		return fmt.Errorf("failed to save subscription %s (planID=%d, status=%s) for organization %s: %v",
+		return fmt.Errorf("failed to save subscription %s (planID=%s, status=%s) for organization %s: %v",
 			subscriptionInfo.ID, plan.ID, subscriptionInfo.Status, subscriptionInfo.OrgAddress, err)
 	}
 
@@ -137,7 +141,7 @@ func (s *Service) handleSubscriptionCreateOrUpdate(subscriptionInfo *Subscriptio
 		log.Warnf("stripe webhook: failed to update customer %s metadata: %v",
 			subscriptionInfo.Customer.ID, err)
 	}
-	log.Infof("stripe webhook: subscription %s (planID=%d, status=%s) saved for organization %s",
+	log.Infof("stripe webhook: subscription %s (planID=%s, status=%s) saved for organization %s",
 		subscriptionInfo.ID, plan.ID, subscriptionInfo.Status, subscriptionInfo.OrgAddress)
 	return nil
 }
@@ -199,39 +203,79 @@ func (s *Service) handleInvoicePayment(event *stripeapi.Event) error {
 	return nil
 }
 
-// handleProductUpdate processes a product update event
-func (s *Service) handleProductUpdate(event *stripeapi.Event) error {
+// handleProductUpsert processes a product created/updated event, keeping the local plan cache
+// in sync with Stripe (the source of truth). Any product carrying our plan-metadata marker is
+// upserted; a product that lacks (or has lost) the marker is removed from the cache if present.
+func (s *Service) handleProductUpsert(event *stripeapi.Event) error {
 	product, err := parseProductFromEvent(event)
 	if err != nil {
 		return fmt.Errorf("failed to parse product from event: %w", err)
 	}
 
-	// Get the existing plan by Stripe product ID
-	existingPlan, err := s.db.PlanByStripeID(product.ID)
-	if err != nil || existingPlan == nil {
-		// If plan doesn't exist in our database, we can skip this update
-		// This might happen if the product is not one of our configured plans
-		log.Debugf("stripe webhook: product %s not found in database, skipping update", product.ID)
+	// Ignore products that are not vocdoni plans, and inactive products. If we previously had this product cached as a
+	// plan (e.g. it was deactivated or its marker was removed), drop it so the cache doesn't go stale.
+	if !product.Active || !isPlanProduct(product) {
+		existing, err := s.db.Plan(product.ID)
+		switch {
+		case errors.Is(err, db.ErrNotFound):
+			// Not cached; nothing to drop.
+		case err != nil:
+			return fmt.Errorf("failed to look up plan for product %s: %w", product.ID, err)
+		default:
+			if err := s.db.DelPlan(existing); err != nil {
+				return fmt.Errorf("failed to remove de-marked plan for product %s: %w", product.ID, err)
+			}
+			log.Infof("stripe webhook: product %s no longer a plan, removed from cache", product.ID)
+		}
 		return nil
 	}
 
+	// Webhook event payloads don't expand default_price, but isDefaultPlan reads
+	// product.DefaultPrice.Metadata. Re-fetch the product with default_price expanded
+	// (as the full sync does) so a product.updated event can't clear the Default flag.
+	product, err = s.client.GetProduct(product.ID)
+	if err != nil {
+		return fmt.Errorf("failed to fetch product %s with expanded default price: %w", product.ID, err)
+	}
+
 	prices, err := s.client.GetProductPrices(product.ID)
-	if err != nil || len(prices) < 2 {
+	if err != nil {
 		return fmt.Errorf("failed to get prices for product %s: %w", product.ID, err)
 	}
 
-	// Update the plan with new product information
-	updatedPlan, err := processProductToPlan(existingPlan.ID, product, prices)
+	plan, err := processProductToPlan(product, prices)
 	if err != nil {
-		return fmt.Errorf("failed to process updated product %s: %w", product.ID, err)
+		return fmt.Errorf("failed to process product %s: %w", product.ID, err)
 	}
 
-	// Update the plan in the database
-	if _, err := s.db.SetPlan(updatedPlan); err != nil {
-		return fmt.Errorf("failed to update plan for product %s: %v", product.ID, err)
+	if err := s.db.SetPlan(plan); err != nil {
+		return fmt.Errorf("failed to upsert plan for product %s: %w", product.ID, err)
 	}
 
-	log.Infof("stripe webhook: product %s updated, plan %d refreshed", product.ID, updatedPlan.ID)
+	log.Infof("stripe webhook: product %s upserted, plan %s refreshed", product.ID, plan.ID)
+	return nil
+}
+
+// handleProductDelete removes a plan from the local cache when its Stripe product is deleted.
+func (s *Service) handleProductDelete(event *stripeapi.Event) error {
+	product, err := parseProductFromEvent(event)
+	if err != nil {
+		return fmt.Errorf("failed to parse product from event: %w", err)
+	}
+
+	existing, err := s.db.Plan(product.ID)
+	if errors.Is(err, db.ErrNotFound) {
+		// Not a plan we track; nothing to do.
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to look up plan for product %s: %w", product.ID, err)
+	}
+	if err := s.db.DelPlan(existing); err != nil {
+		return fmt.Errorf("failed to delete plan for product %s: %w", product.ID, err)
+	}
+
+	log.Infof("stripe webhook: product %s deleted, plan removed from cache", product.ID)
 	return nil
 }
 

--- a/subscriptions/subscriptions.go
+++ b/subscriptions/subscriptions.go
@@ -55,7 +55,7 @@ func (p DBPermission) String() string {
 
 // DBInterface defines the database methods required by the Subscriptions service
 type DBInterface interface {
-	Plan(id uint64) (*db.Plan, error)
+	Plan(id string) (*db.Plan, error)
 	UserByEmail(email string) (*db.User, error)
 	Organization(address common.Address) (*db.Organization, error)
 	OrganizationWithParent(address common.Address) (*db.Organization, *db.Organization, error)
@@ -122,7 +122,7 @@ func (p *Subscriptions) HasTxPermission(
 	}
 
 	// Check if the organization has a subscription
-	if org.Subscription.PlanID == 0 {
+	if org.Subscription.PlanID == "" {
 		return false, errors.ErrOrganizationHasNoSubscription
 	}
 
@@ -205,7 +205,7 @@ func (p *Subscriptions) OrgHasPermission(orgAddress common.Address, permission D
 			return errors.ErrOrganizationNotFound.WithErr(err)
 		}
 
-		if org.Subscription.PlanID == 0 {
+		if org.Subscription.PlanID == "" {
 			return errors.ErrOrganizationHasNoSubscription.With("can't create draft process")
 		}
 
@@ -235,7 +235,7 @@ func (p *Subscriptions) OrgCanAddNMembers(orgAddress common.Address, memberNumbe
 		return errors.ErrOrganizationNotFound.WithErr(err)
 	}
 
-	if org.Subscription.PlanID == 0 {
+	if org.Subscription.PlanID == "" {
 		return errors.ErrOrganizationHasNoSubscription.With("can't create draft process")
 	}
 
@@ -261,7 +261,7 @@ func (p *Subscriptions) OrgCanPublishGroupCensus(census *db.Census, groupID stri
 		return errors.ErrOrganizationNotFound.WithErr(err)
 	}
 
-	if org.Subscription.PlanID == 0 {
+	if org.Subscription.PlanID == "" {
 		return errors.ErrOrganizationHasNoSubscription
 	}
 
@@ -303,7 +303,7 @@ func (p *Subscriptions) OrgCanAddCensusParticipants(orgAddress common.Address, c
 		return errors.ErrOrganizationNotFound.WithErr(err)
 	}
 
-	if org.Subscription.PlanID == 0 {
+	if org.Subscription.PlanID == "" {
 		return errors.ErrOrganizationHasNoSubscription.With("can't create draft process")
 	}
 
@@ -339,7 +339,7 @@ func (p *Subscriptions) IsIntegrator(org *db.Organization) bool {
 	if org.IntegratorLimits != nil {
 		return org.IntegratorLimits.MaxManagedOrgs > 0
 	}
-	if !org.Subscription.Active || org.Subscription.PlanID == 0 {
+	if !org.Subscription.Active || org.Subscription.PlanID == "" {
 		return false
 	}
 	plan, err := p.db.Plan(org.Subscription.PlanID)
@@ -358,7 +358,7 @@ func (p *Subscriptions) EffectiveIntegratorLimits(org *db.Organization) (db.Inte
 	if org.IntegratorLimits != nil {
 		return *org.IntegratorLimits, nil
 	}
-	if org.Subscription.PlanID == 0 {
+	if org.Subscription.PlanID == "" {
 		return db.IntegratorLimits{}, errors.ErrPlanNotFound.With("organization has no subscription plan")
 	}
 	plan, err := p.db.Plan(org.Subscription.PlanID)

--- a/subscriptions/subscriptions_test.go
+++ b/subscriptions/subscriptions_test.go
@@ -23,7 +23,7 @@ func TestHasTxPermission(t *testing.T) {
 	orgWithoutPlan := &db.Organization{
 		Address: testOrgAddress,
 		Subscription: db.OrganizationSubscription{
-			PlanID: 0, // No plan
+			PlanID: "", // No plan
 		},
 	}
 
@@ -31,7 +31,7 @@ func TestHasTxPermission(t *testing.T) {
 	orgWithPlan := &db.Organization{
 		Address: testAnotherOrgAddress,
 		Subscription: db.OrganizationSubscription{
-			PlanID: 1, // Has a plan
+			PlanID: "plan-1", // Has a plan
 		},
 	}
 
@@ -61,9 +61,9 @@ func TestHasTxPermission(t *testing.T) {
 
 	// Create a mock DB that returns a plan for ID 1
 	mockDB := &mockMongoStorage{
-		plans: map[uint64]*db.Plan{
-			1: {
-				ID:   1,
+		plans: map[string]*db.Plan{
+			"plan-1": {
+				ID:   "plan-1",
 				Name: "Test Plan",
 				Organization: db.PlanLimits{
 					MaxProcesses: 10,
@@ -117,7 +117,7 @@ func TestHasDBPermission(t *testing.T) {
 			testAnotherOrgAddress.String(): {
 				Address: testAnotherOrgAddress,
 				Subscription: db.OrganizationSubscription{
-					PlanID: 1,
+					PlanID: "plan-1",
 				},
 				Counters: db.OrganizationCounters{
 					Users:   5,
@@ -125,9 +125,9 @@ func TestHasDBPermission(t *testing.T) {
 				},
 			},
 		},
-		plans: map[uint64]*db.Plan{
-			1: {
-				ID:   1,
+		plans: map[string]*db.Plan{
+			"plan-1": {
+				ID:   "plan-1",
 				Name: "Test Plan",
 				Organization: db.PlanLimits{
 					Users:   10,
@@ -167,9 +167,9 @@ func TestHasDBPermission(t *testing.T) {
 func TestIsIntegrator(t *testing.T) {
 	c := qt.New(t)
 	mockDB := &mockMongoStorage{
-		plans: map[uint64]*db.Plan{
-			1: {ID: 1, IntegratorLimits: db.IntegratorLimits{MaxManagedOrgs: 5}}, // integrator plan
-			2: {ID: 2, IntegratorLimits: db.IntegratorLimits{MaxManagedOrgs: 0}}, // regular plan
+		plans: map[string]*db.Plan{
+			"plan-1": {ID: "plan-1", IntegratorLimits: db.IntegratorLimits{MaxManagedOrgs: 5}}, // integrator plan
+			"plan-2": {ID: "plan-2", IntegratorLimits: db.IntegratorLimits{MaxManagedOrgs: 0}}, // regular plan
 		},
 	}
 	subs := &Subscriptions{db: mockDB}
@@ -191,25 +191,25 @@ func TestIsIntegrator(t *testing.T) {
 
 	// self-serve via an active subscription to an integrator plan
 	c.Assert(subs.IsIntegrator(&db.Organization{
-		Subscription: db.OrganizationSubscription{PlanID: 1, Active: true},
+		Subscription: db.OrganizationSubscription{PlanID: "plan-1", Active: true},
 	}), qt.IsTrue)
 
 	// the same plan with a lapsed (inactive) subscription is not an integrator
 	c.Assert(subs.IsIntegrator(&db.Organization{
-		Subscription: db.OrganizationSubscription{PlanID: 1, Active: false},
+		Subscription: db.OrganizationSubscription{PlanID: "plan-1", Active: false},
 	}), qt.IsFalse)
 
 	// an active subscription to a non-integrator plan is not an integrator
 	c.Assert(subs.IsIntegrator(&db.Organization{
-		Subscription: db.OrganizationSubscription{PlanID: 2, Active: true},
+		Subscription: db.OrganizationSubscription{PlanID: "plan-2", Active: true},
 	}), qt.IsFalse)
 }
 
 func TestEffectiveIntegratorLimits(t *testing.T) {
 	c := qt.New(t)
 	mockDB := &mockMongoStorage{
-		plans: map[uint64]*db.Plan{
-			1: {ID: 1, IntegratorLimits: db.IntegratorLimits{
+		plans: map[string]*db.Plan{
+			"plan-1": {ID: "plan-1", IntegratorLimits: db.IntegratorLimits{
 				MaxManagedOrgs: 5, MaxManagedProcesses: 50, MaxManagedCensusSize: 500,
 			}},
 		},
@@ -224,27 +224,27 @@ func TestEffectiveIntegratorLimits(t *testing.T) {
 	override := &db.IntegratorLimits{MaxManagedOrgs: 2, MaxManagedProcesses: 20, MaxManagedCensusSize: 200}
 	limits, err := subs.EffectiveIntegratorLimits(&db.Organization{
 		IntegratorLimits: override,
-		Subscription:     db.OrganizationSubscription{PlanID: 1},
+		Subscription:     db.OrganizationSubscription{PlanID: "plan-1"},
 	})
 	c.Assert(err, qt.IsNil)
 	c.Assert(limits, qt.DeepEquals, *override)
 
 	// with no override the plan limits are used
 	limits, err = subs.EffectiveIntegratorLimits(&db.Organization{
-		Subscription: db.OrganizationSubscription{PlanID: 1},
+		Subscription: db.OrganizationSubscription{PlanID: "plan-1"},
 	})
 	c.Assert(err, qt.IsNil)
-	c.Assert(limits, qt.DeepEquals, mockDB.plans[1].IntegratorLimits)
+	c.Assert(limits, qt.DeepEquals, mockDB.plans["plan-1"].IntegratorLimits)
 
-	// no override and no plan (PlanID==0) returns a typed ErrPlanNotFound, not a 500
+	// no override and no plan (PlanID=="") returns a typed ErrPlanNotFound, not a 500
 	_, err = subs.EffectiveIntegratorLimits(&db.Organization{
-		Subscription: db.OrganizationSubscription{PlanID: 0},
+		Subscription: db.OrganizationSubscription{PlanID: ""},
 	})
 	c.Assert(err, qt.ErrorIs, errors.ErrPlanNotFound)
 
 	// a plan lookup failure is wrapped
 	_, err = subs.EffectiveIntegratorLimits(&db.Organization{
-		Subscription: db.OrganizationSubscription{PlanID: 99},
+		Subscription: db.OrganizationSubscription{PlanID: "plan-unknown"},
 	})
 	c.Assert(err, qt.ErrorMatches, "could not get subscription plan.*")
 }
@@ -300,12 +300,12 @@ func TestCanPublishForManagedOrg(t *testing.T) {
 
 // Mock implementation of the necessary db.MongoStorage methods for testing
 type mockMongoStorage struct {
-	plans map[uint64]*db.Plan
+	plans map[string]*db.Plan
 	users map[string]*db.User
 	orgs  map[string]*db.Organization
 }
 
-func (m *mockMongoStorage) Plan(id uint64) (*db.Plan, error) {
+func (m *mockMongoStorage) Plan(id string) (*db.Plan, error) {
 	plan, ok := m.plans[id]
 	if !ok {
 		return nil, db.ErrNotFound


### PR DESCRIPTION
## Why

Plan definitions lived in **three** places:
1. Stripe product metadata — but synced only for a **hardcoded 4-product allowlist** (`stripe/config.go`), so any new product (e.g. a paid integrator plan) silently never appeared at `/plans`.
2. A Mongo seed migration (`0012`) for the free integrator tier, bypassing Stripe.
3. Per-org limit overrides.

That meant the "Custom" plan was a shared placeholder customized via local DB edits, and a freshly-created Stripe product (like `Integrator Starter`) couldn't show up without a code change + redeploy. This unifies everything on **Stripe as the single source of truth**.

## What changed

- **String plan IDs.** Plans are keyed by their Stripe product ID. `db.Plan.ID`, `OrganizationSubscription.PlanID`, `apicommon.SubscriptionPlan.ID`/`SubscriptionDetails.PlanID`, and the checkout `LookupKey` are now `string`. No more synthetic auto-increment ints / `nextPlanID` / the config-index `[PlanCount]` array.
- **Dynamic discovery.** `GetPlansFromStripe` lists every active product carrying our plan-metadata marker (`organization`/`votingTypes`/`features`) — no allowlist. Creating a plan (including a per-customer **custom** plan) is now just creating the Stripe product. Webhooks upsert/remove on `product.created`/`updated`/`deleted` (previously `product.updated` skipped unknown products).
- **Hardened sync.** A malformed product is skipped and logged instead of aborting the entire catalog; missing recurring prices are tolerated (free plans have none).
- **Visibility.** `GET /plans` lists only public plans (`db.Plan.Public`, from product metadata `visibility != "private"`). Private plans — per-customer custom contracts and the internal free integrator tier — are hidden from the catalog but remain visible to their own subscriber via the plan **embedded in the subscription payload** (`OrganizationSubscriptionInfo.Plan`). **`GET /plans/{planID}` is removed** (it was public + guessable sequential IDs).
- **`SetPlan` is a full `ReplaceOne` upsert** (was a partial dynamic update). Plans are fully synced from source, and zero-valued fields are meaningful — e.g. a free plan's `monthlyPrice:0` must persist so `FreeIntegratorPlan`'s exact-zero selector matches.
- **Migration `0014`** converts existing org subscription plan IDs `int → string` (via each old plan's `stripeID`; the free integrator seed maps to its Stripe product, env-overridable `STRIPE_FREE_INTEGRATOR_PRODUCT_ID`) and drops the stale int-keyed plan docs (repopulated from Stripe at startup).

## Sandbox setup (already done)

- Created **Integrator Starter** product (`prod_UkvkBzFoXEduuJ`) + monthly/yearly EUR prices, with `integratorLimits`.
- Marked the existing **Integrator Free** product (`prod_UkaJ8hyy6juz5e`) `visibility=private` so it's the canonical Stripe-sourced free integrator tier.

## Testing

- `go build ./...`, `go vet ./...` clean.
- `go test ./stripe/... ./subscriptions/... ./db/... ./api/...` all pass (api suite ~244s via testcontainers).
- Verified the branch compiles in isolation (clean worktree).

## Follow-ups / notes

- **Operators must set `STRIPE_FREE_INTEGRATOR_PRODUCT_ID`** per environment for `0014` (defaults to the sandbox product).
- **Breaking API change**: `planId`/`lookupKey`/plan `id` are now strings — the consumer app (`vocdoni-app`) needs the same type change. The integrator app (`vocdoni-integrator-app`) is updated in a companion PR.
- Free integrator tier now requires Stripe (the `0012` Mongo seed is superseded by `0014`); stripe-less local dev should use the `defaultplan` script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)