### PR TITLE
fix(api): stop swagger promising response fields the API never sends

### DIFF
--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -101,10 +101,6 @@ type OrganizationInfo struct {
 	// Arbitrary key value fields with metadata regarding the organization
 	Meta map[string]any `json:"meta"`
 
-	// Whether to provision the organization's on-chain account at creation
-	// time (opt-in, eager). Default false preserves the legacy two-step flow.
-	ProvisionAccount bool `json:"provisionAccount,omitempty"`
-
 	// Whether to subscribe the new organization to the free integrator plan at
 	// creation time (opt-in). Used by the integrator portal so a newly created org
 	// becomes an integrator on the free tier with no checkout. Default false uses
@@ -484,10 +480,23 @@ func OrganizationFromDB(dbOrg, parent *db.Organization) *OrganizationInfo {
 		Timezone:       dbOrg.Timezone,
 		Active:         dbOrg.Active,
 		Communications: dbOrg.Communications,
+		Meta:           dbOrg.Meta,
 		Parent:         parentOrg,
 		Subscription:   &details,
 		Counters:       &usage,
 	}
+}
+
+// CreateOrganizationRequest is the body of POST /organizations. It embeds the new
+// organization's fields and adds creation-only directives that are not part of the
+// organization's persistent representation (so they must not appear in responses).
+// swagger:model CreateOrganizationRequest
+type CreateOrganizationRequest struct {
+	OrganizationInfo
+	// Whether to provision the organization's on-chain account at creation
+	// time (opt-in, eager). Default false preserves the legacy two-step flow
+	// where the account is created later by the SDK.
+	ProvisionAccount bool `json:"provisionAccount,omitempty"`
 }
 
 // CreateManagedOrganizationRequest is the body of POST /organizations/{address}/managed.
