### PR TITLE
docs(swagger): document integrator and api-key endpoints and scopes

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -19,7 +19,9 @@
 //	@securityDefinitions.apikey	BearerAuth
 //	@in							header
 //	@name						Authorization
-//	@description				Type "Bearer" followed by a space and the JWT token.
+//	@description				Type "Bearer" followed by a space and either a JWT (user session) or a
+//	@description				scoped API key (prefixed "vsk_"). API keys are accepted only on endpoints
+//	@description				that opt into key auth, and only when the key carries the required scope.
 //
 //	@tag.name					auth
 //	@tag.description			Authentication operations

--- a/api/apikeys_handlers.go
+++ b/api/apikeys_handlers.go
@@ -17,18 +17,22 @@ import (
 //
 //	@Summary		Create an API key for an organization
 //	@Description	Create a new API key owned by the organization at the given address. The caller
-//	@Description	must be an admin of the organization. The plaintext secret is returned ONCE and
-//	@Description	cannot be retrieved again.
+//	@Description	must be an admin of the organization. The plaintext secret (prefixed "vsk_") is
+//	@Description	returned ONCE in the response and cannot be retrieved again.
+//	@Description
+//	@Description	`label` and at least one `scope` are required. Valid scopes are deny-by-default and
+//	@Description	must be a subset of: `quota:read`, `managed:read`, `managed:write`, `voting:write`,
+//	@Description	`members:write`. The optional `expiresAt`, when set, must be in the future.
 //	@Tags			apikeys
 //	@Accept			json
 //	@Produce		json
 //	@Security		BearerAuth
 //	@Param			address	path		string							true	"Organization address"
 //	@Param			request	body		apicommon.CreateAPIKeyRequest	true	"API key information"
-//	@Success		200		{object}	apicommon.CreateAPIKeyResponse
-//	@Failure		400		{object}	errors.Error	"Invalid input data"
-//	@Failure		401		{object}	errors.Error	"Unauthorized"
-//	@Failure		500		{object}	errors.Error	"Internal server error"
+//	@Success		200		{object}	apicommon.CreateAPIKeyResponse	"Created key including the one-time plaintext secret"
+//	@Failure		400		{object}	errors.Error					"Invalid input (missing label/scopes, unknown scope, or past expiresAt)"
+//	@Failure		401		{object}	errors.Error					"Unauthorized"
+//	@Failure		500		{object}	errors.Error					"Internal server error"
 //	@Router			/organizations/{address}/apikeys [post]
 func (a *API) createAPIKeyHandler(w http.ResponseWriter, r *http.Request) {
 	user, ok := apicommon.UserFromContext(r.Context())
@@ -138,6 +142,7 @@ func (a *API) apiKeysHandler(w http.ResponseWriter, r *http.Request) {
 //	@Param			address	path		string			true	"Organization address"
 //	@Param			keyID	path		string			true	"API key ID"
 //	@Success		200		{string}	string			"OK"
+//	@Failure		400		{object}	errors.Error	"Invalid input data (missing key ID)"
 //	@Failure		401		{object}	errors.Error	"Unauthorized"
 //	@Failure		404		{object}	errors.Error	"API key not found"
 //	@Failure		500		{object}	errors.Error	"Internal server error"

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -24,15 +24,21 @@ import (
 //	@Description	Create a new organization. If the organization is a suborganization, the parent organization must be
 //	@Description	specified in the request body, and the user must be an admin of the parent. If the parent organization
 //	@Description	is already a suborganization, an error is returned.
+//	@Description
+//	@Description	Two optional opt-in fields support the chain-abstracted flow (both default false, preserving the legacy
+//	@Description	behavior): `provisionAccount` forges the organization's on-chain account eagerly at creation time
+//	@Description	(idempotent) instead of leaving it to the legacy SDK createAccount path; `integrator` subscribes the
+//	@Description	new organization to the free integrator plan so it becomes an integrator on the free tier with no
+//	@Description	checkout.
 //	@Tags			organizations
 //	@Accept			json
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			request	body		apicommon.OrganizationInfo	true	"Organization information"
+//	@Param			request	body		apicommon.OrganizationInfo	true	"Organization info (+ optional provisionAccount / integrator)"
 //	@Success		200		{object}	apicommon.OrganizationInfo
 //	@Failure		400		{object}	errors.Error	"Invalid input data"
 //	@Failure		401		{object}	errors.Error	"Unauthorized"
-//	@Failure		404		{object}	errors.Error	"Parent organization not found"
+//	@Failure		404		{object}	errors.Error	"Parent org not found, or free integrator plan unavailable (integrator=true)"
 //	@Failure		500		{object}	errors.Error	"Internal server error"
 //	@Router			/organizations [post]
 func (a *API) createOrganizationHandler(w http.ResponseWriter, r *http.Request) {

--- a/api/organizations_managed.go
+++ b/api/organizations_managed.go
@@ -42,7 +42,11 @@ func (a *API) releaseManagedOrgSlot(integratorAddr common.Address) {
 //	@Description	Create a new organization managed by the integrator at the given address. The
 //	@Description	caller must be an admin of the integrator organization, which must be enabled as
 //	@Description	an integrator and within its managed-organizations quota. The managed org's on-chain
-//	@Description	account is always provisioned eagerly.
+//	@Description	account is always provisioned eagerly. The optional `ownerEmail` designates the managed
+//	@Description	org's owner/admin (defaults to the calling user); the per-user MaxOrgsPerUser cap is
+//	@Description	bypassed for managed orgs.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `managed:write`).
 //	@Tags			organizations
 //	@Accept			json
 //	@Produce		json
@@ -188,6 +192,8 @@ func (a *API) createManagedOrganizationHandler(w http.ResponseWriter, r *http.Re
 //	@Summary		List organizations managed by an integrator
 //	@Description	Returns a paginated list of organizations managed by the integrator at the given
 //	@Description	address. The caller must be an admin or manager of the integrator organization.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `managed:read`).
 //	@Tags			organizations
 //	@Produce		json
 //	@Security		BearerAuth
@@ -243,7 +249,11 @@ func (a *API) managedOrganizationsHandler(w http.ResponseWriter, r *http.Request
 //	@Summary		Get integrator quota and usage
 //	@Description	Returns whether the organization at the given address is enabled as an integrator,
 //	@Description	along with its effective managed-resource limits and current usage. The caller must
-//	@Description	be an admin or manager of the organization.
+//	@Description	be an admin or manager of the organization. When the organization is not an integrator,
+//	@Description	`enabled` is false and `limits` is omitted (usage counters are still returned).
+//	@Description	A 0 in any limit field means unlimited for that dimension.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `quota:read`).
 //	@Tags			organizations
 //	@Produce		json
 //	@Security		BearerAuth

--- a/api/process.go
+++ b/api/process.go
@@ -22,15 +22,24 @@ import (
 // createProcessHandler godoc
 //
 //	@Summary		Create a new voting process
-//	@Description	Create a new voting process. Requires Manager/Admin role.
+//	@Description	Create a new voting process (draft). Requires Manager/Admin role of the owning organization. The
+//	@Description	request must reference the organization via either a `censusId` or an explicit `orgAddress`.
+//	@Description	Creating a draft consumes the plan's draft permission.
+//	@Description
+//	@Description	The optional `electionParams` field carries the on-chain election definition (questions, dates,
+//	@Description	vote/election types) used later to publish the draft on chain via POST /process/{processId}/publish.
+//	@Description	It is additive: omitting it keeps the legacy draft behavior.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `voting:write`).
 //	@Tags			process
 //	@Accept			json
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			request	body		apicommon.CreateProcessRequest	true	"Process creation information"
-//	@Success		200		{object}	primitive.ObjectID				"Process ID"
+//	@Param			request	body		apicommon.CreateProcessRequest	true	"Process creation information (optionally with electionParams)"
+//	@Success		200		{object}	primitive.ObjectID				"Draft process ID (Mongo ObjectID)"
 //	@Failure		400		{object}	errors.Error					"Invalid input data"
 //	@Failure		401		{object}	errors.Error					"Unauthorized"
+//	@Failure		403		{object}	errors.Error					"Plan does not allow creating more drafts"
 //	@Failure		404		{object}	errors.Error					"Published census not found"
 //	@Failure		409		{object}	errors.Error					"Process already exists"
 //	@Failure		500		{object}	errors.Error					"Internal server error"
@@ -118,17 +127,21 @@ func (a *API) createProcessHandler(w http.ResponseWriter, r *http.Request) {
 // updateProcessHandler godoc
 //
 //	@Summary		Update an existing voting process
-//	@Description	Update an existing voting process. Requires Manager/Admin role.
+//	@Description	Update an existing draft voting process. Requires Manager/Admin role of the owning organization.
+//	@Description	Only drafts that have not yet been published on chain can be updated; updating a published process
+//	@Description	returns a 409. The optional `electionParams` field can be set or replaced here (additive), same as on
+//	@Description	create.
 //	@Tags			process
 //	@Accept			json
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			processId	path		string							true	"Process ID"
-//	@Param			request		body		apicommon.CreateProcessRequest	true	"Process update information"
+//	@Param			processId	path		string							true	"Draft process ID (Mongo ObjectID)"
+//	@Param			request		body		apicommon.UpdateProcessRequest	true	"Process update information (optionally with electionParams)"
 //	@Success		200			{string}	string							"OK"
 //	@Failure		400			{object}	errors.Error					"Invalid input data"
 //	@Failure		401			{object}	errors.Error					"Unauthorized"
 //	@Failure		404			{object}	errors.Error					"Process not found"
+//	@Failure		409			{object}	errors.Error					"Process already published and not in draft mode"
 //	@Failure		500			{object}	errors.Error					"Internal server error"
 //	@Router			/process/{processId} [put]
 func (a *API) updateProcessHandler(w http.ResponseWriter, r *http.Request) {
@@ -376,7 +389,10 @@ func (a *API) deleteProcessHandler(w http.ResponseWriter, r *http.Request) {
 //	@Description	confirms it on a background worker; the call returns 202 with a job id. Poll GET
 //	@Description	/jobs/{jobId} for the resulting on-chain id. Requires Admin role. Idempotent: if
 //	@Description	the draft is already published its on-chain id is returned with 200 without sending
-//	@Description	a new transaction.
+//	@Description	a new transaction. Publishing under a managed organization additionally enforces the
+//	@Description	integrator's per-org and aggregate election/census quotas.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `voting:write`).
 //	@Tags			process
 //	@Accept			json
 //	@Produce		json

--- a/api/process_vote.go
+++ b/api/process_vote.go
@@ -123,6 +123,8 @@ func (a *API) relayVoteHandler(w http.ResponseWriter, r *http.Request) {
 //	@Description	organization signer synchronously, then submits and confirms it on a background
 //	@Description	worker; the call returns 202 with a job id. Poll GET /jobs/{jobId} for the result.
 //	@Description	Requires Manager/Admin role of the organization that owns the process.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `voting:write`).
 //	@Tags			process
 //	@Accept			json
 //	@Produce		json

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1272,6 +1272,30 @@ definitions:
         description: The new role to assign to the user
         type: string
     type: object
+  apicommon.UpdateProcessRequest:
+    properties:
+      address:
+        description: Vochain ID/Address of the process
+        example: deadbeef
+        format: hex
+        type: string
+      censusId:
+        description: Census ID
+        example: deadbeef
+        format: hex
+        type: string
+      electionParams:
+        allOf:
+        - $ref: '#/definitions/db.ElectionParams'
+        description: Optional high-level election parameters (used later at publish
+          time)
+      metadata:
+        additionalProperties: {}
+        description: |-
+          Additional metadata for the process
+          Can be any key-value pairs
+        type: object
+    type: object
   apicommon.UserInfo:
     properties:
       email:
@@ -2335,8 +2359,14 @@ paths:
         Create a new organization. If the organization is a suborganization, the parent organization must be
         specified in the request body, and the user must be an admin of the parent. If the parent organization
         is already a suborganization, an error is returned.
+
+        Two optional opt-in fields support the chain-abstracted flow (both default false, preserving the legacy
+        behavior): `provisionAccount` forges the organization's on-chain account eagerly at creation time
+        (idempotent) instead of leaving it to the legacy SDK createAccount path; `integrator` subscribes the
+        new organization to the free integrator plan so it becomes an integrator on the free tier with no
+        checkout.
       parameters:
-      - description: Organization information
+      - description: Organization info (+ optional provisionAccount / integrator)
         in: body
         name: request
         required: true
@@ -2358,7 +2388,7 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
         "404":
-          description: Parent organization not found
+          description: Parent org not found, or free integrator plan unavailable (integrator=true)
           schema:
             $ref: '#/definitions/errors.Error'
         "500":
@@ -2486,8 +2516,12 @@ paths:
       - application/json
       description: |-
         Create a new API key owned by the organization at the given address. The caller
-        must be an admin of the organization. The plaintext secret is returned ONCE and
-        cannot be retrieved again.
+        must be an admin of the organization. The plaintext secret (prefixed "vsk_") is
+        returned ONCE in the response and cannot be retrieved again.
+
+        `label` and at least one `scope` are required. Valid scopes are deny-by-default and
+        must be a subset of: `quota:read`, `managed:read`, `managed:write`, `voting:write`,
+        `members:write`. The optional `expiresAt`, when set, must be in the future.
       parameters:
       - description: Organization address
         in: path
@@ -2504,11 +2538,12 @@ paths:
       - application/json
       responses:
         "200":
-          description: OK
+          description: Created key including the one-time plaintext secret
           schema:
             $ref: '#/definitions/apicommon.CreateAPIKeyResponse'
         "400":
-          description: Invalid input data
+          description: Invalid input (missing label/scopes, unknown scope, or past
+            expiresAt)
           schema:
             $ref: '#/definitions/errors.Error'
         "401":
@@ -2547,6 +2582,10 @@ paths:
           description: OK
           schema:
             type: string
+        "400":
+          description: Invalid input data (missing key ID)
+          schema:
+            $ref: '#/definitions/errors.Error'
         "401":
           description: Unauthorized
           schema:
@@ -2949,7 +2988,11 @@ paths:
       description: |-
         Returns whether the organization at the given address is enabled as an integrator,
         along with its effective managed-resource limits and current usage. The caller must
-        be an admin or manager of the organization.
+        be an admin or manager of the organization. When the organization is not an integrator,
+        `enabled` is false and `limits` is omitted (usage counters are still returned).
+        A 0 in any limit field means unlimited for that dimension.
+
+        Also callable with a scoped API key (scope: `quota:read`).
       parameters:
       - description: Integrator organization address
         in: path
@@ -3041,6 +3084,8 @@ paths:
       description: |-
         Returns a paginated list of organizations managed by the integrator at the given
         address. The caller must be an admin or manager of the integrator organization.
+
+        Also callable with a scoped API key (scope: `managed:read`).
       parameters:
       - description: Integrator organization address
         in: path
@@ -3086,7 +3131,11 @@ paths:
         Create a new organization managed by the integrator at the given address. The
         caller must be an admin of the integrator organization, which must be enabled as
         an integrator and within its managed-organizations quota. The managed org's on-chain
-        account is always provisioned eagerly.
+        account is always provisioned eagerly. The optional `ownerEmail` designates the managed
+        org's owner/admin (defaults to the calling user); the per-user MaxOrgsPerUser cap is
+        bypassed for managed orgs.
+
+        Also callable with a scoped API key (scope: `managed:write`).
       parameters:
       - description: Integrator organization address
         in: path
@@ -4136,9 +4185,18 @@ paths:
     post:
       consumes:
       - application/json
-      description: Create a new voting process. Requires Manager/Admin role.
+      description: |-
+        Create a new voting process (draft). Requires Manager/Admin role of the owning organization. The
+        request must reference the organization via either a `censusId` or an explicit `orgAddress`.
+        Creating a draft consumes the plan's draft permission.
+
+        The optional `electionParams` field carries the on-chain election definition (questions, dates,
+        vote/election types) used later to publish the draft on chain via POST /process/{processId}/publish.
+        It is additive: omitting it keeps the legacy draft behavior.
+
+        Also callable with a scoped API key (scope: `voting:write`).
       parameters:
-      - description: Process creation information
+      - description: Process creation information (optionally with electionParams)
         in: body
         name: request
         required: true
@@ -4148,7 +4206,7 @@ paths:
       - application/json
       responses:
         "200":
-          description: Process ID
+          description: Draft process ID (Mongo ObjectID)
           schema:
             type: string
         "400":
@@ -4157,6 +4215,10 @@ paths:
             $ref: '#/definitions/errors.Error'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "403":
+          description: Plan does not allow creating more drafts
           schema:
             $ref: '#/definitions/errors.Error'
         "404":
@@ -4251,19 +4313,23 @@ paths:
     put:
       consumes:
       - application/json
-      description: Update an existing voting process. Requires Manager/Admin role.
+      description: |-
+        Update an existing draft voting process. Requires Manager/Admin role of the owning organization.
+        Only drafts that have not yet been published on chain can be updated; updating a published process
+        returns a 409. The optional `electionParams` field can be set or replaced here (additive), same as on
+        create.
       parameters:
-      - description: Process ID
+      - description: Draft process ID (Mongo ObjectID)
         in: path
         name: processId
         required: true
         type: string
-      - description: Process update information
+      - description: Process update information (optionally with electionParams)
         in: body
         name: request
         required: true
         schema:
-          $ref: '#/definitions/apicommon.CreateProcessRequest'
+          $ref: '#/definitions/apicommon.UpdateProcessRequest'
       produces:
       - application/json
       responses:
@@ -4281,6 +4347,10 @@ paths:
             $ref: '#/definitions/errors.Error'
         "404":
           description: Process not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "409":
+          description: Process already published and not in draft mode
           schema:
             $ref: '#/definitions/errors.Error'
         "500":
@@ -4338,7 +4408,10 @@ paths:
         confirms it on a background worker; the call returns 202 with a job id. Poll GET
         /jobs/{jobId} for the resulting on-chain id. Requires Admin role. Idempotent: if
         the draft is already published its on-chain id is returned with 200 without sending
-        a new transaction.
+        a new transaction. Publishing under a managed organization additionally enforces the
+        integrator's per-org and aggregate election/census quotas.
+
+        Also callable with a scoped API key (scope: `voting:write`).
       parameters:
       - description: Draft process ID
         in: path
@@ -4475,6 +4548,8 @@ paths:
         organization signer synchronously, then submits and confirms it on a background
         worker; the call returns 202 with a job id. Poll GET /jobs/{jobId} for the result.
         Requires Manager/Admin role of the organization that owns the process.
+
+        Also callable with a scoped API key (scope: `voting:write`).
       parameters:
       - description: On-chain process id (hex)
         in: path
@@ -5663,7 +5738,10 @@ schemes:
 - https
 securityDefinitions:
   BearerAuth:
-    description: Type "Bearer" followed by a space and the JWT token.
+    description: |-
+      Type "Bearer" followed by a space and either a JWT (user session) or a
+      scoped API key (prefixed "vsk_"). API keys are accepted only on endpoints
+      that opt into key auth, and only when the key carries the required scope.
     in: header
     name: Authorization
     type: apiKey


### PR DESCRIPTION
## What

Makes the OpenAPI/swagger docs for the new **integrator** and **chain-abstraction** endpoints correct and comprehensive. Verified each annotation against its handler. **Docs-only** — no behavior change; the only Go edits are godoc/swag comments, plus the regenerated `docs/swagger.yaml`.

## Changes

- **Auth scheme** (`api.go`): `BearerAuth` now states it accepts a JWT **or** a scoped `vsk_` API key (keys work only on opted-in endpoints holding the required scope).
- **`POST /organizations`**: documents the `provisionAccount` (eager on-chain account) and `integrator` (free-tier) opt-ins, and the 404 when the free integrator plan is unavailable.
- **`POST` / `PUT /process`**: documents the additive `electionParams`; **fixes the update body type** to `UpdateProcessRequest` (matches the handler); adds **403** (draft plan limit) and **409** (already published) responses.
- **publish / vote / status / managed-org create+list / integrator-info**: note the required API-key **scope** per endpoint (`voting:write`, `managed:write`, `managed:read`, `quota:read`) and clarify quota/limit semantics (e.g. `enabled=false` when not an integrator, `0 = unlimited`).
- **API keys**: create lists the 5 valid scopes + one-time secret behavior; revoke gains the missing **400** (empty key ID).

## Notes / boundary

- The API-key allowlist also covers pre-existing members/groups/census/bundle routes. I documented the scope on the **new** endpoints only; the scheme-level note covers the mechanism generally. Happy to propagate per-route scope notes to the legacy allowlisted endpoints if wanted.
- Verified: `make swagger` regenerates clean, `UpdateProcessRequest` model resolves, `go build ./api/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)