### PR TITLE
fix(apikeys): match allowlist routes to registered census and status endpoints

### DIFF
--- a/api/apikeys.go
+++ b/api/apikeys.go
@@ -71,14 +71,14 @@ var apiKeyAllowlist = map[string]string{
 	// voting: processes, censuses, bundles (for managed organizations)
 	"POST " + processCreateEndpoint:                ScopeVotingWrite,
 	"POST " + processPublishEndpoint:               ScopeVotingWrite,
-	"POST " + processStatusEndpoint:                ScopeVotingWrite,
+	"PUT " + processStatusEndpoint:                 ScopeVotingWrite,
 	"GET " + organizationListProcessDraftsEndpoint: ScopeVotingWrite,
 	"GET " + organizationCensusesEndpoint:          ScopeVotingWrite,
 	"GET " + organizationBundlesEndpoint:           ScopeVotingWrite,
 	"POST " + censusEndpoint:                       ScopeVotingWrite,
 	"POST " + censusPublishEndpoint:                ScopeVotingWrite,
 	"POST " + censusGroupPublishEndpoint:           ScopeVotingWrite,
-	"POST " + censusParticipantsEndpoint:           ScopeVotingWrite,
+	"POST " + censusIDEndpoint:                     ScopeVotingWrite,
 	"POST " + processBundleEndpoint:                ScopeVotingWrite,
 	"PUT " + processBundleUpdateEndpoint:           ScopeVotingWrite,
 }

--- a/api/apikeys_test.go
+++ b/api/apikeys_test.go
@@ -65,6 +65,22 @@ func TestRequiredScopeForRoute(t *testing.T) {
 	_, ok = requiredScopeForRoute("GET", usersMeEndpoint)
 	c.Assert(ok, qt.IsFalse)
 
+	// regression: the allowlisted (method, pattern) must match the route actually
+	// registered in initRouter, or key auth can never reach the handler. These two
+	// drifted once (POST /census/{id}/participants vs POST /census/{id}; POST vs PUT
+	// status), which silently blocked census population and status changes via API key.
+	scope, ok = requiredScopeForRoute("POST", censusIDEndpoint) // add census participants
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(scope, qt.Equals, ScopeVotingWrite)
+	scope, ok = requiredScopeForRoute("PUT", processStatusEndpoint) // change election status
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(scope, qt.Equals, ScopeVotingWrite)
+	// the previously-wrong keys must not linger (they matched no real route)
+	_, ok = requiredScopeForRoute("POST", censusParticipantsEndpoint)
+	c.Assert(ok, qt.IsFalse)
+	_, ok = requiredScopeForRoute("POST", processStatusEndpoint)
+	c.Assert(ok, qt.IsFalse)
+
 	// every allowlisted scope is a valid, assignable scope
 	for route, sc := range apiKeyAllowlist {
 		c.Assert(IsValidAPIKeyScope(sc), qt.IsTrue, qt.Commentf("route %q maps to unknown scope %q", route, sc))


### PR DESCRIPTION
Closes #543

## Problem

Two `apiKeyAllowlist` entries (`api/apikeys.go`) didn't match the routes registered in `api/api.go`. Key auth resolves `requiredScopeForRoute(r.Method, chi.RoutePattern())`, so a wrong method/pattern means the **real** route isn't allowlisted → `ErrAPIKeyNotAllowed`, while the allowlist entry points at a non-existent route. Net effect: with a `vsk_` API key you **cannot populate a census** or **pause/end/cancel an election** — both core integrator-journey steps.

| Step | Allowlist had | Real route |
|---|---|---|
| Add census participants | `POST /census/{id}/participants` | `POST /census/{id}` (`/participants` is GET-only) |
| Change election status | `POST /process/{processId}/status` | **`PUT`** `/process/{processId}/status` |

## Fix

```go
"PUT "  + processStatusEndpoint: ScopeVotingWrite,  // was "POST "
"POST " + censusIDEndpoint:      ScopeVotingWrite,  // was "POST " + censusParticipantsEndpoint
```

Plus regression assertions in `TestRequiredScopeForRoute` pinning the corrected (method, route) pairs and asserting the old wrong keys are gone, so future drift from the registered method/pattern is caught without standing up a live router.

## Scope / safety

- Affects `voting:write` API keys only; JWT auth was never impacted. The bug was overly **restrictive**, not permissive — no security exposure, but it blocked the documented flow.
- `make lint` clean, `go vet ./api/` clean. The new assertions are pure map lookups; the api-package test harness needs Docker (testcontainers) which wasn't available here, so the container-backed suite wasn't run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)