### PR TITLE
feat(apikeys): restrict API key creation to integrator organizations

### DIFF
--- a/api/apikeys_api_test.go
+++ b/api/apikeys_api_test.go
@@ -89,6 +89,10 @@ func TestAPIKeysRequireIntegrator(t *testing.T) {
 	_, code := testRequest(t, http.MethodPost, token, createBody, "organizations", orgAddr.String(), "apikeys")
 	c.Assert(code, qt.Equals, http.StatusForbidden) // ErrNotAnIntegrator
 
+	// a malformed {address} path param is rejected with 400, not silently treated as the zero address
+	_, code = testRequest(t, http.MethodPost, token, createBody, "organizations", "not-an-address", "apikeys")
+	c.Assert(code, qt.Equals, http.StatusBadRequest)
+
 	// enable the org as an integrator (override) and creation now succeeds
 	org, err := testDB.Organization(orgAddr)
 	c.Assert(err, qt.IsNil)

--- a/api/apikeys_api_test.go
+++ b/api/apikeys_api_test.go
@@ -75,3 +75,29 @@ func TestAPIKeysAPI(t *testing.T) {
 	_, code = testRequest(t, http.MethodGet, apiKey, nil, "organizations", orgAddr.String(), "integrator")
 	c.Assert(code, qt.Equals, http.StatusUnauthorized)
 }
+
+// TestAPIKeysRequireIntegrator verifies that API keys can only be created by integrator
+// organizations: a plain (non-integrator) org admin is rejected with 403, while the same
+// org once enabled as an integrator (override) is allowed.
+func TestAPIKeysRequireIntegrator(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "apikeyintegratorpass123")
+	orgAddr := testCreateOrganization(t, token) // plain org, not an integrator
+
+	// a plain org admin cannot mint keys (integrator-only)
+	createBody := &apicommon.CreateAPIKeyRequest{Label: "ci", Scopes: []string{ScopeQuotaRead}}
+	_, code := testRequest(t, http.MethodPost, token, createBody, "organizations", orgAddr.String(), "apikeys")
+	c.Assert(code, qt.Equals, http.StatusForbidden) // ErrNotAnIntegrator
+
+	// enable the org as an integrator (override) and creation now succeeds
+	org, err := testDB.Organization(orgAddr)
+	c.Assert(err, qt.IsNil)
+	org.IntegratorLimits = &db.IntegratorLimits{MaxManagedOrgs: 1}
+	c.Assert(testDB.SetOrganization(org), qt.IsNil)
+
+	data, code := testRequest(t, http.MethodPost, token, createBody, "organizations", orgAddr.String(), "apikeys")
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("resp: %s", data))
+	var created apicommon.CreateAPIKeyResponse
+	c.Assert(json.Unmarshal(data, &created), qt.IsNil)
+	c.Assert(strings.HasPrefix(created.Secret, APIKeyPrefix), qt.IsTrue)
+}

