### PR TITLE
chore: disable Claude Code co-author trailer

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "includeCoAuthoredBy": false
+}


### PR DESCRIPTION
Sets `includeCoAuthoredBy: false` in `.claude/settings.json` so Claude Code no longer appends the `Co-Authored-By: Claude …` and `🤖 Generated with Claude Code` lines to commits and PRs in this repo.

Team-shared project setting (committed, applies to everyone working in the repo).