### PR TITLE
docs(swagger): document census, member and group endpoints for integrator key auth

### DIFF
--- a/api/census.go
+++ b/api/census.go
@@ -24,7 +24,10 @@ const (
 // createCensusHandler godoc
 //
 //	@Summary		Create a new census
-//	@Description	Create a new census for an organization. Requires Manager/Admin role.
+//	@Description	Create a new census for an organization. Requires Manager/Admin role. Members are
+//	@Description	added later (see POST /census/{id}); this only creates the empty census.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `voting:write`).
 //	@Tags			census
 //	@Accept			json
 //	@Produce		json
@@ -105,10 +108,13 @@ func (a *API) censusInfoHandler(w http.ResponseWriter, r *http.Request) {
 // addCensusParticipantsHandler godoc
 //
 //	@Summary		Add organization members to a census
-//	@Description	Add existing organization members to a census by member ID (synchronous).
-//	@Description	Members already in the census are skipped.
-//	@Description	Returns number of participants added plus per-member errors in the response `errors` field.
-//	@Description	Requires Manager/Admin role.
+//	@Description	Add existing organization members to a census by member ID (synchronous). Members
+//	@Description	already in the census are skipped. Returns the number of participants added plus
+//	@Description	per-member errors in the response `errors` field. An empty member ID list is a no-op
+//	@Description	that returns added=0. Requires Manager/Admin role and is subject to the plan's census
+//	@Description	quota.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `voting:write`).
 //	@Tags			census
 //	@Accept			json
 //	@Produce		json
@@ -116,8 +122,9 @@ func (a *API) censusInfoHandler(w http.ResponseWriter, r *http.Request) {
 //	@Param			id		path		string									true	"Census ID"
 //	@Param			request	body		apicommon.AddCensusParticipantsRequest	true	"Participant member IDs to add"
 //	@Success		200		{object}	apicommon.AddMembersResponse			"Added count and optional per-member errors"
-//	@Failure		400		{object}	errors.Error							"Invalid input data"
+//	@Failure		400		{object}	errors.Error							"Invalid input data or census not found"
 //	@Failure		401		{object}	errors.Error							"Unauthorized"
+//	@Failure		403		{object}	errors.Error							"Plan census quota exceeded"
 //	@Failure		404		{object}	errors.Error							"Census not found"
 //	@Failure		500		{object}	errors.Error							"Internal server error"
 //	@Router			/census/{id} [post]
@@ -196,7 +203,11 @@ func (a *API) addCensusParticipantsHandler(w http.ResponseWriter, r *http.Reques
 // publishCensusHandler godoc
 //
 //	@Summary		Publish a census for voting
-//	@Description	Publish a census for voting. Requires Manager/Admin role. Returns published census with credentials.
+//	@Description	Publish a census for voting (the CSP public key becomes the census root). Requires
+//	@Description	Manager/Admin role. Returns the published census URI and root. Idempotent: a census
+//	@Description	that is already published is returned as-is without re-publishing.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `voting:write`).
 //	@Tags			census
 //	@Accept			json
 //	@Produce		json
@@ -205,7 +216,7 @@ func (a *API) addCensusParticipantsHandler(w http.ResponseWriter, r *http.Reques
 //	@Success		200	{object}	apicommon.PublishedCensusResponse
 //	@Failure		400	{object}	errors.Error	"Invalid census ID"
 //	@Failure		401	{object}	errors.Error	"Unauthorized"
-//	@Failure		404	{object}	errors.Error	"Census not found"
+//	@Failure		404	{object}	errors.Error	"Census not found or unsupported census type"
 //	@Failure		500	{object}	errors.Error	"Internal server error"
 //	@Router			/census/{id}/publish [post]
 func (a *API) publishCensusHandler(w http.ResponseWriter, r *http.Request) {
@@ -276,7 +287,8 @@ func (a *API) publishCensusHandler(w http.ResponseWriter, r *http.Request) {
 //	@Description	The request body selects the CSP authentication: at least one of authFields or twoFaFields
 //	@Description	must be provided. Supplying only authFields yields an auth-only census (members authenticate
 //	@Description	with their data, no OTP); twoFaFields adds an email/SMS OTP challenge. A body with both empty
-//	@Description	is rejected with 404 (ErrCensusTypeNotFound). Returns the published census root and URI.
+//	@Description	is rejected with 404 (ErrCensusTypeNotFound). Subject to the plan's census quota. Idempotent:
+//	@Description	an already-published census is returned as-is. Returns the published census root and URI.
 //	@Description
 //	@Description	Also callable with a scoped API key (scope: `voting:write`).
 //	@Tags			census
@@ -284,11 +296,12 @@ func (a *API) publishCensusHandler(w http.ResponseWriter, r *http.Request) {
 //	@Produce		json
 //	@Security		BearerAuth
 //	@Param			id		path		string								true	"Census ID"
-//	@Param			groupId	path		string								true	"Group ID"
+//	@Param			groupid	path		string								true	"Group ID"
 //	@Param			request	body		apicommon.PublishCensusGroupRequest	true	"Census authentication configuration"
 //	@Success		200		{object}	apicommon.PublishedCensusResponse
 //	@Failure		400		{object}	errors.Error	"Invalid census ID or group ID"
 //	@Failure		401		{object}	errors.Error	"Unauthorized"
+//	@Failure		403		{object}	errors.Error	"Plan census quota exceeded"
 //	@Failure		404		{object}	errors.Error	"Census not found, or neither authFields nor twoFaFields provided (ErrCensusTypeNotFound)"
 //	@Failure		500		{object}	errors.Error	"Internal server error"
 //	@Router			/census/{id}/group/{groupid}/publish [post]

--- a/api/org_members.go
+++ b/api/org_members.go
@@ -281,7 +281,9 @@ func (a *API) addOrganizationMembersHandler(w http.ResponseWriter, r *http.Reque
 //
 //	@Summary		Check the progress of adding members
 //	@Description	Check the progress of a job to add members to an organization. Returns the progress of the job.
-//	@Description	If the job is completed, the job is deleted after 60 seconds.
+//	@Description	While a job is running its status is served from memory; once completed, the in-memory status
+//	@Description	is evicted after 60 seconds. Completed jobs remain retrievable afterwards from the persisted
+//	@Description	job record (returned with progress 100).
 //	@Description
 //	@Description	Also callable with a scoped API key (scope: `members:write`).
 //	@Tags			organizations

--- a/api/org_members.go
+++ b/api/org_members.go
@@ -77,7 +77,9 @@ func (a *API) sendMembersImportCompletionEmail(userEmail, userName string, org *
 // organizationMembersHandler godoc
 //
 //	@Summary		Get organization members
-//	@Description	Retrieve all members of an organization with pagination support
+//	@Description	Retrieve all members of an organization with pagination support. Requires Manager/Admin role.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `members:write`).
 //	@Tags			organizations
 //	@Accept			json
 //	@Produce		json
@@ -146,18 +148,24 @@ func (a *API) organizationMembersHandler(w http.ResponseWriter, r *http.Request)
 // addOrganizationMembersHandler godoc
 //
 //	@Summary		Add members to an organization
-//	@Description	Add multiple members to an organization. Requires Manager/Admin role.
+//	@Description	Add multiple members to an organization. Requires Manager/Admin role and is subject to the
+//	@Description	plan's member quota. With `async=true` the import runs in the background and the response
+//	@Description	carries a `jobId` to poll via GET /organizations/{address}/members/job/{jobid}; otherwise it
+//	@Description	completes synchronously. An empty members list is a no-op that returns added=0.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `members:write`).
 //	@Tags			organizations
 //	@Accept			json
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			address	path		string						true	"Organization address"
-//	@Param			async	query		boolean						false	"Process asynchronously and return job ID"
-//	@Param			request	body		apicommon.AddMembersRequest	true	"Members to add"
-//	@Success		200		{object}	apicommon.AddMembersResponse
-//	@Failure		400		{object}	errors.Error	"Invalid input data"
-//	@Failure		401		{object}	errors.Error	"Unauthorized"
-//	@Failure		500		{object}	errors.Error	"Internal server error"
+//	@Param			address	path		string							true	"Organization address"
+//	@Param			async	query		boolean							false	"Process asynchronously and return job ID"
+//	@Param			request	body		apicommon.AddMembersRequest		true	"Members to add"
+//	@Success		200		{object}	apicommon.AddMembersResponse	"Added count (sync) or jobId (async)"
+//	@Failure		400		{object}	errors.Error					"Invalid input data"
+//	@Failure		401		{object}	errors.Error					"Unauthorized"
+//	@Failure		403		{object}	errors.Error					"Plan member quota exceeded"
+//	@Failure		500		{object}	errors.Error					"Internal server error"
 //	@Router			/organizations/{address}/members [post]
 func (a *API) addOrganizationMembersHandler(w http.ResponseWriter, r *http.Request) {
 	// get the organization info from the request context
@@ -274,6 +282,8 @@ func (a *API) addOrganizationMembersHandler(w http.ResponseWriter, r *http.Reque
 //	@Summary		Check the progress of adding members
 //	@Description	Check the progress of a job to add members to an organization. Returns the progress of the job.
 //	@Description	If the job is completed, the job is deleted after 60 seconds.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `members:write`).
 //	@Tags			organizations
 //	@Accept			json
 //	@Produce		json
@@ -284,6 +294,7 @@ func (a *API) addOrganizationMembersHandler(w http.ResponseWriter, r *http.Reque
 //	@Failure		400		{object}	errors.Error	"Invalid job ID"
 //	@Failure		401		{object}	errors.Error	"Unauthorized"
 //	@Failure		404		{object}	errors.Error	"Job not found"
+//	@Failure		500		{object}	errors.Error	"Internal server error"
 //	@Router			/organizations/{address}/members/job/{jobid} [get]
 func (a *API) addOrganizationMembersJobStatusHandler(w http.ResponseWriter, r *http.Request) {
 	jobID := internal.HexBytes{}
@@ -340,6 +351,8 @@ func (a *API) addOrganizationMembersJobStatusHandler(w http.ResponseWriter, r *h
 //	@Summary		Create or update an organization member
 //	@Description	Create or update an organization member. Requires Manager/Admin role.
 //	@Description	Automatically updates census participant hashes when member data changes.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `members:write`).
 //	@Tags			organizations
 //	@Accept			json
 //	@Produce		json
@@ -396,7 +409,10 @@ func (a *API) upsertOrganizationMemberHandler(w http.ResponseWriter, r *http.Req
 // deleteOrganizationMembersHandler godoc
 //
 //	@Summary		Delete organization members
-//	@Description	Delete multiple members from an organization or all members. Requires Manager/Admin role.
+//	@Description	Delete specific members (by ID) or all members of an organization. Requires Manager/Admin
+//	@Description	role. An empty ID list (without the `all` flag) is a no-op that returns count=0.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `members:write`).
 //	@Tags			organizations
 //	@Accept			json
 //	@Produce		json
@@ -407,7 +423,7 @@ func (a *API) upsertOrganizationMemberHandler(w http.ResponseWriter, r *http.Req
 //	@Failure		400		{object}	errors.Error	"Invalid input data"
 //	@Failure		401		{object}	errors.Error	"Unauthorized"
 //	@Failure		500		{object}	errors.Error	"Internal server error"
-//	@Router			/organizations/{address}/member [delete]
+//	@Router			/organizations/{address}/members [delete]
 func (a *API) deleteOrganizationMembersHandler(w http.ResponseWriter, r *http.Request) {
 	// get the organization info from the request context
 	org, _, ok := a.organizationFromRequest(r)

--- a/api/organization_groups.go
+++ b/api/organization_groups.go
@@ -16,7 +16,9 @@ import (
 //	@Summary		Get organization member groups
 //	@Description	Get the list of groups and their info of the organization
 //	@Description	Does not return the members of the groups, only the groups themselves.
-//	@Description	Needs admin or manager role
+//	@Description	Needs admin or manager role.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `members:write`).
 //	@Tags			organizations
 //	@Accept			json
 //	@Produce		json
@@ -25,9 +27,8 @@ import (
 //	@Param			page	query		integer	false	"Page number (default: 1)"
 //	@Param			limit	query		integer	false	"Number of items per page (default: 10)"
 //	@Success		200		{object}	apicommon.OrganizationMemberGroupsResponse
-//	@Failure		400		{object}	errors.Error	"Invalid input data"
+//	@Failure		400		{object}	errors.Error	"Invalid input data, or organization not found"
 //	@Failure		401		{object}	errors.Error	"Unauthorized"
-//	@Failure		404		{object}	errors.Error	"Organization not found"
 //	@Failure		500		{object}	errors.Error	"Internal server error"
 //	@Router			/organizations/{address}/groups [get]
 func (a *API) organizationMemberGroupsHandler(w http.ResponseWriter, r *http.Request) {
@@ -88,7 +89,9 @@ func (a *API) organizationMemberGroupsHandler(w http.ResponseWriter, r *http.Req
 //
 //	@Summary		Get the information of an organization member group
 //	@Description	Get the information of an organization member group by its ID
-//	@Description	Needs admin or manager role
+//	@Description	Needs admin or manager role.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `members:write`).
 //	@Tags			organizations
 //	@Accept			json
 //	@Produce		json
@@ -96,9 +99,8 @@ func (a *API) organizationMemberGroupsHandler(w http.ResponseWriter, r *http.Req
 //	@Param			address	path		string	true	"Organization address"
 //	@Param			groupID	path		string	true	"Group ID"
 //	@Success		200		{object}	apicommon.OrganizationMemberGroupInfo
-//	@Failure		400		{object}	errors.Error	"Invalid input data"
+//	@Failure		400		{object}	errors.Error	"Invalid input data, or organization/group not found"
 //	@Failure		401		{object}	errors.Error	"Unauthorized"
-//	@Failure		404		{object}	errors.Error	"Organization or group not found"
 //	@Failure		500		{object}	errors.Error	"Internal server error"
 //	@Router			/organizations/{address}/groups/{groupID} [get]
 func (a *API) organizationMemberGroupHandler(w http.ResponseWriter, r *http.Request) {
@@ -163,8 +165,10 @@ func (a *API) organizationMemberGroupHandler(w http.ResponseWriter, r *http.Requ
 // createOrganizationMemberGroupHandler godoc
 //
 //	@Summary		Create an organization member group
-//	@Description	Create an organization member group with the given members or all members
-//	@Description	Needs admin or manager role
+//	@Description	Create an organization member group with the given members, or with all members when
+//	@Description	`includeAllMembers` is set. Needs admin or manager role.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `members:write`).
 //	@Tags			organizations
 //	@Accept			json
 //	@Produce		json
@@ -172,9 +176,8 @@ func (a *API) organizationMemberGroupHandler(w http.ResponseWriter, r *http.Requ
 //	@Param			address	path		string											true	"Organization address"
 //	@Param			group	body		apicommon.CreateOrganizationMemberGroupRequest	true	"Group info to create"
 //	@Success		200		{object}	apicommon.OrganizationMemberGroupInfo
-//	@Failure		400		{object}	errors.Error	"Invalid input data"
+//	@Failure		400		{object}	errors.Error	"Invalid input data, or organization not found"
 //	@Failure		401		{object}	errors.Error	"Unauthorized"
-//	@Failure		404		{object}	errors.Error	"Organization not found"
 //	@Failure		500		{object}	errors.Error	"Internal server error"
 //	@Router			/organizations/{address}/groups [post]
 func (a *API) createOrganizationMemberGroupHandler(w http.ResponseWriter, r *http.Request) {
@@ -247,8 +250,11 @@ func (a *API) createOrganizationMemberGroupHandler(w http.ResponseWriter, r *htt
 // updateOrganizationMemberGroupHandler godoc
 //
 //	@Summary		Update an organization member group
-//	@Description	Update an organization member group changing the info, and adding or removing members
-//	@Description	Needs admin or manager role
+//	@Description	Update an organization member group changing the info, and adding or removing members.
+//	@Description	Needs admin or manager role. The auto-generated "All members" group cannot have its
+//	@Description	membership modified.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `members:write`).
 //	@Tags			organizations
 //	@Accept			json
 //	@Produce		json
@@ -257,9 +263,9 @@ func (a *API) createOrganizationMemberGroupHandler(w http.ResponseWriter, r *htt
 //	@Param			groupID	path		string											true	"Group ID"
 //	@Param			group	body		apicommon.UpdateOrganizationMemberGroupsRequest	true	"Group info to update"
 //	@Success		200		{string}	string											"OK"
-//	@Failure		400		{object}	errors.Error									"Invalid input data"
+//	@Failure		400		{object}	errors.Error									"Invalid input data, or organization/group not found"
 //	@Failure		401		{object}	errors.Error									"Unauthorized"
-//	@Failure		404		{object}	errors.Error									"Organization or group not found"
+//	@Failure		403		{object}	errors.Error									"Auto-generated group membership cannot be modified"
 //	@Failure		500		{object}	errors.Error									"Internal server error"
 //	@Router			/organizations/{address}/groups/{groupID} [put]
 func (a *API) updateOrganizationMemberGroupHandler(w http.ResponseWriter, r *http.Request) {
@@ -318,7 +324,10 @@ func (a *API) updateOrganizationMemberGroupHandler(w http.ResponseWriter, r *htt
 // deleteOrganizationMemberGroupHandler godoc
 //
 //	@Summary		Delete an organization member group
-//	@Description	Delete an organization member group by its ID
+//	@Description	Delete an organization member group by its ID. Needs admin or manager role. The
+//	@Description	auto-generated "All members" group cannot be deleted.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `members:write`).
 //	@Tags			organizations
 //	@Accept			json
 //	@Produce		json
@@ -326,9 +335,9 @@ func (a *API) updateOrganizationMemberGroupHandler(w http.ResponseWriter, r *htt
 //	@Param			address	path		string			true	"Organization address"
 //	@Param			groupID	path		string			true	"Group ID"
 //	@Success		200		{string}	string			"OK"
-//	@Failure		400		{object}	errors.Error	"Invalid input data"
+//	@Failure		400		{object}	errors.Error	"Invalid input data, or organization/group not found"
 //	@Failure		401		{object}	errors.Error	"Unauthorized"
-//	@Failure		404		{object}	errors.Error	"Organization or group not found"
+//	@Failure		403		{object}	errors.Error	"Auto-generated group cannot be deleted"
 //	@Failure		500		{object}	errors.Error	"Internal server error"
 //	@Router			/organizations/{address}/groups/{groupID} [delete]
 func (a *API) deleteOrganizationMemberGroupHandler(w http.ResponseWriter, r *http.Request) {
@@ -372,8 +381,10 @@ func (a *API) deleteOrganizationMemberGroupHandler(w http.ResponseWriter, r *htt
 // listOrganizationMemberGroupsHandler godoc
 //
 //	@Summary		Get the list of members with details of an organization member group
-//	@Description	Get the list of members with details of an organization member group
-//	@Description	Needs admin or manager role
+//	@Description	Get the paginated list of members with details of an organization member group.
+//	@Description	Needs admin or manager role.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `members:write`).
 //	@Tags			organizations
 //	@Accept			json
 //	@Produce		json
@@ -383,9 +394,8 @@ func (a *API) deleteOrganizationMemberGroupHandler(w http.ResponseWriter, r *htt
 //	@Param			page	query		int		false	"Page number for pagination"
 //	@Param			limit	query		int		false	"Number of items per page"
 //	@Success		200		{object}	apicommon.ListOrganizationMemberGroupResponse
-//	@Failure		400		{object}	errors.Error	"Invalid input data"
+//	@Failure		400		{object}	errors.Error	"Invalid input data, or organization/group not found"
 //	@Failure		401		{object}	errors.Error	"Unauthorized"
-//	@Failure		404		{object}	errors.Error	"Organization or group not found"
 //	@Failure		500		{object}	errors.Error	"Internal server error"
 //	@Router			/organizations/{address}/groups/{groupID}/members [get]
 func (a *API) listOrganizationMemberGroupsHandler(w http.ResponseWriter, r *http.Request) {
@@ -450,6 +460,10 @@ func (a *API) listOrganizationMemberGroupsHandler(w http.ResponseWriter, r *http
 //
 //	@Summary		Validate organization group members data
 //	@Description	Checks the AuthFields for duplicates or empty fields and the TwoFaFields for empty ones.
+//	@Description	On failure the offending member IDs are returned in the error `data`. Needs admin or
+//	@Description	manager role.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `members:write`).
 //	@Tags			organizations
 //	@Accept			json
 //	@Produce		json
@@ -458,9 +472,8 @@ func (a *API) listOrganizationMemberGroupsHandler(w http.ResponseWriter, r *http
 //	@Param			groupID	path		string									true	"Group ID"
 //	@Param			members	body		apicommon.ValidateMemberGroupRequest	true	"Members validation request"
 //	@Success		200		{string}	string									"OK"
-//	@Failure		400		{object}	errors.Error							"Invalid input data"
+//	@Failure		400		{object}	errors.Error							"Invalid input data, duplicate/missing fields, or organization/group not found"
 //	@Failure		401		{object}	errors.Error							"Unauthorized"
-//	@Failure		404		{object}	errors.Error							"Organization or group not found"
 //	@Failure		500		{object}	errors.Error							"Internal server error"
 //
 //	@Router			/organizations/{address}/groups/{groupID}/validate [post]

--- a/api/process_bundles.go
+++ b/api/process_bundles.go
@@ -56,9 +56,9 @@ func (a *API) resolveBundleProcessID(raw string) (internal.HexBytes, *errors.Err
 // createProcessBundleHandler godoc
 //
 //	@Summary		Create a new process bundle
-//	@Description	Create a new process bundle with the specified census and optional list of processes. Requires
-//	@Description	Manager/Admin role for the organization that owns the census. The census root will be the same as the
-//	@Description	account's public key.
+//	@Description	Create a new process bundle linking a census to an optional list of on-chain processes,
+//	@Description	used by the CSP voter flow. Requires Manager/Admin role for the organization that owns
+//	@Description	the census. The census root is the CSP (account) public key.
 //	@Description
 //	@Description	Also callable with a scoped API key (scope: `voting:write`).
 //	@Tags			process
@@ -67,9 +67,8 @@ func (a *API) resolveBundleProcessID(raw string) (internal.HexBytes, *errors.Err
 //	@Security		BearerAuth
 //	@Param			request	body		apicommon.CreateProcessBundleRequest	true	"Process bundle creation information"
 //	@Success		200		{object}	apicommon.CreateProcessBundleResponse
-//	@Failure		400		{object}	errors.Error	"Invalid input data"
+//	@Failure		400		{object}	errors.Error	"Invalid input data, or census/organization not found"
 //	@Failure		401		{object}	errors.Error	"Unauthorized"
-//	@Failure		404		{object}	errors.Error	"Census not found"
 //	@Failure		500		{object}	errors.Error	"Internal server error"
 //	@Router			/process/bundle [post]
 func (a *API) createProcessBundleHandler(w http.ResponseWriter, r *http.Request) {
@@ -207,8 +206,9 @@ func (a *API) createProcessBundleHandler(w http.ResponseWriter, r *http.Request)
 // updateProcessBundleHandler godoc
 //
 //	@Summary		Add processes to an existing bundle
-//	@Description	Add additional processes to an existing bundle. Requires Manager/Admin role for the organization
-//	@Description	that owns the bundle.
+//	@Description	Add additional on-chain processes to an existing bundle. Requires Manager/Admin role for
+//	@Description	the organization that owns the bundle. An empty process list is a no-op that returns the
+//	@Description	bundle's current root.
 //	@Description
 //	@Description	Also callable with a scoped API key (scope: `voting:write`).
 //	@Tags			process
@@ -218,9 +218,8 @@ func (a *API) createProcessBundleHandler(w http.ResponseWriter, r *http.Request)
 //	@Param			bundleId	path		string						true	"Bundle ID"
 //	@Param			request		body		AddProcessesToBundleRequest	true	"Processes to add"
 //	@Success		200			{object}	apicommon.CreateProcessBundleResponse
-//	@Failure		400			{object}	errors.Error	"Invalid input data"
+//	@Failure		400			{object}	errors.Error	"Invalid input data, or bundle not found"
 //	@Failure		401			{object}	errors.Error	"Unauthorized"
-//	@Failure		404			{object}	errors.Error	"Bundle or census not found"
 //	@Failure		500			{object}	errors.Error	"Internal server error"
 //	@Router			/process/bundle/{bundleId} [put]
 func (a *API) updateProcessBundleHandler(w http.ResponseWriter, r *http.Request) {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3622,7 +3622,9 @@ paths:
       - application/json
       description: |-
         Check the progress of a job to add members to an organization. Returns the progress of the job.
-        If the job is completed, the job is deleted after 60 seconds.
+        While a job is running its status is served from memory; once completed, the in-memory status
+        is evicted after 60 seconds. Completed jobs remain retrievable afterwards from the persisted
+        job record (returned with progress 100).
 
         Also callable with a scoped API key (scope: `members:write`).
       parameters:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2184,8 +2184,11 @@ paths:
     post:
       consumes:
       - application/json
-      description: Create a new census for an organization. Requires Manager/Admin
-        role.
+      description: |-
+        Create a new census for an organization. Requires Manager/Admin role. Members are
+        added later (see POST /census/{id}); this only creates the empty census.
+
+        Also callable with a scoped API key (scope: `voting:write`).
       parameters:
       - description: Census information
         in: body
@@ -2255,10 +2258,13 @@ paths:
       consumes:
       - application/json
       description: |-
-        Add existing organization members to a census by member ID (synchronous).
-        Members already in the census are skipped.
-        Returns number of participants added plus per-member errors in the response `errors` field.
-        Requires Manager/Admin role.
+        Add existing organization members to a census by member ID (synchronous). Members
+        already in the census are skipped. Returns the number of participants added plus
+        per-member errors in the response `errors` field. An empty member ID list is a no-op
+        that returns added=0. Requires Manager/Admin role and is subject to the plan's census
+        quota.
+
+        Also callable with a scoped API key (scope: `voting:write`).
       parameters:
       - description: Census ID
         in: path
@@ -2279,11 +2285,15 @@ paths:
           schema:
             $ref: '#/definitions/apicommon.AddMembersResponse'
         "400":
-          description: Invalid input data
+          description: Invalid input data or census not found
           schema:
             $ref: '#/definitions/errors.Error'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "403":
+          description: Plan census quota exceeded
           schema:
             $ref: '#/definitions/errors.Error'
         "404":
@@ -2308,7 +2318,8 @@ paths:
         The request body selects the CSP authentication: at least one of authFields or twoFaFields
         must be provided. Supplying only authFields yields an auth-only census (members authenticate
         with their data, no OTP); twoFaFields adds an email/SMS OTP challenge. A body with both empty
-        is rejected with 404 (ErrCensusTypeNotFound). Returns the published census root and URI.
+        is rejected with 404 (ErrCensusTypeNotFound). Subject to the plan's census quota. Idempotent:
+        an already-published census is returned as-is. Returns the published census root and URI.
 
         Also callable with a scoped API key (scope: `voting:write`).
       parameters:
@@ -2319,7 +2330,7 @@ paths:
         type: string
       - description: Group ID
         in: path
-        name: groupId
+        name: groupid
         required: true
         type: string
       - description: Census authentication configuration
@@ -2341,6 +2352,10 @@ paths:
             $ref: '#/definitions/errors.Error'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "403":
+          description: Plan census quota exceeded
           schema:
             $ref: '#/definitions/errors.Error'
         "404":
@@ -2401,8 +2416,12 @@ paths:
     post:
       consumes:
       - application/json
-      description: Publish a census for voting. Requires Manager/Admin role. Returns
-        published census with credentials.
+      description: |-
+        Publish a census for voting (the CSP public key becomes the census root). Requires
+        Manager/Admin role. Returns the published census URI and root. Idempotent: a census
+        that is already published is returned as-is without re-publishing.
+
+        Also callable with a scoped API key (scope: `voting:write`).
       parameters:
       - description: Census ID
         in: path
@@ -2425,7 +2444,7 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
         "404":
-          description: Census not found
+          description: Census not found or unsupported census type
           schema:
             $ref: '#/definitions/errors.Error'
         "500":
@@ -3019,7 +3038,9 @@ paths:
       description: |-
         Get the list of groups and their info of the organization
         Does not return the members of the groups, only the groups themselves.
-        Needs admin or manager role
+        Needs admin or manager role.
+
+        Also callable with a scoped API key (scope: `members:write`).
       parameters:
       - description: Organization address
         in: path
@@ -3042,15 +3063,11 @@ paths:
           schema:
             $ref: '#/definitions/apicommon.OrganizationMemberGroupsResponse'
         "400":
-          description: Invalid input data
+          description: Invalid input data, or organization not found
           schema:
             $ref: '#/definitions/errors.Error'
         "401":
           description: Unauthorized
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "404":
-          description: Organization not found
           schema:
             $ref: '#/definitions/errors.Error'
         "500":
@@ -3066,8 +3083,10 @@ paths:
       consumes:
       - application/json
       description: |-
-        Create an organization member group with the given members or all members
-        Needs admin or manager role
+        Create an organization member group with the given members, or with all members when
+        `includeAllMembers` is set. Needs admin or manager role.
+
+        Also callable with a scoped API key (scope: `members:write`).
       parameters:
       - description: Organization address
         in: path
@@ -3088,15 +3107,11 @@ paths:
           schema:
             $ref: '#/definitions/apicommon.OrganizationMemberGroupInfo'
         "400":
-          description: Invalid input data
+          description: Invalid input data, or organization not found
           schema:
             $ref: '#/definitions/errors.Error'
         "401":
           description: Unauthorized
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "404":
-          description: Organization not found
           schema:
             $ref: '#/definitions/errors.Error'
         "500":
@@ -3112,7 +3127,11 @@ paths:
     delete:
       consumes:
       - application/json
-      description: Delete an organization member group by its ID
+      description: |-
+        Delete an organization member group by its ID. Needs admin or manager role. The
+        auto-generated "All members" group cannot be deleted.
+
+        Also callable with a scoped API key (scope: `members:write`).
       parameters:
       - description: Organization address
         in: path
@@ -3132,15 +3151,15 @@ paths:
           schema:
             type: string
         "400":
-          description: Invalid input data
+          description: Invalid input data, or organization/group not found
           schema:
             $ref: '#/definitions/errors.Error'
         "401":
           description: Unauthorized
           schema:
             $ref: '#/definitions/errors.Error'
-        "404":
-          description: Organization or group not found
+        "403":
+          description: Auto-generated group cannot be deleted
           schema:
             $ref: '#/definitions/errors.Error'
         "500":
@@ -3157,7 +3176,9 @@ paths:
       - application/json
       description: |-
         Get the information of an organization member group by its ID
-        Needs admin or manager role
+        Needs admin or manager role.
+
+        Also callable with a scoped API key (scope: `members:write`).
       parameters:
       - description: Organization address
         in: path
@@ -3177,15 +3198,11 @@ paths:
           schema:
             $ref: '#/definitions/apicommon.OrganizationMemberGroupInfo'
         "400":
-          description: Invalid input data
+          description: Invalid input data, or organization/group not found
           schema:
             $ref: '#/definitions/errors.Error'
         "401":
           description: Unauthorized
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "404":
-          description: Organization or group not found
           schema:
             $ref: '#/definitions/errors.Error'
         "500":
@@ -3201,8 +3218,11 @@ paths:
       consumes:
       - application/json
       description: |-
-        Update an organization member group changing the info, and adding or removing members
-        Needs admin or manager role
+        Update an organization member group changing the info, and adding or removing members.
+        Needs admin or manager role. The auto-generated "All members" group cannot have its
+        membership modified.
+
+        Also callable with a scoped API key (scope: `members:write`).
       parameters:
       - description: Organization address
         in: path
@@ -3228,15 +3248,15 @@ paths:
           schema:
             type: string
         "400":
-          description: Invalid input data
+          description: Invalid input data, or organization/group not found
           schema:
             $ref: '#/definitions/errors.Error'
         "401":
           description: Unauthorized
           schema:
             $ref: '#/definitions/errors.Error'
-        "404":
-          description: Organization or group not found
+        "403":
+          description: Auto-generated group membership cannot be modified
           schema:
             $ref: '#/definitions/errors.Error'
         "500":
@@ -3253,8 +3273,10 @@ paths:
       consumes:
       - application/json
       description: |-
-        Get the list of members with details of an organization member group
-        Needs admin or manager role
+        Get the paginated list of members with details of an organization member group.
+        Needs admin or manager role.
+
+        Also callable with a scoped API key (scope: `members:write`).
       parameters:
       - description: Organization address
         in: path
@@ -3282,15 +3304,11 @@ paths:
           schema:
             $ref: '#/definitions/apicommon.ListOrganizationMemberGroupResponse'
         "400":
-          description: Invalid input data
+          description: Invalid input data, or organization/group not found
           schema:
             $ref: '#/definitions/errors.Error'
         "401":
           description: Unauthorized
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "404":
-          description: Organization or group not found
           schema:
             $ref: '#/definitions/errors.Error'
         "500":
@@ -3306,8 +3324,12 @@ paths:
     post:
       consumes:
       - application/json
-      description: Checks the AuthFields for duplicates or empty fields and the TwoFaFields
-        for empty ones.
+      description: |-
+        Checks the AuthFields for duplicates or empty fields and the TwoFaFields for empty ones.
+        On failure the offending member IDs are returned in the error `data`. Needs admin or
+        manager role.
+
+        Also callable with a scoped API key (scope: `members:write`).
       parameters:
       - description: Organization address
         in: path
@@ -3333,15 +3355,12 @@ paths:
           schema:
             type: string
         "400":
-          description: Invalid input data
+          description: Invalid input data, duplicate/missing fields, or organization/group
+            not found
           schema:
             $ref: '#/definitions/errors.Error'
         "401":
           description: Unauthorized
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "404":
-          description: Organization or group not found
           schema:
             $ref: '#/definitions/errors.Error'
         "500":
@@ -3405,12 +3424,15 @@ paths:
       summary: Get organization jobs
       tags:
       - organizations
-  /organizations/{address}/member:
+  /organizations/{address}/members:
     delete:
       consumes:
       - application/json
-      description: Delete multiple members from an organization or all members. Requires
-        Manager/Admin role.
+      description: |-
+        Delete specific members (by ID) or all members of an organization. Requires Manager/Admin
+        role. An empty ID list (without the `all` flag) is a no-op that returns count=0.
+
+        Also callable with a scoped API key (scope: `members:write`).
       parameters:
       - description: Organization address
         in: path
@@ -3447,11 +3469,13 @@ paths:
       summary: Delete organization members
       tags:
       - organizations
-  /organizations/{address}/members:
     get:
       consumes:
       - application/json
-      description: Retrieve all members of an organization with pagination support
+      description: |-
+        Retrieve all members of an organization with pagination support. Requires Manager/Admin role.
+
+        Also callable with a scoped API key (scope: `members:write`).
       parameters:
       - description: Organization address
         in: path
@@ -3497,8 +3521,13 @@ paths:
     post:
       consumes:
       - application/json
-      description: Add multiple members to an organization. Requires Manager/Admin
-        role.
+      description: |-
+        Add multiple members to an organization. Requires Manager/Admin role and is subject to the
+        plan's member quota. With `async=true` the import runs in the background and the response
+        carries a `jobId` to poll via GET /organizations/{address}/members/job/{jobid}; otherwise it
+        completes synchronously. An empty members list is a no-op that returns added=0.
+
+        Also callable with a scoped API key (scope: `members:write`).
       parameters:
       - description: Organization address
         in: path
@@ -3519,7 +3548,7 @@ paths:
       - application/json
       responses:
         "200":
-          description: OK
+          description: Added count (sync) or jobId (async)
           schema:
             $ref: '#/definitions/apicommon.AddMembersResponse'
         "400":
@@ -3528,6 +3557,10 @@ paths:
             $ref: '#/definitions/errors.Error'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "403":
+          description: Plan member quota exceeded
           schema:
             $ref: '#/definitions/errors.Error'
         "500":
@@ -3545,6 +3578,8 @@ paths:
       description: |-
         Create or update an organization member. Requires Manager/Admin role.
         Automatically updates census participant hashes when member data changes.
+
+        Also callable with a scoped API key (scope: `members:write`).
       parameters:
       - description: Organization address
         in: path
@@ -3588,6 +3623,8 @@ paths:
       description: |-
         Check the progress of a job to add members to an organization. Returns the progress of the job.
         If the job is completed, the job is deleted after 60 seconds.
+
+        Also callable with a scoped API key (scope: `members:write`).
       parameters:
       - description: Organization address
         in: path
@@ -3616,6 +3653,10 @@ paths:
             $ref: '#/definitions/errors.Error'
         "404":
           description: Job not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
           schema:
             $ref: '#/definitions/errors.Error'
       security:
@@ -4800,9 +4841,9 @@ paths:
       consumes:
       - application/json
       description: |-
-        Create a new process bundle with the specified census and optional list of processes. Requires
-        Manager/Admin role for the organization that owns the census. The census root will be the same as the
-        account's public key.
+        Create a new process bundle linking a census to an optional list of on-chain processes,
+        used by the CSP voter flow. Requires Manager/Admin role for the organization that owns
+        the census. The census root is the CSP (account) public key.
 
         Also callable with a scoped API key (scope: `voting:write`).
       parameters:
@@ -4820,15 +4861,11 @@ paths:
           schema:
             $ref: '#/definitions/apicommon.CreateProcessBundleResponse'
         "400":
-          description: Invalid input data
+          description: Invalid input data, or census/organization not found
           schema:
             $ref: '#/definitions/errors.Error'
         "401":
           description: Unauthorized
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "404":
-          description: Census not found
           schema:
             $ref: '#/definitions/errors.Error'
         "500":
@@ -4879,8 +4916,9 @@ paths:
       consumes:
       - application/json
       description: |-
-        Add additional processes to an existing bundle. Requires Manager/Admin role for the organization
-        that owns the bundle.
+        Add additional on-chain processes to an existing bundle. Requires Manager/Admin role for
+        the organization that owns the bundle. An empty process list is a no-op that returns the
+        bundle's current root.
 
         Also callable with a scoped API key (scope: `voting:write`).
       parameters:
@@ -4903,15 +4941,11 @@ paths:
           schema:
             $ref: '#/definitions/apicommon.CreateProcessBundleResponse'
         "400":
-          description: Invalid input data
+          description: Invalid input data, or bundle not found
           schema:
             $ref: '#/definitions/errors.Error'
         "401":
           description: Unauthorized
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "404":
-          description: Bundle or census not found
           schema:
             $ref: '#/definitions/errors.Error'
         "500":


### PR DESCRIPTION
## What

Second swagger pass over the integrator-journey endpoints that opt into **API-key auth** but weren't covered by the first pass (#541, now merged). Documentation-only — the only Go edits are godoc/swag comments, plus the regenerated `docs/swagger.yaml`. Verified each annotation against its handler.

## Changes

**Scope notes** (consistent with the first pass) — per allowlisted endpoint:
- `voting:write`: census create / add-participants / publish / group-publish, and bundle create / update.
- `members:write`: member list / add / upsert / delete / job-status, and group list / get / create / update / delete / members / validate.

**Error-code corrections** (read from the handlers):
- census add-participants & group-publish → added **403** (plan census quota).
- bundle create/update → census/bundle-not-found is **400** (`ErrMalformedURLParam`), not the documented 404.
- group handlers → removed a **phantom 404** (org and group not-found both return 400); update/delete group → added **403** (auto-generated "All members" group is protected).
- member add → added **403** (member quota); job-status → added **500**.

**Routing / param fixes:**
- delete-members `@Router` was `/member` (singular) → `/members`.
- group-publish `@Param groupId` → `groupid` (matches the chi param).

## Notes

- Rebased onto current `main` (cherry-picked the single commit; `make swagger` reproduces the result byte-for-byte).
- `golangci-lint run ./api/...` clean on the edited files (only the pre-existing `package api` test-name `revive` warning remains). Container test suite not run (no Docker), but all changes are comments + generated YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)