--- a/api/apikeys_handlers.go
+++ b/api/apikeys_handlers.go
@@ -17,7 +17,8 @@ import (
 //
 //	@Summary		Create an API key for an organization
 //	@Description	Create a new API key owned by the organization at the given address. The caller
-//	@Description	must be an admin of the organization. The plaintext secret (prefixed "vsk_") is
+//	@Description	must be an admin of the organization, which must be enabled as an integrator —
+//	@Description	API keys are integrator-only. The plaintext secret (prefixed "vsk_") is
 //	@Description	returned ONCE in the response and cannot be retrieved again.
 //	@Description
 //	@Description	`label` and at least one `scope` are required. Valid scopes are deny-by-default and
@@ -32,6 +33,7 @@ import (
 //	@Success		200		{object}	apicommon.CreateAPIKeyResponse	"Created key including the one-time plaintext secret"
 //	@Failure		400		{object}	errors.Error					"Invalid input (missing label/scopes, unknown scope, or past expiresAt)"
 //	@Failure		401		{object}	errors.Error					"Unauthorized"
+//	@Failure		403		{object}	errors.Error					"Organization is not an integrator"
 //	@Failure		500		{object}	errors.Error					"Internal server error"
 //	@Router			/organizations/{address}/apikeys [post]
 func (a *API) createAPIKeyHandler(w http.ResponseWriter, r *http.Request) {
@@ -43,6 +45,22 @@ func (a *API) createAPIKeyHandler(w http.ResponseWriter, r *http.Request) {
 	orgAddr := common.HexToAddress(chi.URLParam(r, "address"))
 	if !user.HasRoleFor(orgAddr, db.AdminRole) {
 		errors.ErrUnauthorized.Withf("user is not admin of the organization").Write(w)
+		return
+	}
+	// API keys are an integrator capability: only integrator organizations may mint them.
+	// A managed or plain org admin is rejected even though they are an admin, because the
+	// API-key scope set (quota/managed/voting/members) is integrator-oriented.
+	org, err := a.db.Organization(orgAddr)
+	if err != nil {
+		if err == db.ErrNotFound {
+			errors.ErrOrganizationNotFound.Write(w)
+			return
+		}
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+	if !a.subscriptions.IsIntegrator(org) {
+		errors.ErrNotAnIntegrator.Write(w)
 		return
 	}
 	req := &apicommon.CreateAPIKeyRequest{}

--- a/api/apikeys_handlers.go
+++ b/api/apikeys_handlers.go
@@ -31,9 +31,10 @@ import (
 //	@Param			address	path		string							true	"Organization address"
 //	@Param			request	body		apicommon.CreateAPIKeyRequest	true	"API key information"
 //	@Success		200		{object}	apicommon.CreateAPIKeyResponse	"Created key including the one-time plaintext secret"
-//	@Failure		400		{object}	errors.Error					"Invalid input (missing label/scopes, unknown scope, or past expiresAt)"
+//	@Failure		400		{object}	errors.Error					"Invalid input (bad address, missing label/scopes, unknown scope, past expiresAt)"
 //	@Failure		401		{object}	errors.Error					"Unauthorized"
 //	@Failure		403		{object}	errors.Error					"Organization is not an integrator"
+//	@Failure		404		{object}	errors.Error					"Organization not found"
 //	@Failure		500		{object}	errors.Error					"Internal server error"
 //	@Router			/organizations/{address}/apikeys [post]
 func (a *API) createAPIKeyHandler(w http.ResponseWriter, r *http.Request) {
@@ -42,7 +43,14 @@ func (a *API) createAPIKeyHandler(w http.ResponseWriter, r *http.Request) {
 		errors.ErrUnauthorized.Write(w)
 		return
 	}
-	orgAddr := common.HexToAddress(chi.URLParam(r, "address"))
+	// validate the address up front: common.HexToAddress silently maps a malformed {address}
+	// to the zero address, which would otherwise surface as a confusing 401/404 instead of 400.
+	addr := chi.URLParam(r, "address")
+	if !common.IsHexAddress(addr) {
+		errors.ErrMalformedURLParam.With("invalid organization address").Write(w)
+		return
+	}
+	orgAddr := common.HexToAddress(addr)
 	if !user.HasRoleFor(orgAddr, db.AdminRole) {
 		errors.ErrUnauthorized.Withf("user is not admin of the organization").Write(w)
 		return

--- a/api/apikeys_handlers.go
+++ b/api/apikeys_handlers.go
@@ -56,8 +56,10 @@ func (a *API) createAPIKeyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// API keys are an integrator capability: only integrator organizations may mint them.
-	// A managed or plain org admin is rejected even though they are an admin, because the
-	// API-key scope set (quota/managed/voting/members) is integrator-oriented.
+	// An admin of any org that is not integrator-enabled is rejected here, even though they
+	// are an admin, because the API-key scope set (quota/managed/voting/members) is
+	// integrator-oriented. Integrator status is determined by subscriptions.IsIntegrator,
+	// which accounts for per-org IntegratorLimits overrides and the active plan's limits.
 	org, err := a.db.Organization(orgAddr)
 	if err != nil {
 		if err == db.ErrNotFound {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2641,8 +2641,8 @@ paths:
           schema:
             $ref: '#/definitions/apicommon.CreateAPIKeyResponse'
         "400":
-          description: Invalid input (missing label/scopes, unknown scope, or past
-            expiresAt)
+          description: Invalid input (bad address, missing label/scopes, unknown scope,
+            past expiresAt)
           schema:
             $ref: '#/definitions/errors.Error'
         "401":
@@ -2651,6 +2651,10 @@ paths:
             $ref: '#/definitions/errors.Error'
         "403":
           description: Organization is not an integrator
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "404":
+          description: Organization not found
           schema:
             $ref: '#/definitions/errors.Error'
         "500":

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2614,7 +2614,8 @@ paths:
       - application/json
       description: |-
         Create a new API key owned by the organization at the given address. The caller
-        must be an admin of the organization. The plaintext secret (prefixed "vsk_") is
+        must be an admin of the organization, which must be enabled as an integrator —
+        API keys are integrator-only. The plaintext secret (prefixed "vsk_") is
         returned ONCE in the response and cannot be retrieved again.
 
         `label` and at least one `scope` are required. Valid scopes are deny-by-default and
@@ -2646,6 +2647,10 @@ paths:
             $ref: '#/definitions/errors.Error'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "403":
+          description: Organization is not an integrator
           schema:
             $ref: '#/definitions/errors.Error'
         "500":


### PR DESCRIPTION
## Problem

API keys were designed as an integrator capability — every assignable scope (`quota:read`, `managed:read/write`, `voting:write`, `members:write`) is integrator-oriented, and integrators use keys to drive their managed organizations. But `createAPIKeyHandler` checked only admin role on the target address, with **no integrator guard**. An admin of a managed or plain org could therefore mint working keys (the `voting:write`/`members:write` scopes actually function against such orgs).

This also leaves an orphan-`apiKeys`-rows gap for the upcoming `DELETE /organizations/{address}/managed/{orgAddress}` cascade: if a managed org ever minted keys, deleting it would leave orphaned rows pointing at a deleted org.

## Changes

- **`createAPIKeyHandler`** — after the admin role check, load the org and require `a.subscriptions.IsIntegrator(org)`, returning `ErrNotAnIntegrator` (403) otherwise. Mirrors the existing check in `createManagedOrganizationHandler`.
- Swag annotations updated to document the integrator requirement and the new `403` response.
- `docs/swagger.yaml` regenerated via `make swagger`.

The list / get / revoke endpoints are intentionally left open to any admin of the owning org, so legacy keys on non-integrator orgs (if any) remain manageable.

## Out of scope

- **Legacy keys** already created on non-integrator orgs are left as-is (non-destructive). API keys are a recent feature so this is unlikely to affect anyone in practice; a revoking migration can be added later if an audit shows any exist.
- Enforcing that managed orgs cannot have keys is a consequence of this change rather than a separate managed-org check — `IsIntegrator` is false for managed and plain orgs alike.

## Notes for reviewers

- The existing `TestAPIKeysAPI` was already written assuming this guard (it sets `IntegratorLimits` before creating keys), so this brings the code in line with the test rather than breaking it.
- New `TestAPIKeysRequireIntegrator` covers: plain org → 403, same org enabled as integrator via override → 200.
- `go build ./...`, `go vet`, and `go test -run TestAPIKeys ./api/` pass (Docker/testcontainers green). `golangci-lint` is not installed locally; `gofmt` clean.

---

**Update:** `golangci-lint` now installed locally. `make lint` reports 56 findings, **all pre-existing** in untouched files (`db/helpers.go`, `cmd/client/*`, `errors/errors.go`, `migrations/*`, plus 50 `goconst` across the repo). Zero findings in the two files this PR changes (`api/apikeys_handlers.go`, `api/apikeys_api_test.go`).