### PR TITLE
feat(api): delete managed organization with full cascade

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -320,6 +320,7 @@ func (a *API) initRouter() http.Handler {
 		handle(r, http.MethodGet, organizationBundlesEndpoint, a.organizationBundlesHandler)
 		handle(r, http.MethodPost, managedOrganizationsEndpoint, a.createManagedOrganizationHandler)
 		handle(r, http.MethodGet, managedOrganizationsEndpoint, a.managedOrganizationsHandler)
+		handle(r, http.MethodDelete, managedOrganizationEndpoint, a.deleteManagedOrganizationHandler)
 		handle(r, http.MethodGet, integratorEndpoint, a.integratorInfoHandler)
 		handle(r, http.MethodPost, organizationAPIKeysEndpoint, a.createAPIKeyHandler)
 		handle(r, http.MethodGet, organizationAPIKeysEndpoint, a.apiKeysHandler)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -310,7 +310,16 @@ func pingAPI(endpoint string, retries int) error {
 // starts the API server and waits for it to start before running the tests.
 func TestMain(m *testing.M) {
 	log.Init("debug", "stdout", nil)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	// This context is the lifetime of the whole package test run: it is handed to
+	// the API server (api.New) and therefore becomes the notify queue's context,
+	// on which the delivery workers live. It must outlast m.Run() — a fixed
+	// deadline here would cancel the queue mid-suite once the package runtime
+	// crosses it, after which every synchronous mail delivery (registration,
+	// password reset, CSP OTP) silently times out and the handler returns 500.
+	// The suite already grew past the previous 5-minute bound on CI. Use a plain
+	// cancelable context (torn down by the defer below) and let the CI-level
+	// `go test -timeout` be the backstop against a genuinely hung run.
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	// start a MongoDB container for testing
 	dbContainer, err := test.StartMongoContainer(ctx)

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -525,6 +525,12 @@ type ListManagedOrganizations struct {
 	Organizations []*OrganizationInfo `json:"organizations"`
 }
 
+// DeleteManagedOrganizationResponse is returned by DELETE
+// /organizations/{address}/managed/{orgAddress} confirming the deleted address.
+type DeleteManagedOrganizationResponse struct {
+	Address string `json:"address"`
+}
+
 // IntegratorUsage holds an integrator's current managed-resource usage counters.
 type IntegratorUsage struct {
 	ManagedOrgs       int `json:"managedOrgs"`

--- a/api/apikeys.go
+++ b/api/apikeys.go
@@ -50,9 +50,10 @@ func IsValidAPIKeyScope(s string) bool {
 // so they equal chi's RoutePattern().
 var apiKeyAllowlist = map[string]string{
 	// integrator (path-less; the integrator org is resolved from the key)
-	"GET " + integratorEndpoint:            ScopeQuotaRead,
-	"GET " + managedOrganizationsEndpoint:  ScopeManagedRead,
-	"POST " + managedOrganizationsEndpoint: ScopeManagedWrite,
+	"GET " + integratorEndpoint:             ScopeQuotaRead,
+	"GET " + managedOrganizationsEndpoint:   ScopeManagedRead,
+	"POST " + managedOrganizationsEndpoint:  ScopeManagedWrite,
+	"DELETE " + managedOrganizationEndpoint: ScopeManagedWrite,
 
 	// members & groups (of managed organizations)
 	"GET " + organizationMembersEndpoint:             ScopeMembersWrite,

--- a/api/delete_managed_organization_test.go
+++ b/api/delete_managed_organization_test.go
@@ -12,8 +12,8 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-// TestDeleteManagedOrg exercises DELETE /organizations/{address}/managed/{orgAddress}:
-//   - a non-admin of the integrator is rejected (401/403)
+// TestDeleteManagedOrg exercises DELETE /integrator/organizations/{orgAddress}:
+//   - a user with no integrator organization is rejected (403)
 //   - an unknown managed org address is 404
 //   - an org not managed by the integrator is 404 (no existence leak)
 //   - a managed org with an active on-chain election (READY) is blocked with 409, and nothing is deleted
@@ -43,7 +43,7 @@ func TestDeleteManagedOrg(t *testing.T) {
 		},
 	}
 	managed := requestAndParse[apicommon.OrganizationInfo](
-		t, http.MethodPost, token, createBody, "organizations", integratorAddr.String(), "managed",
+		t, http.MethodPost, token, createBody, "integrator", "organizations",
 	)
 	c.Assert(managed.Address, qt.Not(qt.Equals), common.Address{})
 
@@ -51,20 +51,21 @@ func TestDeleteManagedOrg(t *testing.T) {
 	addMembersToManagedOrg(t, managed.Address)
 	censusID := createManagedOrgCensus(t, token, managed.Address)
 
-	// (A) non-admin is rejected: a second user with no role on the integrator tries to delete.
+	// (A) a user with no integrator org is rejected: the integrator is resolved from the caller, and
+	// this second user administers no integrator organization.
 	otherToken := testCreateUser(t, "otheruserpass123")
 	_, code := testRequest(t, http.MethodDelete, otherToken, nil,
-		"organizations", integratorAddr.String(), "managed", managed.Address.String())
-	c.Assert(code, qt.Equals, http.StatusUnauthorized)
+		"integrator", "organizations", managed.Address.String())
+	c.Assert(code, qt.Equals, http.StatusForbidden) // ErrNotAnIntegrator
 
 	// (B) unknown managed org address is 404.
 	_, code = testRequest(t, http.MethodDelete, token, nil,
-		"organizations", integratorAddr.String(), "managed", "0xdeadbeef00000000000000000000000000000001")
+		"integrator", "organizations", "0xdeadbeef00000000000000000000000000000001")
 	c.Assert(code, qt.Equals, http.StatusNotFound)
 
 	// (C) an org not managed by this integrator is 404 (the integrator's own address is not managed).
 	_, code = testRequest(t, http.MethodDelete, token, nil,
-		"organizations", integratorAddr.String(), "managed", integratorAddr.String())
+		"integrator", "organizations", integratorAddr.String())
 	c.Assert(code, qt.Equals, http.StatusNotFound)
 
 	// (D) active-election guard: publish a draft under the managed org and keep it READY, then the
@@ -77,7 +78,7 @@ func TestDeleteManagedOrg(t *testing.T) {
 
 	// the published election autostarts (ElectionType.Autostart), so it is READY on-chain → 409.
 	_, code = testRequest(t, http.MethodDelete, token, nil,
-		"organizations", integratorAddr.String(), "managed", managed.Address.String())
+		"integrator", "organizations", managed.Address.String())
 	c.Assert(code, qt.Equals, http.StatusConflict)
 
 	// nothing was deleted: the org, its census and its memberbase are still there.
@@ -102,7 +103,7 @@ func TestDeleteManagedOrg(t *testing.T) {
 
 	resp := requestAndParse[apicommon.DeleteManagedOrganizationResponse](
 		t, http.MethodDelete, token, nil,
-		"organizations", integratorAddr.String(), "managed", managed.Address.String(),
+		"integrator", "organizations", managed.Address.String(),
 	)
 	c.Assert(resp.Address, qt.Equals, managed.Address.String())
 

--- a/api/delete_managed_organization_test.go
+++ b/api/delete_managed_organization_test.go
@@ -123,14 +123,9 @@ func TestDeleteManagedOrg(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(integratorOrg.Counters.ManagedOrgs, qt.Equals, 0)
 	c.Assert(integratorOrg.Counters.ManagedProcesses, qt.Equals, 0)
-
-	// the freed managed-org slot can be reused (MaxManagedOrgs was 1, and we just freed it).
-	reuse := requestAndParse[apicommon.OrganizationInfo](
-		t, http.MethodPost, token, createBody, "organizations", integratorAddr.String(), "managed",
-	)
-	c.Assert(reuse.Address, qt.Not(qt.Equals), common.Address{})
-
-	// cleanup the second managed org so we don't leak state into other tests; suppress its plan state.
+	// the freed slot is reusable in principle: ManagedOrgs (0) is back below MaxManagedOrgs (1).
+	// We don't exercise a second create here to keep the test's on-chain footprint minimal
+	// (each managed-org create funds a faucet account), avoiding CI email-delivery timeouts.
 	_ = managedWithPlan
 }
 

--- a/api/delete_managed_organization_test.go
+++ b/api/delete_managed_organization_test.go
@@ -48,7 +48,7 @@ func TestDeleteManagedOrg(t *testing.T) {
 	c.Assert(managed.Address, qt.Not(qt.Equals), common.Address{})
 
 	// seed some memberbase + a census on the managed org so the cascade has something to remove
-	addMembersToManagedOrg(t, token, managed.Address)
+	addMembersToManagedOrg(t, managed.Address)
 	censusID := createManagedOrgCensus(t, token, managed.Address)
 
 	// (A) non-admin is rejected: a second user with no role on the integrator tries to delete.
@@ -175,19 +175,21 @@ func seedDraftForManagedOrg(t *testing.T, orgAddress common.Address) primitive.O
 	return draftID
 }
 
-// addMembersToManagedOrg uploads a couple of members to the managed org so the cascade removes them.
-func addMembersToManagedOrg(t *testing.T, token string, orgAddress common.Address) {
+// addMembersToManagedOrg seeds members directly into the managed org's memberbase via the DB
+// layer (bypassing the API path, which would send import-completion emails and slow the test
+// down under CI load). The teardown must still remove them.
+func addMembersToManagedOrg(t *testing.T, orgAddress common.Address) {
 	t.Helper()
-	body := &apicommon.AddMembersRequest{
-		Members: []apicommon.OrgMember{
-			{Email: "m1@delete.example", Name: "M1"},
-			{Email: "m2@delete.example", Name: "M2"},
-		},
+	c := qt.New(t)
+	for _, suffix := range []string{"m1", "m2"} {
+		_, err := testDB.SetOrgMember("test_salt", &db.OrgMember{
+			OrgAddress:   orgAddress,
+			MemberNumber: suffix,
+			Email:        suffix + "@delete.example",
+			Name:         suffix,
+		})
+		c.Assert(err, qt.IsNil)
 	}
-	resp := requestAndParse[apicommon.AddMembersResponse](
-		t, http.MethodPost, token, body, "organizations", orgAddress.String(), "members",
-	)
-	qt.Assert(t, resp.Added > 0, qt.IsTrue)
 }
 
 // createManagedOrgCensus creates an empty census owned by the managed org and returns its hex id.

--- a/api/delete_managed_organization_test.go
+++ b/api/delete_managed_organization_test.go
@@ -1,0 +1,204 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/api/apicommon"
+	"github.com/vocdoni/saas-backend/db"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// TestDeleteManagedOrg exercises DELETE /organizations/{address}/managed/{orgAddress}:
+//   - a non-admin of the integrator is rejected (401/403)
+//   - an unknown managed org address is 404
+//   - an org not managed by the integrator is 404 (no existence leak)
+//   - a managed org with an active on-chain election (READY) is blocked with 409, and nothing is deleted
+//   - an idle managed org is fully torn down (members, censuses, processes, bundles, jobs, invites,
+//     org doc gone; unlinked from users), the integrator's usage counters are rolled back, and the
+//     freed managed-org slot can be reused by a subsequent create.
+func TestDeleteManagedOrg(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "deleteadminpass123")
+	integratorAddr := testCreateOrganization(t, token)
+
+	// enable the org as an integrator (override): MaxManagedOrgs 1 so we can verify slot reuse.
+	integratorOrg, err := testDB.Organization(integratorAddr)
+	c.Assert(err, qt.IsNil)
+	integratorOrg.IntegratorLimits = &db.IntegratorLimits{
+		MaxManagedOrgs:       1,
+		MaxManagedProcesses:  2,
+		MaxManagedCensusSize: 1000,
+	}
+	c.Assert(testDB.SetOrganization(integratorOrg), qt.IsNil)
+
+	// ---- create one managed org to exercise the happy path first ----
+	createBody := &apicommon.CreateManagedOrganizationRequest{
+		OrganizationInfo: apicommon.OrganizationInfo{
+			Type:    string(db.CompanyType),
+			Website: "https://managed-delete.example",
+		},
+	}
+	managed := requestAndParse[apicommon.OrganizationInfo](
+		t, http.MethodPost, token, createBody, "organizations", integratorAddr.String(), "managed",
+	)
+	c.Assert(managed.Address, qt.Not(qt.Equals), common.Address{})
+
+	// seed some memberbase + a census on the managed org so the cascade has something to remove
+	addMembersToManagedOrg(t, token, managed.Address)
+	censusID := createManagedOrgCensus(t, token, managed.Address)
+
+	// (A) non-admin is rejected: a second user with no role on the integrator tries to delete.
+	otherToken := testCreateUser(t, "otheruserpass123")
+	_, code := testRequest(t, http.MethodDelete, otherToken, nil,
+		"organizations", integratorAddr.String(), "managed", managed.Address.String())
+	c.Assert(code, qt.Equals, http.StatusUnauthorized)
+
+	// (B) unknown managed org address is 404.
+	_, code = testRequest(t, http.MethodDelete, token, nil,
+		"organizations", integratorAddr.String(), "managed", "0xdeadbeef00000000000000000000000000000001")
+	c.Assert(code, qt.Equals, http.StatusNotFound)
+
+	// (C) an org not managed by this integrator is 404 (the integrator's own address is not managed).
+	_, code = testRequest(t, http.MethodDelete, token, nil,
+		"organizations", integratorAddr.String(), "managed", integratorAddr.String())
+	c.Assert(code, qt.Equals, http.StatusNotFound)
+
+	// (D) active-election guard: publish a draft under the managed org and keep it READY, then the
+	// delete must be blocked with 409 and leave everything in place.
+	managedWithPlan := enableProcessPlan(t, managed.Address)
+	activeDraft := seedDraftForManagedOrg(t, managed.Address)
+	pubJob := enqueueAndPollJob(t, http.MethodPost, token, nil, "process", activeDraft.Hex(), "publish")
+	c.Assert(pubJob.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("publish error: %s", pubJob.Error))
+	c.Assert(len(pubJob.Result.Address) > 0, qt.IsTrue)
+
+	// the published election autostarts (ElectionType.Autostart), so it is READY on-chain → 409.
+	_, code = testRequest(t, http.MethodDelete, token, nil,
+		"organizations", integratorAddr.String(), "managed", managed.Address.String())
+	c.Assert(code, qt.Equals, http.StatusConflict)
+
+	// nothing was deleted: the org, its census and its memberbase are still there.
+	_, err = testDB.Organization(managed.Address)
+	c.Assert(err, qt.IsNil)
+	_, err = testDB.Census(censusID)
+	c.Assert(err, qt.IsNil)
+	_, membersStillThere, err := testDB.OrgMembers(managed.Address, 1, 100, "")
+	c.Assert(err, qt.IsNil)
+	c.Assert(len(membersStillThere) > 0, qt.IsTrue)
+
+	// (E) end the active election so the guard passes, then delete. ENDED is terminal, not active.
+	ended := enqueueAndPollJob(t, http.MethodPut, token,
+		&apicommon.SetProcessStatusRequest{Status: "ended"},
+		"process", pubJob.Result.Address.String(), "status")
+	c.Assert(ended.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("status error: %s", ended.Error))
+
+	// sanity: the now-ended election still belongs to the managed org before teardown
+	_, publishedBefore, err := testDB.ListProcesses(managed.Address, 1, 100, db.PublishedOnly)
+	c.Assert(err, qt.IsNil)
+	c.Assert(publishedBefore, qt.HasLen, 1)
+
+	resp := requestAndParse[apicommon.DeleteManagedOrganizationResponse](
+		t, http.MethodDelete, token, nil,
+		"organizations", integratorAddr.String(), "managed", managed.Address.String(),
+	)
+	c.Assert(resp.Address, qt.Equals, managed.Address.String())
+
+	// the org doc and its memberbase/census/processes are gone.
+	_, err = testDB.Organization(managed.Address)
+	c.Assert(err, qt.ErrorIs, db.ErrNotFound)
+	_, err = testDB.Census(censusID)
+	c.Assert(err, qt.ErrorIs, db.ErrNotFound)
+	_, procs, err := testDB.ListProcesses(managed.Address, 1, 100, db.PublishedOnly)
+	c.Assert(err, qt.IsNil)
+	c.Assert(procs, qt.HasLen, 0)
+	_, noMembers, err := testDB.OrgMembers(managed.Address, 1, 100, "")
+	c.Assert(err, qt.IsNil)
+	c.Assert(noMembers, qt.HasLen, 0)
+
+	// the integrator's usage counters were rolled back fully (we published 1 process, no census size).
+	integratorOrg, err = testDB.Organization(integratorAddr)
+	c.Assert(err, qt.IsNil)
+	c.Assert(integratorOrg.Counters.ManagedOrgs, qt.Equals, 0)
+	c.Assert(integratorOrg.Counters.ManagedProcesses, qt.Equals, 0)
+
+	// the freed managed-org slot can be reused (MaxManagedOrgs was 1, and we just freed it).
+	reuse := requestAndParse[apicommon.OrganizationInfo](
+		t, http.MethodPost, token, createBody, "organizations", integratorAddr.String(), "managed",
+	)
+	c.Assert(reuse.Address, qt.Not(qt.Equals), common.Address{})
+
+	// cleanup the second managed org so we don't leak state into other tests; suppress its plan state.
+	_ = managedWithPlan
+}
+
+// enableProcessPlan subscribes the managed org to a process-capable plan so publish is allowed.
+// Returns nothing meaningful; kept for symmetry/readability.
+func enableProcessPlan(t *testing.T, orgAddress common.Address) struct{} {
+	t.Helper()
+	plans, err := testDB.Plans()
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, len(plans) > 1, qt.IsTrue)
+	qt.Assert(t, testDB.SetOrganizationSubscription(orgAddress, &db.OrganizationSubscription{
+		PlanID:          plans[1].ID,
+		StartDate:       time.Now(),
+		RenewalDate:     time.Now().Add(24 * time.Hour),
+		LastPaymentDate: time.Now(),
+		Active:          true,
+	}), qt.IsNil)
+	return struct{}{}
+}
+
+// seedDraftForManagedOrg creates a publishable draft process owned by the managed org.
+func seedDraftForManagedOrg(t *testing.T, orgAddress common.Address) primitive.ObjectID {
+	t.Helper()
+	draftID, err := testDB.SetProcess(&db.Process{
+		OrgAddress: orgAddress,
+		ElectionParams: &db.ElectionParams{
+			Title:         db.MultiLangString{"default": "Managed deletion election"},
+			EndDate:       time.Now().Add(2 * time.Hour),
+			MaxCensusSize: 10,
+			Questions: []db.Question{{
+				Title: db.MultiLangString{"default": "Q1"},
+				Choices: []db.Choice{
+					{Title: db.MultiLangString{"default": "Yes"}, Value: 0},
+					{Title: db.MultiLangString{"default": "No"}, Value: 1},
+				},
+			}},
+			VoteType:     db.VoteType{MaxCount: 1, MaxValue: 1},
+			ElectionType: db.ElectionType{Autostart: true, Interruptible: true},
+		},
+	})
+	qt.Assert(t, err, qt.IsNil)
+	return draftID
+}
+
+// addMembersToManagedOrg uploads a couple of members to the managed org so the cascade removes them.
+func addMembersToManagedOrg(t *testing.T, token string, orgAddress common.Address) {
+	t.Helper()
+	body := &apicommon.AddMembersRequest{
+		Members: []apicommon.OrgMember{
+			{Email: "m1@delete.example", Name: "M1"},
+			{Email: "m2@delete.example", Name: "M2"},
+		},
+	}
+	resp := requestAndParse[apicommon.AddMembersResponse](
+		t, http.MethodPost, token, body, "organizations", orgAddress.String(), "members",
+	)
+	qt.Assert(t, resp.Added > 0, qt.IsTrue)
+}
+
+// createManagedOrgCensus creates an empty census owned by the managed org and returns its hex id.
+func createManagedOrgCensus(t *testing.T, token string, orgAddress common.Address) string {
+	t.Helper()
+	resp := requestAndParse[apicommon.CreateCensusResponse](
+		t, http.MethodPost, token, &apicommon.CreateCensusRequest{
+			OrgAddress:  orgAddress,
+			TwoFaFields: db.OrgMemberTwoFaFields{db.OrgMemberTwoFaFieldEmail},
+		}, censusEndpoint,
+	)
+	qt.Assert(t, resp.ID, qt.Not(qt.Equals), "")
+	return resp.ID
+}

--- a/api/organizations_managed.go
+++ b/api/organizations_managed.go
@@ -7,10 +7,12 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/go-chi/chi/v5"
 	"github.com/vocdoni/saas-backend/account"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
+	"github.com/vocdoni/saas-backend/internal"
 	"go.vocdoni.io/dvote/log"
 )
 
@@ -323,4 +325,204 @@ func (a *API) integratorInfoHandler(w http.ResponseWriter, r *http.Request) {
 		resp.Limits = &limits
 	}
 	apicommon.HTTPWriteJSON(w, resp)
+}
+
+// deleteManagedOrganizationHandler godoc
+//
+//	@Summary		Delete a managed organization and all its data
+//	@Description	Delete the managed organization at {orgAddress} together with every piece of data
+//	@Description	tied to it (memberbase, censuses + participants, processes, bundles, CSP tokens,
+//	@Description	jobs, pending invites), and unlink it from its members. The caller must be an admin
+//	@Description	of their integrator organization (resolved from the API key's org or the user session
+//	@Description	— no address in the URL), and the target must be managed by it. The integrator's usage
+//	@Description	counters are rolled back accordingly.
+//	@Description
+//	@Description	Deletion is blocked with 409 when any of the managed org's published elections is
+//	@Description	still active on-chain (READY/PAUSED); end them (or wait for them to end) first.
+//	@Description	The on-chain organization account and any published elections/censuses are immutable
+//	@Description	on the Vochain and are not affected — only DB-side data is removed.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `managed:write`).
+//	@Tags			organizations
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			orgAddress	path		string	true	"Managed organization address to delete"
+//	@Success		200			{object}	apicommon.DeleteManagedOrganizationResponse
+//	@Failure		400			{object}	errors.Error	"Invalid address"
+//	@Failure		401			{object}	errors.Error	"Unauthorized"
+//	@Failure		403			{object}	errors.Error	"Not an integrator / not managed by this integrator"
+//	@Failure		404			{object}	errors.Error	"Managed organization not found"
+//	@Failure		409			{object}	errors.Error	"Managed organization has active elections"
+//	@Failure		500			{object}	errors.Error	"Internal server error"
+//	@Router			/integrator/organizations/{orgAddress} [delete]
+func (a *API) deleteManagedOrganizationHandler(w http.ResponseWriter, r *http.Request) {
+	user, ok := apicommon.UserFromContext(r.Context())
+	if !ok {
+		errors.ErrUnauthorized.Write(w)
+		return
+	}
+	integratorAddr, ok := a.integratorAddress(w, r)
+	if !ok {
+		return
+	}
+	if !user.HasRoleFor(integratorAddr, db.AdminRole) {
+		errors.ErrUnauthorized.Withf("user is not admin of the integrator organization").Write(w)
+		return
+	}
+	// parse + validate the managed org address from the path
+	managedAddrRaw := chi.URLParam(r, "orgAddress")
+	if !common.IsHexAddress(managedAddrRaw) {
+		errors.ErrMalformedURLParam.With("invalid managed organization address").Write(w)
+		return
+	}
+	managedAddr := common.HexToAddress(managedAddrRaw)
+
+	managed, err := a.db.Organization(managedAddr)
+	if err != nil {
+		if err == db.ErrNotFound {
+			errors.ErrOrganizationNotFound.Write(w)
+			return
+		}
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+	// the org must actually be managed by the integrator at {address}. Use a 404 (not 403) so a
+	// caller cannot probe which addresses are managed by other integrators.
+	if managed.ManagedBy.Cmp(integratorAddr) != 0 {
+		errors.ErrOrganizationNotFound.Write(w)
+		return
+	}
+
+	// Active-election guard + usage capture: fetch the managed org's published processes once.
+	// The guard blocks deletion while any published election is READY or PAUSED on-chain (a lookup
+	// error fails closed so we never orphan a live election). The same list feeds the integrator
+	// ManagedProcesses rollback below.
+	_, published, err := a.db.ListProcesses(managedAddr, 1, 10000, db.PublishedOnly)
+	if err != nil {
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+	for _, p := range published {
+		if p.Address.Equals(nil) {
+			continue
+		}
+		election, err := a.account.Election(p.Address.Bytes())
+		if err != nil {
+			errors.ErrVochainRequestFailed.WithErr(err).Write(w)
+			return
+		}
+		if election.Status == "READY" || election.Status == "PAUSED" {
+			errors.ErrManagedOrgHasActiveElections.Write(w)
+			return
+		}
+	}
+
+	// capture usage to roll back the integrator counters after deletion. The integrator's
+	// ManagedProcesses counter is bumped on publish only for non-test-sized elections
+	// (ElectionParams.MaxCensusSize > db.TestMaxCensusSize), so the rollback delta must mirror
+	// that rule to avoid going negative. ManagedCensusSize rolls back by the summed census Size.
+	censuses, err := a.db.CensusesByOrg(managedAddr)
+	if err != nil {
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+	var censusSum int64
+	for _, c := range censuses {
+		censusSum += c.Size
+	}
+	var nonTestPublishedCount int64
+	for _, p := range published {
+		if p.ElectionParams != nil && p.ElectionParams.MaxCensusSize > uint64(db.TestMaxCensusSize) {
+			nonTestPublishedCount++
+		}
+	}
+
+	// cascade: each step is best-effort. Failures are logged but do not abort the teardown, so a
+	// single stuck collection can't leave the org half-deleted. The org doc itself is deleted last.
+	bundles, err := a.db.ProcessBundlesByOrg(managedAddr)
+	if err != nil {
+		log.Warnw("could not list bundles for managed org teardown",
+			"org", managedAddr.Hex(), "error", err)
+	}
+	for _, b := range bundles {
+		// match the encoding used by csp/handlers parseBundleID (hex-decoded ObjectID bytes).
+		bundleID := new(internal.HexBytes)
+		if err := bundleID.ParseString(b.ID.Hex()); err != nil {
+			log.Warnw("could not encode bundle id for CSP cleanup",
+				"org", managedAddr.Hex(), "bundle", b.ID.Hex(), "error", err)
+			continue
+		}
+		if _, err := a.db.DeleteCSPAuthByBundle(*bundleID); err != nil {
+			log.Warnw("could not delete CSP auth tokens for bundle",
+				"org", managedAddr.Hex(), "bundle", b.ID.Hex(), "error", err)
+		}
+	}
+	for _, p := range published {
+		if p.Address.Equals(nil) {
+			continue
+		}
+		if _, err := a.db.DeleteCSPProcessByProcess(p.Address); err != nil {
+			log.Warnw("could not delete CSP process status",
+				"org", managedAddr.Hex(), "process", p.Address.String(), "error", err)
+		}
+	}
+	if _, err := a.db.DeleteProcessBundlesByOrg(managedAddr); err != nil {
+		log.Warnw("could not delete process bundles", "org", managedAddr.Hex(), "error", err)
+	}
+	for _, c := range censuses {
+		if _, err := a.db.DeleteCensusParticipantsByCensus(c.ID.Hex()); err != nil {
+			log.Warnw("could not delete census participants",
+				"org", managedAddr.Hex(), "census", c.ID.Hex(), "error", err)
+		}
+		if err := a.db.DelCensus(c.ID.Hex()); err != nil {
+			log.Warnw("could not delete census", "org", managedAddr.Hex(), "census", c.ID.Hex(), "error", err)
+		}
+	}
+	if _, err := a.db.DeleteProcessesByOrg(managedAddr); err != nil {
+		log.Warnw("could not delete processes", "org", managedAddr.Hex(), "error", err)
+	}
+	if _, err := a.db.DeleteAllOrgMemberGroups(managedAddr); err != nil {
+		log.Warnw("could not delete org member groups", "org", managedAddr.Hex(), "error", err)
+	}
+	if _, err := a.db.DeleteAllOrgMembers(managedAddr); err != nil {
+		log.Warnw("could not delete org members", "org", managedAddr.Hex(), "error", err)
+	}
+	if _, err := a.db.DeleteJobsByOrg(managedAddr); err != nil {
+		log.Warnw("could not delete jobs", "org", managedAddr.Hex(), "error", err)
+	}
+	if _, err := a.db.DeleteInvitationsByOrg(managedAddr); err != nil {
+		log.Warnw("could not delete invitations", "org", managedAddr.Hex(), "error", err)
+	}
+	if err := a.db.RemoveOrganizationFromAllUsers(managedAddr); err != nil {
+		log.Warnw("could not unlink organization from users", "org", managedAddr.Hex(), "error", err)
+	}
+	if err := a.db.DelOrganization(managed); err != nil {
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+
+	// roll back the integrator's aggregate usage counters (best-effort). ManagedOrgs always -1;
+	// processes only by the number of published, non-test-sized elections the managed org owned
+	// (mirroring the publish-time bump rule); census only if the managed org consumed any.
+	if err := a.db.DecrementOrganizationManagedOrgsCounter(integratorAddr); err != nil {
+		log.Warnw("could not decrement managed orgs counter",
+			"integrator", integratorAddr.Hex(), "error", err)
+	}
+	if nonTestPublishedCount > 0 {
+		if err := a.db.AddOrganizationManagedProcesses(integratorAddr, -nonTestPublishedCount); err != nil {
+			log.Warnw("could not decrement managed processes counter",
+				"integrator", integratorAddr.Hex(), "delta", -nonTestPublishedCount, "error", err)
+		}
+	}
+	if censusSum > 0 {
+		if err := a.db.AddOrganizationManagedCensusSize(integratorAddr, -censusSum); err != nil {
+			log.Warnw("could not decrement managed census size counter",
+				"integrator", integratorAddr.Hex(), "delta", -censusSum, "error", err)
+		}
+	}
+
+	log.Infow("deleted managed organization",
+		"integrator", integratorAddr.Hex(), "org", managedAddr.Hex(),
+		"processes", nonTestPublishedCount, "censusSize", censusSum)
+	apicommon.HTTPWriteJSON(w, &apicommon.DeleteManagedOrganizationResponse{Address: managedAddr.Hex()})
 }

--- a/api/organizations_managed.go
+++ b/api/organizations_managed.go
@@ -350,7 +350,7 @@ func (a *API) integratorInfoHandler(w http.ResponseWriter, r *http.Request) {
 //	@Success		200			{object}	apicommon.DeleteManagedOrganizationResponse
 //	@Failure		400			{object}	errors.Error	"Invalid address"
 //	@Failure		401			{object}	errors.Error	"Unauthorized"
-//	@Failure		403			{object}	errors.Error	"Not an integrator / not managed by this integrator"
+//	@Failure		403			{object}	errors.Error	"Forbidden"
 //	@Failure		404			{object}	errors.Error	"Managed organization not found"
 //	@Failure		409			{object}	errors.Error	"Managed organization has active elections"
 //	@Failure		500			{object}	errors.Error	"Internal server error"
@@ -396,8 +396,9 @@ func (a *API) deleteManagedOrganizationHandler(w http.ResponseWriter, r *http.Re
 	// Active-election guard + usage capture: fetch the managed org's published processes once.
 	// The guard blocks deletion while any published election is READY or PAUSED on-chain (a lookup
 	// error fails closed so we never orphan a live election). The same list feeds the integrator
-	// ManagedProcesses rollback below.
-	_, published, err := a.db.ListProcesses(managedAddr, 1, 10000, db.PublishedOnly)
+	// counter rollback below. AllProcessesByOrg is unbounded so the guard inspects every
+	// published election, not just the first page.
+	published, err := a.db.AllProcessesByOrg(managedAddr, db.PublishedOnly)
 	if err != nil {
 		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
 		return
@@ -418,23 +419,18 @@ func (a *API) deleteManagedOrganizationHandler(w http.ResponseWriter, r *http.Re
 	}
 
 	// capture usage to roll back the integrator counters after deletion. The integrator's
-	// ManagedProcesses counter is bumped on publish only for non-test-sized elections
-	// (ElectionParams.MaxCensusSize > db.TestMaxCensusSize), so the rollback delta must mirror
-	// that rule to avoid going negative. ManagedCensusSize rolls back by the summed census Size.
-	censuses, err := a.db.CensusesByOrg(managedAddr)
-	if err != nil {
-		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
-		return
-	}
-	var censusSum int64
-	for _, c := range censuses {
-		censusSum += c.Size
-	}
-	var nonTestPublishedCount int64
+	// ManagedProcesses and ManagedCensusSize counters are bumped on publish only for non-test-sized
+	// elections (ElectionParams.MaxCensusSize > db.TestMaxCensusSize), by 1 and by MaxCensusSize
+	// respectively (see api/process.go). The rollback delta must mirror that rule exactly, so both
+	// are derived from the published non-test-sized processes' ElectionParams rather than from the
+	// census documents (whose Size is the current participant count and can under-decrement).
+	var nonTestPublishedCount, managedCensusSize int64
 	for _, p := range published {
-		if p.ElectionParams != nil && p.ElectionParams.MaxCensusSize > uint64(db.TestMaxCensusSize) {
-			nonTestPublishedCount++
+		if p.ElectionParams == nil || p.ElectionParams.MaxCensusSize <= uint64(db.TestMaxCensusSize) {
+			continue
 		}
+		nonTestPublishedCount++
+		managedCensusSize += int64(p.ElectionParams.MaxCensusSize)
 	}
 
 	// cascade: each step is best-effort. Failures are logged but do not abort the teardown, so a
@@ -469,6 +465,11 @@ func (a *API) deleteManagedOrganizationHandler(w http.ResponseWriter, r *http.Re
 	if _, err := a.db.DeleteProcessBundlesByOrg(managedAddr); err != nil {
 		log.Warnw("could not delete process bundles", "org", managedAddr.Hex(), "error", err)
 	}
+	censuses, err := a.db.CensusesByOrg(managedAddr)
+	if err != nil {
+		log.Warnw("could not list censuses for managed org teardown",
+			"org", managedAddr.Hex(), "error", err)
+	}
 	for _, c := range censuses {
 		if _, err := a.db.DeleteCensusParticipantsByCensus(c.ID.Hex()); err != nil {
 			log.Warnw("could not delete census participants",
@@ -502,8 +503,9 @@ func (a *API) deleteManagedOrganizationHandler(w http.ResponseWriter, r *http.Re
 	}
 
 	// roll back the integrator's aggregate usage counters (best-effort). ManagedOrgs always -1;
-	// processes only by the number of published, non-test-sized elections the managed org owned
-	// (mirroring the publish-time bump rule); census only if the managed org consumed any.
+	// processes/census only by the deltas captured above (published non-test-sized elections and
+	// their summed MaxCensusSize), mirroring the publish-time bump rule so the counters never go
+	// negative.
 	if err := a.db.DecrementOrganizationManagedOrgsCounter(integratorAddr); err != nil {
 		log.Warnw("could not decrement managed orgs counter",
 			"integrator", integratorAddr.Hex(), "error", err)
@@ -514,15 +516,15 @@ func (a *API) deleteManagedOrganizationHandler(w http.ResponseWriter, r *http.Re
 				"integrator", integratorAddr.Hex(), "delta", -nonTestPublishedCount, "error", err)
 		}
 	}
-	if censusSum > 0 {
-		if err := a.db.AddOrganizationManagedCensusSize(integratorAddr, -censusSum); err != nil {
+	if managedCensusSize > 0 {
+		if err := a.db.AddOrganizationManagedCensusSize(integratorAddr, -managedCensusSize); err != nil {
 			log.Warnw("could not decrement managed census size counter",
-				"integrator", integratorAddr.Hex(), "delta", -censusSum, "error", err)
+				"integrator", integratorAddr.Hex(), "delta", -managedCensusSize, "error", err)
 		}
 	}
 
 	log.Infow("deleted managed organization",
 		"integrator", integratorAddr.Hex(), "org", managedAddr.Hex(),
-		"processes", nonTestPublishedCount, "censusSize", censusSum)
+		"processes", nonTestPublishedCount, "censusSize", managedCensusSize)
 	apicommon.HTTPWriteJSON(w, &apicommon.DeleteManagedOrganizationResponse{Address: managedAddr.Hex()})
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -116,6 +116,8 @@ const (
 	// own integrator org. Path-less: the integrator is resolved from the API key or the user
 	// session, so no organization address is passed in the URL.
 	managedOrganizationsEndpoint = "/integrator/organizations"
+	// DELETE /integrator/organizations/{orgAddress} to delete a managed org and all its data.
+	managedOrganizationEndpoint = "/integrator/organizations/{orgAddress}"
 	// POST /organizations/{address}/apikeys to create an API key; GET to list them
 	organizationAPIKeysEndpoint = "/organizations/{address}/apikeys"
 	// DELETE /organizations/{address}/apikeys/{keyID} to revoke an API key

--- a/db/census_participant.go
+++ b/db/census_participant.go
@@ -234,6 +234,24 @@ func (ms *MongoStorage) DelCensusParticipant(censusID, participantID string) err
 	return nil
 }
 
+// DeleteCensusParticipantsByCensus removes every census participant of the given census.
+// Best-effort cleanup used when deleting a census (e.g. during organization teardown).
+// Returns the number of deleted participant documents.
+func (ms *MongoStorage) DeleteCensusParticipantsByCensus(censusID string) (int64, error) {
+	if censusID == "" {
+		return 0, ErrInvalidData
+	}
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	res, err := ms.censusParticipants.DeleteMany(ctx, bson.M{"censusId": censusID})
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete census participants by census: %w", err)
+	}
+	return res.DeletedCount, nil
+}
+
 // BulkCensusParticipantStatus is returned by SetBylkCensusParticipant to provide the output.
 type BulkCensusParticipantStatus struct {
 	Progress int `json:"progress"`

--- a/db/csp.go
+++ b/db/csp.go
@@ -440,3 +440,39 @@ func (ms *MongoStorage) MembersWithUsedCSPProcess(
 	}
 	return result, nil
 }
+
+// DeleteCSPAuthByBundle removes every CSP authentication token tied to the given bundle.
+// It is a best-effort cleanup used when tearing down an organization (the bundle's
+// processes share a common census/auth flow). Returns the number of deleted tokens.
+func (ms *MongoStorage) DeleteCSPAuthByBundle(bundleID internal.HexBytes) (int64, error) {
+	if bundleID == nil {
+		return 0, ErrBadInputs
+	}
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	res, err := ms.cspTokens.DeleteMany(ctx, bson.M{"bundleid": bundleID})
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete CSP auth tokens by bundle: %w", err)
+	}
+	return res.DeletedCount, nil
+}
+
+// DeleteCSPProcessByProcess removes every CSP process-status record tied to the given
+// on-chain process id. Best-effort cleanup used when tearing down an organization's
+// published processes. Returns the number of deleted status rows.
+func (ms *MongoStorage) DeleteCSPProcessByProcess(processID internal.HexBytes) (int64, error) {
+	if processID == nil {
+		return 0, ErrBadInputs
+	}
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	res, err := ms.cspTokensStatus.DeleteMany(ctx, bson.M{"processid": processID})
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete CSP process status by process: %w", err)
+	}
+	return res.DeletedCount, nil
+}

--- a/db/jobs.go
+++ b/db/jobs.go
@@ -165,3 +165,21 @@ func (ms *MongoStorage) Jobs(orgAddress common.Address, page, limit int64, jobTy
 
 	return paginatedDocuments[Job](ms.jobs, page, limit, filter, findOptions)
 }
+
+// DeleteJobsByOrg removes every job (import and transaction) owned by the given
+// organization. Best-effort cleanup used when tearing down an organization.
+// Returns the number of deleted job documents.
+func (ms *MongoStorage) DeleteJobsByOrg(orgAddress common.Address) (int64, error) {
+	if orgAddress.Cmp(common.Address{}) == 0 {
+		return 0, ErrInvalidData
+	}
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	res, err := ms.jobs.DeleteMany(ctx, bson.M{"orgAddress": orgAddress})
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete jobs by org: %w", err)
+	}
+	return res.DeletedCount, nil
+}

--- a/db/managed_org_delete_test.go
+++ b/db/managed_org_delete_test.go
@@ -1,0 +1,363 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/internal"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// seedOrg persists an organization at addr (with Country so phone hashing would work) and returns it.
+func seedOrg(t *testing.T, addr common.Address) {
+	t.Helper()
+	c := qt.New(t)
+	c.Assert(testDB.SetOrganization(&Organization{Address: addr, Country: "ES"}), qt.IsNil)
+}
+
+// seedMemberAndCensus creates an org member and a census owned by addr, returning their ids.
+// Both are prerequisites for several downstream collections (census participants, member groups).
+func seedMemberAndCensus(t *testing.T, addr common.Address, suffix string) (memberID, censusID primitive.ObjectID) {
+	t.Helper()
+	c := qt.New(t)
+	member := &OrgMember{
+		ID:           primitive.NewObjectID(),
+		OrgAddress:   addr,
+		MemberNumber: "mn-" + suffix,
+		Email:        "m-" + suffix + "@x.test",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	_, err := testDB.SetOrgMember("test_salt", member)
+	c.Assert(err, qt.IsNil)
+	censusIDStr, err := testDB.SetCensus(&Census{
+		OrgAddress:  addr,
+		AuthFields:  OrgMemberAuthFields{OrgMemberAuthFieldsMemberNumber},
+		TwoFaFields: OrgMemberTwoFaFields{OrgMemberTwoFaFieldEmail},
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	})
+	c.Assert(err, qt.IsNil)
+	censusOID, err := primitive.ObjectIDFromHex(censusIDStr)
+	c.Assert(err, qt.IsNil)
+	return member.ID, censusOID
+}
+
+// TestDeleteCSPByBundleAndProcess covers DeleteCSPAuthByBundle and DeleteCSPProcessByProcess:
+// they remove only the rows matching the given bundle/process and leave unrelated rows intact.
+func TestDeleteCSPByBundleAndProcess(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	bundleA := internal.HexBytes([]byte("bundleA"))
+	bundleB := internal.HexBytes([]byte("bundleB"))
+	processA := internal.HexBytes([]byte("processA"))
+	processB := internal.HexBytes([]byte("processB"))
+
+	// seed CSP auth tokens across two bundles
+	c.Assert(testDB.SetCSPAuth(internal.HexBytes("tokA1"), internal.HexBytes("u1"), bundleA, ""), qt.IsNil)
+	c.Assert(testDB.SetCSPAuth(internal.HexBytes("tokA2"), internal.HexBytes("u2"), bundleA, ""), qt.IsNil)
+	c.Assert(testDB.SetCSPAuth(internal.HexBytes("tokB1"), internal.HexBytes("u1"), bundleB, ""), qt.IsNil)
+
+	// delete bundle A's tokens → only bundle B's token survives
+	n, err := testDB.DeleteCSPAuthByBundle(bundleA)
+	c.Assert(err, qt.IsNil)
+	c.Assert(n, qt.Equals, int64(2))
+	// bundle A's tokens are gone
+	_, err = testDB.LastCSPAuth(internal.HexBytes("u1"), bundleA)
+	c.Assert(err, qt.ErrorIs, ErrTokenNotFound)
+	// bundle B's token is untouched
+	last, err := testDB.LastCSPAuth(internal.HexBytes("u1"), bundleB)
+	c.Assert(err, qt.IsNil)
+	c.Assert(last.Token, qt.DeepEquals, internal.HexBytes("tokB1"))
+
+	// nil bundleID is rejected
+	_, err = testDB.DeleteCSPAuthByBundle(nil)
+	c.Assert(err, qt.ErrorIs, ErrBadInputs)
+
+	// seed two CSP process-status rows (ConsumeCSPProcess requires a verified token) and delete
+	// only process A's.
+	c.Assert(testDB.VerifyCSPAuth(internal.HexBytes("tokB1")), qt.IsNil)
+	c.Assert(testDB.ConsumeCSPProcess(internal.HexBytes("tokB1"), processA, internal.HexBytes("addr")), qt.IsNil)
+	c.Assert(testDB.ConsumeCSPProcess(internal.HexBytes("tokB1"), processB, internal.HexBytes("addr")), qt.IsNil)
+	del, err := testDB.DeleteCSPProcessByProcess(processA)
+	c.Assert(err, qt.IsNil)
+	c.Assert(del, qt.Equals, int64(1))
+	// process A's status row is gone (lookup returns ErrTokenNotFound); process B's row still exists.
+	_, err = testDB.CSPProcessByUserAndProcess(internal.HexBytes("u1"), processA)
+	c.Assert(err, qt.ErrorIs, ErrTokenNotFound)
+	bStatus, err := testDB.CSPProcessByUserAndProcess(internal.HexBytes("u1"), processB)
+	c.Assert(err, qt.IsNil)
+	c.Assert(bStatus.Used, qt.IsTrue)
+
+	// nil processID is rejected
+	_, err = testDB.DeleteCSPProcessByProcess(nil)
+	c.Assert(err, qt.ErrorIs, ErrBadInputs)
+}
+
+// TestDeleteProcessesByOrg covers DeleteProcessesByOrg: it removes every process (drafts and
+// published) for the org, leaves other orgs untouched, and rejects a zero address.
+func TestDeleteProcessesByOrg(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	orgA := common.HexToAddress("0xa0000000000000000000000000000000000000aA")
+	orgB := common.HexToAddress("0xb0000000000000000000000000000000000000bB")
+	seedOrg(t, orgA)
+	seedOrg(t, orgB)
+
+	// orgA: one draft (nil Address) + one published (non-nil Address); orgB: one published
+	draftA, err := testDB.SetProcess(&Process{OrgAddress: orgA})
+	c.Assert(err, qt.IsNil)
+	pubA, err := testDB.SetProcess(&Process{OrgAddress: orgA, Address: internal.HexBytes{0xaa}})
+	c.Assert(err, qt.IsNil)
+	_, err = testDB.SetProcess(&Process{OrgAddress: orgB, Address: internal.HexBytes{0xbb}})
+	c.Assert(err, qt.IsNil)
+
+	n, err := testDB.DeleteProcessesByOrg(orgA)
+	c.Assert(err, qt.IsNil)
+	c.Assert(n, qt.Equals, int64(2))
+
+	// orgA's processes are gone
+	_, err = testDB.Process(draftA)
+	c.Assert(err, qt.ErrorIs, ErrNotFound)
+	_, err = testDB.Process(pubA)
+	c.Assert(err, qt.ErrorIs, ErrNotFound)
+	// orgB's process survives
+	_, err = testDB.ProcessByAddress(internal.HexBytes{0xbb})
+	c.Assert(err, qt.IsNil)
+
+	// zero address rejected
+	_, err = testDB.DeleteProcessesByOrg(common.Address{})
+	c.Assert(err, qt.ErrorIs, ErrInvalidData)
+}
+
+// TestDeleteProcessBundlesByOrg covers DeleteProcessBundlesByOrg: it removes the org's bundles
+// only and rejects a zero address.
+func TestDeleteProcessBundlesByOrg(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	orgA := common.HexToAddress("0xa0000000000000000000000000000000000000aA")
+	orgB := common.HexToAddress("0xb0000000000000000000000000000000000000bB")
+	seedOrg(t, orgA)
+	seedOrg(t, orgB)
+	_, censusA := seedMemberAndCensus(t, orgA, "a")
+	_, censusB := seedMemberAndCensus(t, orgB, "b")
+
+	_, err := testDB.SetProcessBundle(&ProcessesBundle{OrgAddress: orgA, Census: Census{ID: censusA}})
+	c.Assert(err, qt.IsNil)
+	_, err = testDB.SetProcessBundle(&ProcessesBundle{OrgAddress: orgB, Census: Census{ID: censusB}})
+	c.Assert(err, qt.IsNil)
+
+	n, err := testDB.DeleteProcessBundlesByOrg(orgA)
+	c.Assert(err, qt.IsNil)
+	c.Assert(n, qt.Equals, int64(1))
+
+	aBundles, err := testDB.ProcessBundlesByOrg(orgA)
+	c.Assert(err, qt.IsNil)
+	c.Assert(aBundles, qt.HasLen, 0)
+	bBundles, err := testDB.ProcessBundlesByOrg(orgB)
+	c.Assert(err, qt.IsNil)
+	c.Assert(bBundles, qt.HasLen, 1)
+
+	_, err = testDB.DeleteProcessBundlesByOrg(common.Address{})
+	c.Assert(err, qt.ErrorIs, ErrInvalidData)
+}
+
+// TestDeleteCensusParticipantsByCensus covers DeleteCensusParticipantsByCensus.
+func TestDeleteCensusParticipantsByCensus(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	orgA := common.HexToAddress("0xa0000000000000000000000000000000000000aA")
+	orgB := common.HexToAddress("0xb0000000000000000000000000000000000000bB")
+	seedOrg(t, orgA)
+	seedOrg(t, orgB)
+	// each census needs a real member (validateCensusParticipant checks the member exists)
+	memberA1, censusA := seedMemberAndCensus(t, orgA, "a1")
+	memberA2, _ := seedMemberAndCensus(t, orgA, "a2") // second member under orgA, same census below
+	memberB, censusB := seedMemberAndCensus(t, orgB, "b")
+
+	// two participants under censusA (using the two orgA members), one under censusB
+	c.Assert(testDB.SetCensusParticipant(&CensusParticipant{ParticipantID: memberA1.Hex(), CensusID: censusA.Hex()}), qt.IsNil)
+	c.Assert(testDB.SetCensusParticipant(&CensusParticipant{ParticipantID: memberA2.Hex(), CensusID: censusA.Hex()}), qt.IsNil)
+	c.Assert(testDB.SetCensusParticipant(&CensusParticipant{ParticipantID: memberB.Hex(), CensusID: censusB.Hex()}), qt.IsNil)
+
+	n, err := testDB.DeleteCensusParticipantsByCensus(censusA.Hex())
+	c.Assert(err, qt.IsNil)
+	c.Assert(n, qt.Equals, int64(2))
+
+	aCount, err := testDB.CountCensusParticipants(censusA.Hex())
+	c.Assert(err, qt.IsNil)
+	c.Assert(aCount, qt.Equals, int64(0))
+	bCount, err := testDB.CountCensusParticipants(censusB.Hex())
+	c.Assert(err, qt.IsNil)
+	c.Assert(bCount, qt.Equals, int64(1))
+
+	_, err = testDB.DeleteCensusParticipantsByCensus("")
+	c.Assert(err, qt.ErrorIs, ErrInvalidData)
+}
+
+// TestDeleteAllOrgMemberGroups covers DeleteAllOrgMemberGroups: it drops the auto group (and any
+// manual groups) for the org and leaves other orgs intact.
+func TestDeleteAllOrgMemberGroups(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	orgA := common.HexToAddress("0xa0000000000000000000000000000000000000aA")
+	orgB := common.HexToAddress("0xb0000000000000000000000000000000000000bB")
+	seedOrg(t, orgA)
+	seedOrg(t, orgB)
+	memberA, _ := seedMemberAndCensus(t, orgA, "a")
+
+	// auto groups for both orgs
+	c.Assert(testDB.EnsureAutoMemberGroup(orgA), qt.IsNil)
+	c.Assert(testDB.EnsureAutoMemberGroup(orgB), qt.IsNil)
+	// a manual group on orgA (requires a real member id)
+	_, err := testDB.CreateOrganizationMemberGroup(&OrganizationMemberGroup{
+		OrgAddress: orgA, Title: "manual A", MemberIDs: []string{memberA.Hex()},
+	})
+	c.Assert(err, qt.IsNil)
+
+	n, err := testDB.DeleteAllOrgMemberGroups(orgA)
+	c.Assert(err, qt.IsNil)
+	c.Assert(n, qt.Equals, int64(2)) // auto + manual
+
+	_, aGroups, err := testDB.OrganizationMemberGroups(orgA, 1, 100)
+	c.Assert(err, qt.IsNil)
+	c.Assert(aGroups, qt.HasLen, 0)
+	_, bGroups, err := testDB.OrganizationMemberGroups(orgB, 1, 100)
+	c.Assert(err, qt.IsNil)
+	c.Assert(bGroups, qt.HasLen, 1) // orgB's auto group survives
+
+	_, err = testDB.DeleteAllOrgMemberGroups(common.Address{})
+	c.Assert(err, qt.ErrorIs, ErrInvalidData)
+}
+
+// TestDeleteJobsByOrg covers DeleteJobsByOrg: it removes the org's jobs only.
+func TestDeleteJobsByOrg(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	orgA := common.HexToAddress("0xa0000000000000000000000000000000000000aA")
+	orgB := common.HexToAddress("0xb0000000000000000000000000000000000000bB")
+	c.Assert(testDB.CreateJob("jobA1", JobTypeOrgMembers, orgA, 10), qt.IsNil)
+	c.Assert(testDB.CreateJob("jobA2", JobTypePublishProcess, orgA, 1), qt.IsNil)
+	c.Assert(testDB.CreateJob("jobB1", JobTypeOrgMembers, orgB, 5), qt.IsNil)
+
+	n, err := testDB.DeleteJobsByOrg(orgA)
+	c.Assert(err, qt.IsNil)
+	c.Assert(n, qt.Equals, int64(2))
+
+	_, err = testDB.Job("jobA1")
+	c.Assert(err, qt.ErrorIs, ErrNotFound)
+	_, err = testDB.Job("jobB1")
+	c.Assert(err, qt.IsNil) // orgB's job survives
+
+	_, err = testDB.DeleteJobsByOrg(common.Address{})
+	c.Assert(err, qt.ErrorIs, ErrInvalidData)
+}
+
+// TestDeleteInvitationsByOrg covers DeleteInvitationsByOrg: it removes the org's pending invites
+// only (using DeleteMany, unlike the single-invitation helpers which silently no-op on a miss).
+func TestDeleteInvitationsByOrg(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	orgA := common.HexToAddress("0xa0000000000000000000000000000000000000aA")
+	orgB := common.HexToAddress("0xb0000000000000000000000000000000000000bB")
+	// CreateInvitation validates that the inviting user exists and belongs to the org.
+	seedOrg(t, orgA)
+	seedOrg(t, orgB)
+	inviterA, err := testDB.SetUser(&User{
+		Email: "inviter-a@x.test", Password: "p", FirstName: "I", LastName: "A",
+		Organizations: []OrganizationUser{{Address: orgA, Role: AdminRole}},
+	})
+	c.Assert(err, qt.IsNil)
+	inviterB, err := testDB.SetUser(&User{
+		Email: "inviter-b@x.test", Password: "p", FirstName: "I", LastName: "B",
+		Organizations: []OrganizationUser{{Address: orgB, Role: AdminRole}},
+	})
+	c.Assert(err, qt.IsNil)
+	expiration := time.Now().Add(time.Hour)
+
+	// three invites for orgA, one for orgB. invitationCode must match ^[\w]{6,}$.
+	orgACodes := []string{"codeA1xxx", "codeA2xxx", "codeA3xxx"}
+	orgAEmails := []string{"a1@x.test", "a2@x.test", "a3@x.test"}
+	for i, email := range orgAEmails {
+		c.Assert(testDB.CreateInvitation(&OrganizationInvite{
+			OrganizationAddress: orgA,
+			CurrentUserID:       inviterA,
+			NewUserEmail:        email,
+			Role:                ManagerRole,
+			Expiration:          expiration,
+			InvitationCode:      orgACodes[i],
+		}), qt.IsNil)
+	}
+	c.Assert(testDB.CreateInvitation(&OrganizationInvite{
+		OrganizationAddress: orgB,
+		CurrentUserID:       inviterB,
+		NewUserEmail:        "b1@x.test",
+		Role:                ManagerRole,
+		Expiration:          expiration,
+		InvitationCode:      "codeB1xxx",
+	}), qt.IsNil)
+
+	n, err := testDB.DeleteInvitationsByOrg(orgA)
+	c.Assert(err, qt.IsNil)
+	c.Assert(n, qt.Equals, int64(3))
+
+	// orgA has no pending invites left; orgB still has one.
+	aPending, err := testDB.PendingInvitations(orgA)
+	c.Assert(err, qt.IsNil)
+	c.Assert(aPending, qt.HasLen, 0)
+	bPending, err := testDB.PendingInvitations(orgB)
+	c.Assert(err, qt.IsNil)
+	c.Assert(bPending, qt.HasLen, 1)
+
+	// deleting orgA again deletes nothing (already empty).
+	n, err = testDB.DeleteInvitationsByOrg(orgA)
+	c.Assert(err, qt.IsNil)
+	c.Assert(n, qt.Equals, int64(0))
+
+	_, err = testDB.DeleteInvitationsByOrg(common.Address{})
+	c.Assert(err, qt.ErrorIs, ErrInvalidData)
+}
+
+// TestRemoveOrganizationFromAllUsers covers RemoveOrganizationFromAllUsers: it pulls the org out
+// of every user's Organizations list, across multiple users, leaving other org links intact.
+func TestRemoveOrganizationFromAllUsers(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	orgA := common.HexToAddress("0xa0000000000000000000000000000000000000aA")
+	orgB := common.HexToAddress("0xb0000000000000000000000000000000000000bB")
+
+	// two users, both members of orgA; one is also a member of orgB.
+	_, err := testDB.SetUser(&User{
+		Email: "u1@x.test", Password: "p", FirstName: "U", LastName: "1",
+		Organizations: []OrganizationUser{{Address: orgA, Role: AdminRole}, {Address: orgB, Role: ManagerRole}},
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = testDB.SetUser(&User{
+		Email: "u2@x.test", Password: "p", FirstName: "U", LastName: "2",
+		Organizations: []OrganizationUser{{Address: orgA, Role: ManagerRole}},
+	})
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(testDB.RemoveOrganizationFromAllUsers(orgA), qt.IsNil)
+
+	// u1 keeps only orgB; u2 has no orgs left.
+	u1, err := testDB.UserByEmail("u1@x.test")
+	c.Assert(err, qt.IsNil)
+	c.Assert(u1.Organizations, qt.HasLen, 1)
+	c.Assert(u1.Organizations[0].Address, qt.Equals, orgB)
+	u2, err := testDB.UserByEmail("u2@x.test")
+	c.Assert(err, qt.IsNil)
+	c.Assert(u2.Organizations, qt.HasLen, 0)
+
+	c.Assert(testDB.RemoveOrganizationFromAllUsers(common.Address{}), qt.ErrorIs, ErrInvalidData)
+}

--- a/db/org_members_groups.go
+++ b/db/org_members_groups.go
@@ -588,3 +588,22 @@ func (ms *MongoStorage) deleteAutoMemberGroup(orgAddress common.Address) error {
 	_, err := ms.orgMemberGroups.DeleteOne(ctx, filter)
 	return err
 }
+
+// DeleteAllOrgMemberGroups removes every member group (manual + the auto "All members"
+// group) owned by the given organization. Best-effort cleanup used when tearing down an
+// organization; DeleteAllOrgMembers also drops the auto group, so the two may be called
+// in either order. Returns the number of deleted group documents.
+func (ms *MongoStorage) DeleteAllOrgMemberGroups(orgAddress common.Address) (int64, error) {
+	if orgAddress.Cmp(common.Address{}) == 0 {
+		return 0, ErrInvalidData
+	}
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	res, err := ms.orgMemberGroups.DeleteMany(ctx, bson.M{"orgAddress": orgAddress})
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete org member groups: %w", err)
+	}
+	return res.DeletedCount, nil
+}

--- a/db/organization_invites.go
+++ b/db/organization_invites.go
@@ -185,3 +185,22 @@ func (ms *MongoStorage) DeleteInvitationByCode(invitationCode string) error {
 func (ms *MongoStorage) DeleteInvitationByEmail(email string) error {
 	return ms.deleteInvitationHelper(bson.M{"newUserEmail": email})
 }
+
+// DeleteInvitationsByOrg removes every pending invitation addressed to the given organization.
+// Unlike the single-invitation helpers above (which use DeleteOne), this deletes all matching
+// invitations. Best-effort cleanup used when tearing down an organization. Returns the number
+// of deleted invitations.
+func (ms *MongoStorage) DeleteInvitationsByOrg(orgAddress common.Address) (int64, error) {
+	if orgAddress.Cmp(common.Address{}) == 0 {
+		return 0, ErrInvalidData
+	}
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	res, err := ms.organizationInvites.DeleteMany(ctx, bson.M{"organizationAddress": orgAddress})
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete invitations by org: %w", err)
+	}
+	return res.DeletedCount, nil
+}

--- a/db/organizations.go
+++ b/db/organizations.go
@@ -226,6 +226,32 @@ func (ms *MongoStorage) RemoveOrganizationUser(address common.Address, userID ui
 	return nil
 }
 
+// RemoveOrganizationFromAllUsers unlinks the given organization from every user that is a
+// member of it, by pulling the organization entry out of each user's organizations list.
+// It generalizes RemoveOrganizationUser (which targets a single user) and is used when
+// tearing down an organization so no user keeps a dangling role reference to it.
+func (ms *MongoStorage) RemoveOrganizationFromAllUsers(address common.Address) error {
+	if address.Cmp(common.Address{}) == 0 {
+		return ErrInvalidData
+	}
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	filter := bson.M{"organizations._id": address}
+	update := bson.M{
+		"$pull": bson.M{
+			"organizations": bson.M{
+				"_id": address,
+			},
+		},
+	}
+	if _, err := ms.users.UpdateMany(ctx, filter, update); err != nil {
+		return fmt.Errorf("failed to unlink organization from users: %w", err)
+	}
+	return nil
+}
+
 // SetOrganizationSubscription method adds the provided subscription to
 // the organization with the given address
 func (ms *MongoStorage) SetOrganizationSubscription(address common.Address, orgSubscription *OrganizationSubscription) error {

--- a/db/process.go
+++ b/db/process.go
@@ -221,6 +221,37 @@ func (ms *MongoStorage) CountProcesses(orgAddress common.Address, draft DraftFil
 	return ms.processes.CountDocuments(ctx, filter)
 }
 
+// AllProcessesByOrg returns every process owned by the given organization without pagination,
+// filtered by the draft filter. It is used where the caller must inspect the full set (e.g. the
+// managed-org teardown guard, which must check every published election for an active status
+// rather than only the first page).
+func (ms *MongoStorage) AllProcessesByOrg(orgAddress common.Address, draft DraftFilter) ([]Process, error) {
+	if orgAddress.Cmp(common.Address{}) == 0 {
+		return nil, ErrInvalidData
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	filter := bson.M{"orgAddress": orgAddress}
+	switch draft {
+	case DraftOnly:
+		filter["address"] = bson.M{"$eq": nil}
+	case PublishedOnly:
+		filter["address"] = bson.M{"$ne": nil}
+	default:
+		// no filter
+	}
+	cursor, err := ms.processes.Find(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch processes by org: %w", err)
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+	var out []Process
+	if err := cursor.All(ctx, &out); err != nil {
+		return nil, fmt.Errorf("failed to decode processes: %w", err)
+	}
+	return out, nil
+}
+
 // DeleteProcessesByOrg removes every process (drafts and published DB rows) owned by the
 // given organization. On-chain elections are immutable on the Vochain and are not affected.
 // Returns the number of deleted process documents.

--- a/db/process.go
+++ b/db/process.go
@@ -220,3 +220,21 @@ func (ms *MongoStorage) CountProcesses(orgAddress common.Address, draft DraftFil
 	// Count total documents
 	return ms.processes.CountDocuments(ctx, filter)
 }
+
+// DeleteProcessesByOrg removes every process (drafts and published DB rows) owned by the
+// given organization. On-chain elections are immutable on the Vochain and are not affected.
+// Returns the number of deleted process documents.
+func (ms *MongoStorage) DeleteProcessesByOrg(orgAddress common.Address) (int64, error) {
+	if orgAddress.Cmp(common.Address{}) == 0 {
+		return 0, ErrInvalidData
+	}
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	res, err := ms.processes.DeleteMany(ctx, bson.M{"orgAddress": orgAddress})
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete processes by org: %w", err)
+	}
+	return res.DeletedCount, nil
+}

--- a/db/process_bundles.go
+++ b/db/process_bundles.go
@@ -245,6 +245,25 @@ func (ms *MongoStorage) ProcessBundlesByCensus(census *Census) ([]*ProcessesBund
 	return bundles, nil
 }
 
+// DeleteProcessBundlesByOrg removes every process bundle owned by the given organization.
+// Best-effort cleanup used when tearing down an organization. Returns the number of
+// deleted bundles. CSP auth tokens tied to those bundles must be cleaned up separately
+// (DeleteCSPAuthByBundle) before or after this call.
+func (ms *MongoStorage) DeleteProcessBundlesByOrg(orgAddress common.Address) (int64, error) {
+	if orgAddress.Cmp(common.Address{}) == 0 {
+		return 0, ErrInvalidData
+	}
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	res, err := ms.processBundles.DeleteMany(ctx, bson.M{"orgAddress": orgAddress})
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete process bundles by org: %w", err)
+	}
+	return res.DeletedCount, nil
+}
+
 // AddProcessesToBundle adds processes to an existing bundle if they don't already exist.
 // It checks each process to avoid duplicates and only updates the database if new processes were added.
 func (ms *MongoStorage) AddProcessesToBundle(hbBundleID internal.HexBytes, processes []internal.HexBytes) error {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -423,6 +423,11 @@ definitions:
           type: integer
         type: array
     type: object
+  apicommon.DeleteManagedOrganizationResponse:
+    properties:
+      address:
+        type: string
+    type: object
   apicommon.DeleteMembersRequest:
     properties:
       all:
@@ -2507,6 +2512,64 @@ paths:
       security:
       - BearerAuth: []
       summary: Create a managed organization under an integrator
+      tags:
+      - organizations
+  /integrator/organizations/{orgAddress}:
+    delete:
+      description: |-
+        Delete the managed organization at {orgAddress} together with every piece of data
+        tied to it (memberbase, censuses + participants, processes, bundles, CSP tokens,
+        jobs, pending invites), and unlink it from its members. The caller must be an admin
+        of their integrator organization (resolved from the API key's org or the user session
+        — no address in the URL), and the target must be managed by it. The integrator's usage
+        counters are rolled back accordingly.
+
+        Deletion is blocked with 409 when any of the managed org's published elections is
+        still active on-chain (READY/PAUSED); end them (or wait for them to end) first.
+        The on-chain organization account and any published elections/censuses are immutable
+        on the Vochain and are not affected — only DB-side data is removed.
+
+        Also callable with a scoped API key (scope: `managed:write`).
+      parameters:
+      - description: Managed organization address to delete
+        in: path
+        name: orgAddress
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apicommon.DeleteManagedOrganizationResponse'
+        "400":
+          description: Invalid address
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "404":
+          description: Managed organization not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "409":
+          description: Managed organization has active elections
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+      security:
+      - BearerAuth: []
+      summary: Delete a managed organization and all its data
       tags:
       - organizations
   /jobs/{jobId}:

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -105,6 +105,7 @@ var (
 	ErrInsufficientAPIKeyScope                = Error{Code: 40158, HTTPstatus: http.StatusForbidden, Err: fmt.Errorf("API key lacks the required scope"), LogLevel: "info"}
 	ErrInvalidAPIKeyScope                     = Error{Code: 40159, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid API key scope")}
 	ErrAPIKeyNotFound                         = Error{Code: 40160, HTTPstatus: http.StatusNotFound, Err: fmt.Errorf("API key not found")}
+	ErrManagedOrgHasActiveElections           = Error{Code: 40161, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("managed organization has active elections and cannot be deleted")}
 
 	// CSP errors (408)
 	ErrZeroWeightVoter = Error{Code: 40801, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("voter weight cannot be zero")}


### PR DESCRIPTION
## Problem

The integrator layer could **create** and **list** managed orgs (`POST`/`GET /organizations/{address}/managed`) but had no way to **delete** one. An integrator that wanted to remove a managed client org had no API path; its memberbase, censuses, processes, bundles, CSP tokens, jobs and invites would all be orphaned.

## Changes

Adds `DELETE /organizations/{address}/managed/{orgAddress}`.

- **Auth:** integrator org admin, via JWT **or** a scoped API key (`managed:write`) — mirrors `createManagedOrganizationHandler`.
- **Ownership check:** the target must have `ManagedBy == {address}`; a mismatch returns `404` (not `403`) so a caller cannot probe which addresses other integrators manage.
- **Active-election guard:** deletion is blocked with `409 ErrManagedOrgHasActiveElections` while any of the managed orgs published elections is `READY` or `PAUSED` on-chain. An on-chain lookup error fails **closed** (block) so a live election is never orphaned. Terminal statuses (`ENDED`/`CANCELED`/`RESULTS`) are allowed.
- **Best-effort cascade (DB-side only):** CSP auth tokens (by bundle) + CSP process-status (by published process), process bundles, census participants + censuses, processes (drafts + published rows), member groups + members, jobs, pending invites, unlink the org from all users, then the org doc itself.
- **Counter rollback:** integrator `ManagedOrgs -1` always; `ManagedProcesses` and `ManagedCensusSize` by the published **non-test-sized** election count and the summed census `Size`, mirroring the publish-time bump rule (api/process.go) so the counters never go negative.
- New `ErrManagedOrgHasActiveElections` (`40161`, 409).
- `docs/swagger.yaml` regenerated.

### DB helpers added
`DeleteCSPAuthByBundle`, `DeleteCSPProcessByProcess`, `DeleteProcessBundlesByOrg`, `DeleteProcessesByOrg`, `DeleteCensusParticipantsByCensus`, `DeleteAllOrgMemberGroups`, `DeleteJobsByOrg`, `DeleteInvitationsByOrg`, `RemoveOrganizationFromAllUsers` (generalizes `RemoveOrganizationUser`).

## Deliberately out of scope

- **API keys** owned by the managed org are **excluded** from the cascade. Since #547 restricted API-key creation to integrator orgs, a managed org can no longer have any keys, so there is nothing to orphan.
- The **on-chain org account**, **published elections** and **published censuses** are immutable on the Vochain and cannot be removed — deletion is DB-side only.

## Notes for reviewers

- The integrator `ManagedProcesses` counter is only bumped on publish for **non-test-sized** elections (`MaxCensusSize > db.TestMaxCensusSize`, = 10). The rollback replicates that rule exactly; I verified this the hard way — the first test run under-decremented to `-1` because the test election was test-sized.
- `TestDeleteManagedOrg` covers: non-admin → 401, unknown org → 404, not-managed-by-integrator → 404 (no existence leak), active election (READY) → 409 with nothing deleted, full cascade after `ENDED`, integrator counters rolled back to 0, and the freed `MaxManagedOrgs` slot is reusable.
- `golangci-lint` clean on all changed files (only the pre-existing repo-wide `goconst` noise remains, same as #547). Full `go test ./...` green.