@@ -556,12 +565,6 @@ type SubscriptionPlan struct {
 
 	// Yearly price
 	YearlyPrice int64 `json:"yearlyPrice"`
-
-	// Stripe price ID
-	StripePriceID string `json:"stripePriceId"`
-
-	// Starting price in cents
-	StartingPrice int64 `json:"startingPrice"`
 
 	// Whether this is the default plan
 	Default bool `json:"default"`
@@ -720,9 +723,6 @@ type SubscriptionDetails struct {
 
 	// Whether the subscription is active
 	Active bool `json:"active"`
-
-	// Maximum census size allowed
-	MaxCensusSize int `json:"maxCensusSize"`
 
 	// Email associated with the subscription
 	Email string `json:"email"`
@@ -906,6 +906,7 @@ func OrganizationCensusFromDB(census *db.Census) OrganizationCensus {
 		Type:        census.Type,
 		OrgAddress:  census.OrgAddress,
 		Size:        census.Size,
+		Weighted:    census.Weighted,
 		GroupID:     census.GroupID.Hex(),
 		AuthFields:  census.AuthFields,
 		TwoFaFields: census.TwoFaFields,

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -468,6 +468,13 @@ func OrganizationFromDB(dbOrg, parent *db.Organization) *OrganizationInfo {
 	}
 	details := SubscriptionDetailsFromDB(&dbOrg.Subscription)
 	usage := SubscriptionUsageFromDB(&dbOrg.Counters)
+	// normalize a nil Meta to an empty map so responses are consistent: the DB
+	// read path already does this, but dbOrg may be built in-memory (e.g. at
+	// creation) where Meta is nil, which would otherwise emit "meta": null.
+	meta := dbOrg.Meta
+	if meta == nil {
+		meta = make(map[string]any)
+	}
 	return &OrganizationInfo{
 		Address:        dbOrg.Address,
 		Website:        dbOrg.Website,
@@ -480,7 +487,7 @@ func OrganizationFromDB(dbOrg, parent *db.Organization) *OrganizationInfo {
 		Timezone:       dbOrg.Timezone,
 		Active:         dbOrg.Active,
 		Communications: dbOrg.Communications,
-		Meta:           dbOrg.Meta,
+		Meta:           meta,
 		Parent:         parentOrg,
 		Subscription:   &details,
 		Counters:       &usage,

--- a/api/e2e_full_flow_test.go
+++ b/api/e2e_full_flow_test.go
@@ -38,9 +38,11 @@ func TestFullElectionLifecycle(t *testing.T) {
 
 	// --- organizer: user, org with on-chain account, plan subscription ---
 	token := testCreateUser(t, "superpassword123")
-	orgInfo := &apicommon.OrganizationInfo{
-		Type:             string(db.CompanyType),
-		Website:          fmt.Sprintf("https://e2e-%d.com", internal.RandomInt(100000)),
+	orgInfo := &apicommon.CreateOrganizationRequest{
+		OrganizationInfo: apicommon.OrganizationInfo{
+			Type:    string(db.CompanyType),
+			Website: fmt.Sprintf("https://e2e-%d.com", internal.RandomInt(100000)),
+		},
 		ProvisionAccount: true,
 	}
 	org := requestAndParse[apicommon.OrganizationInfo](t, http.MethodPost, token, orgInfo, organizationsEndpoint)

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -34,7 +34,7 @@ import (
 //	@Accept			json
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			request	body		apicommon.OrganizationInfo	true	"Organization info (+ optional provisionAccount / integrator)"
+//	@Param			request	body		apicommon.CreateOrganizationRequest	true	"Organization info (+ optional provisionAccount / integrator)"
 //	@Success		200		{object}	apicommon.OrganizationInfo
 //	@Failure		400		{object}	errors.Error	"Invalid input data"
 //	@Failure		401		{object}	errors.Error	"Unauthorized"
@@ -49,7 +49,7 @@ func (a *API) createOrganizationHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	// get the organization info from the request body
-	orgInfo := &apicommon.OrganizationInfo{}
+	orgInfo := &apicommon.CreateOrganizationRequest{}
 	if err := json.NewDecoder(r.Body).Decode(orgInfo); err != nil {
 		errors.ErrMalformedBody.Write(w)
 		return

--- a/api/organizations_provision_test.go
+++ b/api/organizations_provision_test.go
@@ -39,9 +39,11 @@ func TestProvisionAccountOnOrgCreation(t *testing.T) {
 	t.Run("flag on = provisioned + idempotent", func(t *testing.T) {
 		c := qt.New(t)
 		token := testCreateUser(t, "password123")
-		orgInfo := &apicommon.OrganizationInfo{
-			Type:             string(db.CompanyType),
-			Website:          fmt.Sprintf("https://on-%d.com", internal.RandomInt(100000)),
+		orgInfo := &apicommon.CreateOrganizationRequest{
+			OrganizationInfo: apicommon.OrganizationInfo{
+				Type:    string(db.CompanyType),
+				Website: fmt.Sprintf("https://on-%d.com", internal.RandomInt(100000)),
+			},
 			ProvisionAccount: true,
 		}
 		resp := requestAndParse[apicommon.OrganizationInfo](t, http.MethodPost, token, orgInfo, organizationsEndpoint)

--- a/api/process_publish_test.go
+++ b/api/process_publish_test.go
@@ -23,9 +23,11 @@ func TestPublishProcess(t *testing.T) {
 	token := testCreateUser(t, "password123")
 
 	// create an org with eager on-chain account provisioning (Phase 1)
-	orgInfo := &apicommon.OrganizationInfo{
-		Type:             string(db.CompanyType),
-		Website:          fmt.Sprintf("https://pub-%d.com", internal.RandomInt(100000)),
+	orgInfo := &apicommon.CreateOrganizationRequest{
+		OrganizationInfo: apicommon.OrganizationInfo{
+			Type:    string(db.CompanyType),
+			Website: fmt.Sprintf("https://pub-%d.com", internal.RandomInt(100000)),
+		},
 		ProvisionAccount: true,
 	}
 	org := requestAndParse[apicommon.OrganizationInfo](t, http.MethodPost, token, orgInfo, organizationsEndpoint)

--- a/api/process_vote_test.go
+++ b/api/process_vote_test.go
@@ -50,9 +50,11 @@ func TestProcessStatusLifecycle(t *testing.T) {
 	token := testCreateUser(t, "password123")
 
 	// create an org with eager on-chain account provisioning
-	orgInfo := &apicommon.OrganizationInfo{
-		Type:             string(db.CompanyType),
-		Website:          fmt.Sprintf("https://status-%d.com", internal.RandomInt(100000)),
+	orgInfo := &apicommon.CreateOrganizationRequest{
+		OrganizationInfo: apicommon.OrganizationInfo{
+			Type:    string(db.CompanyType),
+			Website: fmt.Sprintf("https://status-%d.com", internal.RandomInt(100000)),
+		},
 		ProvisionAccount: true,
 	}
 	org := requestAndParse[apicommon.OrganizationInfo](t, http.MethodPost, token, orgInfo, organizationsEndpoint)

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -255,11 +255,6 @@ definitions:
         allOf:
         - $ref: '#/definitions/apicommon.OrganizationInfo'
         description: Parent organization if this is a sub-organization
-      provisionAccount:
-        description: |-
-          Whether to provision the organization's on-chain account at creation
-          time (opt-in, eager). Default false preserves the legacy two-step flow.
-        type: boolean
       size:
         description: The size category of the organization
         type: string
@@ -296,6 +291,73 @@ definitions:
         type: array
       title:
         description: Title of the group
+        type: string
+    type: object
+  apicommon.CreateOrganizationRequest:
+    properties:
+      active:
+        description: Whether the organization is active
+        type: boolean
+      address:
+        description: The organization's blockchain address
+        items:
+          type: integer
+        type: array
+      color:
+        description: The organization's brand color in hex format
+        type: string
+      communications:
+        description: Whether the organization has enabled communications
+        type: boolean
+      counters:
+        allOf:
+        - $ref: '#/definitions/apicommon.SubscriptionUsage'
+        description: Usage counters for the organization
+      country:
+        description: The country where the organization is based
+        type: string
+      createdAt:
+        description: Creation timestamp in RFC3339 format
+        type: string
+      integrator:
+        description: |-
+          Whether to subscribe the new organization to the free integrator plan at
+          creation time (opt-in). Used by the integrator portal so a newly created org
+          becomes an integrator on the free tier with no checkout. Default false uses
+          the regular default plan.
+        type: boolean
+      meta:
+        additionalProperties: {}
+        description: Arbitrary key value fields with metadata regarding the organization
+        type: object
+      parent:
+        allOf:
+        - $ref: '#/definitions/apicommon.OrganizationInfo'
+        description: Parent organization if this is a sub-organization
+      provisionAccount:
+        description: |-
+          Whether to provision the organization's on-chain account at creation
+          time (opt-in, eager). Default false preserves the legacy two-step flow
+          where the account is created later by the SDK.
+        type: boolean
+      size:
+        description: The size category of the organization
+        type: string
+      subdomain:
+        description: The organization's subdomain
+        type: string
+      subscription:
+        allOf:
+        - $ref: '#/definitions/apicommon.SubscriptionDetails'
+        description: Subscription details for the organization
+      timezone:
+        description: The organization's timezone
+        type: string
+      type:
+        description: The type of organization
+        type: string
+      website:
+        description: The organization's website URL
         type: string
     type: object
   apicommon.CreateOrganizationTicketRequest:
@@ -753,11 +815,6 @@ definitions:
         allOf:
         - $ref: '#/definitions/apicommon.OrganizationInfo'
         description: Parent organization if this is a sub-organization
-      provisionAccount:
-        description: |-
-          Whether to provision the organization's on-chain account at creation
-          time (opt-in, eager). Default false preserves the legacy two-step flow.
-        type: boolean
       size:
         description: The size category of the organization
         type: string
@@ -1113,9 +1170,6 @@ definitions:
       lastPaymentDate:
         description: Date of the last payment
         type: string
-      maxCensusSize:
-        description: Maximum census size allowed
-        type: integer
       planId:
         description: ID of the subscription plan
         type: integer
@@ -1198,17 +1252,11 @@ definitions:
         allOf:
         - $ref: '#/definitions/apicommon.SubscriptionPlanLimits'
         description: Organization limits for this plan
-      startingPrice:
-        description: Starting price in cents
-        type: integer
       stripeId:
         description: Stripe product ID
         type: string
       stripeMonthlyPriceId:
         description: Stripe monthly price ID
-        type: string
-      stripePriceId:
-        description: Stripe price ID
         type: string
       stripeYearlyPriceId:
         description: Stripe yearly price ID
@@ -2415,7 +2463,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/apicommon.OrganizationInfo'
+          $ref: '#/definitions/apicommon.CreateOrganizationRequest'
       produces:
       - application/json
       responses:


### PR DESCRIPTION
## Problem

The reported `integrator`-on-responses issue is one instance of a general pattern: **several response schemas in `docs/swagger.yaml` advertise fields that no response actually carries.** A systematic sweep of the shared DTOs and all `…FromDB` converters in `api/apicommon/` turned up two flavors:

- **(A) write-only creation inputs** living on a struct reused as both request and response, so they leak into the response schema where the handler never populates them (hidden at runtime by `omitempty`, but the contract lies);
- **(B) response fields the `…FromDB` converter silently never populates** — these have no `omitempty`, so clients actually receive a misleading `0` / `false` / `null`.

## Changes

| Field | Flavor | Fix |
|---|---|---|
| `OrganizationInfo.provisionAccount` | A | Moved to a dedicated `CreateOrganizationRequest` body; the response model no longer carries it |
| `OrganizationCensus.weighted` | B | **Data bug** — stored (`db.Census.Weighted`, set at publish) but dropped by `OrganizationCensusFromDB`, so GET/list census always returned `weighted:false`. Now populated |
| `OrganizationInfo.meta` | B | Documented but dropped by `OrganizationFromDB` (always `meta:null`). Now populated from `db.Organization.Meta` |
| `SubscriptionDetails.maxCensusSize` | B | No backing field on `db.OrganizationSubscription`; always `0`. Removed |
| `SubscriptionPlan.stripePriceId` | B | No backing field on `db.Plan`; never set (dead). Removed |
| `SubscriptionPlan.startingPrice` | B | No backing field on `db.Plan`; never set (dead). Removed |

`docs/swagger.yaml` regenerated via `make swagger`.

## Deliberately out of scope

- **`integrator`** (same shared-model class as `provisionAccount`) is left untouched to avoid conflicting with in-flight work surfacing real integrator status on responses.
- **`UserInfo.password` / `OrgMember.password`** are also write-only fields on shared models, but they're already neutralized at runtime by `omitempty` and acknowledged in comments. Making the response schema honest requires splitting those auth-critical types into request/response variants — proposed as a follow-up to keep this PR focused and low-risk.

## Notes for reviewers
- `meta` population is a judgment call: the field is now truthful and useful on every org response, but it does add payload to responses that previously omitted it (it was also separately available via the dedicated meta endpoint). Happy to instead drop it from the response model if you prefer keeping org payloads lean.
- Removing the three dead fields is technically a response-schema change, but each was always a zero value, so no consumer could have meaningfully relied on it.
- `go build ./...` and `go vet ./api/...` pass; the 4 provisioning tests were updated to the new request struct. The remaining `make lint` findings are pre-existing repo debt in untouched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)