### PR TITLE
feat(api)!: resolve integrator org from auth context (drop {address} from integrator endpoints)

### DIFF
--- a/api/apicommon/helpers.go
+++ b/api/apicommon/helpers.go
@@ -21,6 +21,17 @@ func UserFromContext(ctx context.Context) (*db.User, bool) {
 	return nil, false
 }
 
+// APIKeyFromContext retrieves the authenticating API key from the context, present only when the
+// request was authenticated with an API key (set by the authenticator middleware). The second
+// return value reports whether a key was present.
+func APIKeyFromContext(ctx context.Context) (*db.APIKey, bool) {
+	rawKey, ok := ctx.Value(APIKeyMetadataKey).(db.APIKey)
+	if ok {
+		return &rawKey, ok
+	}
+	return nil, false
+}
+
 // HTTPWriteJSON helper function allows to write a JSON response.
 func HTTPWriteJSON(w http.ResponseWriter, data any) {
 	w.Header().Set("Content-Type", "application/json")

--- a/api/apikeys.go
+++ b/api/apikeys.go
@@ -49,7 +49,7 @@ func IsValidAPIKeyScope(s string) bool {
 // tickets, checkout, etc.) JWT-only. The patterns must match the constants used at registration
 // so they equal chi's RoutePattern().
 var apiKeyAllowlist = map[string]string{
-	// integrator
+	// integrator (path-less; the integrator org is resolved from the key)
 	"GET " + integratorEndpoint:            ScopeQuotaRead,
 	"GET " + managedOrganizationsEndpoint:  ScopeManagedRead,
 	"POST " + managedOrganizationsEndpoint: ScopeManagedWrite,

--- a/api/apikeys_api_test.go
+++ b/api/apikeys_api_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
@@ -41,17 +42,18 @@ func TestAPIKeysAPI(t *testing.T) {
 		"organizations", orgAddr.String(), "apikeys")
 	c.Assert(code, qt.Equals, http.StatusBadRequest)
 
-	// the key works on allowlisted endpoints within its scopes
-	_, code = testRequest(t, http.MethodGet, apiKey, nil, "organizations", orgAddr.String(), "integrator")
+	// the key works on allowlisted endpoints within its scopes (path-less: the integrator org is
+	// resolved from the key itself, no address in the URL)
+	_, code = testRequest(t, http.MethodGet, apiKey, nil, "integrator")
 	c.Assert(code, qt.Equals, http.StatusOK) // quota:read
-	_, code = testRequest(t, http.MethodGet, apiKey, nil, "organizations", orgAddr.String(), "managed")
+	_, code = testRequest(t, http.MethodGet, apiKey, nil, "integrator", "organizations")
 	c.Assert(code, qt.Equals, http.StatusOK) // managed:read
 
 	// missing scope → 403 (key lacks managed:write)
 	mbody := &apicommon.CreateManagedOrganizationRequest{
 		OrganizationInfo: apicommon.OrganizationInfo{Type: string(db.CompanyType)},
 	}
-	_, code = testRequest(t, http.MethodPost, apiKey, mbody, "organizations", orgAddr.String(), "managed")
+	_, code = testRequest(t, http.MethodPost, apiKey, mbody, "integrator", "organizations")
 	c.Assert(code, qt.Equals, http.StatusForbidden)
 
 	// non-allowlisted endpoint → 403 (API keys can't manage API keys)
@@ -72,8 +74,52 @@ func TestAPIKeysAPI(t *testing.T) {
 	c.Assert(code, qt.Equals, http.StatusOK)
 
 	// the revoked key no longer authenticates
-	_, code = testRequest(t, http.MethodGet, apiKey, nil, "organizations", orgAddr.String(), "integrator")
+	_, code = testRequest(t, http.MethodGet, apiKey, nil, "integrator")
 	c.Assert(code, qt.Equals, http.StatusUnauthorized)
+}
+
+// TestIntegratorAPIKeyPathless verifies the path-less integrator endpoints resolve the integrator
+// organization from the API key: a key with the integrator scopes creates and lists managed orgs and
+// reads quota with no organization address in the URL, and the managed org is owned by the key's org.
+func TestIntegratorAPIKeyPathless(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "pathlesskeypass123")
+	orgAddr := testCreateOrganization(t, token)
+
+	org, err := testDB.Organization(orgAddr)
+	c.Assert(err, qt.IsNil)
+	org.IntegratorLimits = &db.IntegratorLimits{MaxManagedOrgs: 2, MaxManagedProcesses: 5, MaxManagedCensusSize: 100}
+	c.Assert(testDB.SetOrganization(org), qt.IsNil)
+
+	// mint a key with the integrator scopes
+	createBody := &apicommon.CreateAPIKeyRequest{
+		Label:  "pathless",
+		Scopes: []string{ScopeQuotaRead, ScopeManagedRead, ScopeManagedWrite},
+	}
+	data, code := testRequest(t, http.MethodPost, token, createBody, "organizations", orgAddr.String(), "apikeys")
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("resp: %s", data))
+	var created apicommon.CreateAPIKeyResponse
+	c.Assert(json.Unmarshal(data, &created), qt.IsNil)
+	apiKey := created.Secret
+
+	// create a managed org with the key — no address in the URL, resolved from the key's own org
+	mbody := &apicommon.CreateManagedOrganizationRequest{
+		OrganizationInfo: apicommon.OrganizationInfo{Type: string(db.CompanyType), Website: "https://m1.example"},
+	}
+	createdOrg := requestAndParse[apicommon.OrganizationInfo](t, http.MethodPost, apiKey, mbody, "integrator", "organizations")
+	c.Assert(createdOrg.Address, qt.Not(qt.Equals), common.Address{})
+
+	// the managed org is owned by the key's integrator org
+	mo, err := testDB.Organization(createdOrg.Address)
+	c.Assert(err, qt.IsNil)
+	c.Assert(mo.ManagedBy, qt.Equals, orgAddr)
+
+	// list + quota reflect it, all path-less
+	list := requestAndParse[apicommon.ListManagedOrganizations](t, http.MethodGet, apiKey, nil, "integrator", "organizations")
+	c.Assert(list.Organizations, qt.HasLen, 1)
+	info := requestAndParse[apicommon.IntegratorInfoResponse](t, http.MethodGet, apiKey, nil, "integrator")
+	c.Assert(info.Enabled, qt.IsTrue)
+	c.Assert(info.Usage.ManagedOrgs, qt.Equals, 1)
 }
 
 // TestAPIKeysRequireIntegrator verifies that API keys can only be created by integrator

--- a/api/integrator_subscription_test.go
+++ b/api/integrator_subscription_test.go
@@ -57,7 +57,8 @@ func TestIntegratorPlanSubscription(t *testing.T) {
 
 	// Integrator info: enabled, and the limits are exactly the plan's.
 	info := requestAndParse[apicommon.IntegratorInfoResponse](
-		t, http.MethodGet, token, nil, "organizations", integratorAddr.String(), "integrator")
+		t, http.MethodGet, token, nil, "integrator",
+	)
 	c.Assert(info.Enabled, qt.IsTrue)
 	c.Assert(info.Limits, qt.Not(qt.IsNil))
 	c.Assert(info.Limits.MaxManagedOrgs, qt.Equals, maxManagedOrgs)
@@ -74,7 +75,8 @@ func TestIntegratorPlanSubscription(t *testing.T) {
 					Website: fmt.Sprintf("https://managed-plan-%d.example", i),
 				},
 			},
-			"organizations", integratorAddr.String(), "managed")
+			"integrator", "organizations",
+		)
 		c.Assert(created.Address, qt.Not(qt.Equals), common.Address{})
 		managed = append(managed, created.Address)
 	}
@@ -87,15 +89,17 @@ func TestIntegratorPlanSubscription(t *testing.T) {
 				Website: "https://managed-plan-over.example",
 			},
 		},
-		"organizations", integratorAddr.String(), "managed")
+		"integrator", "organizations")
 	c.Assert(code, qt.Equals, http.StatusBadRequest) // ErrMaxManagedOrgsReached
 
 	// Usage and the managed list both reflect the created orgs.
 	info = requestAndParse[apicommon.IntegratorInfoResponse](
-		t, http.MethodGet, token, nil, "organizations", integratorAddr.String(), "integrator")
+		t, http.MethodGet, token, nil, "integrator",
+	)
 	c.Assert(info.Usage.ManagedOrgs, qt.Equals, maxManagedOrgs)
 	list := requestAndParse[apicommon.ListManagedOrganizations](
-		t, http.MethodGet, token, nil, "organizations", integratorAddr.String(), "managed")
+		t, http.MethodGet, token, nil, "integrator", "organizations",
+	)
 	c.Assert(list.Organizations, qt.HasLen, maxManagedOrgs)
 
 	// Each managed org is linked to the integrator and auto-subscribed to the

--- a/api/integrator_test.go
+++ b/api/integrator_test.go
@@ -20,13 +20,13 @@ func TestIntegratorManagedOrgs(t *testing.T) {
 	c := qt.New(t)
 	token := testCreateUser(t, "integratorpass123")
 	integratorAddr := testCreateOrganization(t, token)
-	plainAddr := testCreateOrganization(t, token) // a normal org owned by the same user
 
-	// rejection: a non-integrator org cannot create managed orgs
+	// rejection: a user with no integrator org cannot create managed orgs. The integrator org is
+	// resolved from the session (path-less), and integratorAddr is not an integrator yet here.
 	body := &apicommon.CreateManagedOrganizationRequest{
 		OrganizationInfo: apicommon.OrganizationInfo{Type: string(db.CompanyType), Website: "https://managed.example"},
 	}
-	_, code := testRequest(t, http.MethodPost, token, body, "organizations", plainAddr.String(), "managed")
+	_, code := testRequest(t, http.MethodPost, token, body, "integrator", "organizations")
 	c.Assert(code, qt.Equals, http.StatusForbidden) // ErrNotAnIntegrator
 
 	// enable integrator with an override (override beats plan):
@@ -50,7 +50,7 @@ func TestIntegratorManagedOrgs(t *testing.T) {
 			},
 		}
 		created := requestAndParse[apicommon.OrganizationInfo](
-			t, http.MethodPost, token, reqBody, "organizations", integratorAddr.String(), "managed",
+			t, http.MethodPost, token, reqBody, "integrator", "organizations",
 		)
 		c.Assert(created.Address, qt.Not(qt.Equals), common.Address{})
 		if i == 0 {
@@ -62,12 +62,12 @@ func TestIntegratorManagedOrgs(t *testing.T) {
 		&apicommon.CreateManagedOrganizationRequest{
 			OrganizationInfo: apicommon.OrganizationInfo{Type: string(db.CompanyType), Website: "https://managed-3.example"},
 		},
-		"organizations", integratorAddr.String(), "managed")
+		"integrator", "organizations")
 	c.Assert(code, qt.Equals, http.StatusBadRequest) // ErrMaxManagedOrgsReached
 
 	// integrator info reflects usage + limits
 	info := requestAndParse[apicommon.IntegratorInfoResponse](
-		t, http.MethodGet, token, nil, "organizations", integratorAddr.String(), "integrator",
+		t, http.MethodGet, token, nil, "integrator",
 	)
 	c.Assert(info.Enabled, qt.IsTrue)
 	c.Assert(info.Limits.MaxManagedOrgs, qt.Equals, 2)
@@ -75,7 +75,7 @@ func TestIntegratorManagedOrgs(t *testing.T) {
 
 	// managed list returns the two orgs
 	list := requestAndParse[apicommon.ListManagedOrganizations](
-		t, http.MethodGet, token, nil, "organizations", integratorAddr.String(), "managed",
+		t, http.MethodGet, token, nil, "integrator", "organizations",
 	)
 	c.Assert(list.Organizations, qt.HasLen, 2)
 

--- a/api/organizations_managed.go
+++ b/api/organizations_managed.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/go-chi/chi/v5"
 	"github.com/vocdoni/saas-backend/account"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
@@ -15,16 +14,37 @@ import (
 	"go.vocdoni.io/dvote/log"
 )
 
-// integratorAddressFromRequest validates the {address} path param and returns it as an
-// address. It writes ErrMalformedURLParam and returns ok=false when the param is not a
-// valid hex address, so callers fail with a 400 rather than treating it as the zero address.
-func integratorAddressFromRequest(w http.ResponseWriter, r *http.Request) (common.Address, bool) {
-	addr := chi.URLParam(r, "address")
-	if !common.IsHexAddress(addr) {
-		errors.ErrMalformedURLParam.With("invalid organization address").Write(w)
+// integratorAddress resolves the integrator organization for an integrator-scoped request. The
+// integrator endpoints are path-less: the organization is taken from the authenticated principal,
+// never from the URL. With an API key it is the key's own org. With a user session (JWT) it is the
+// integrator organization the user administers — an integrator manages a single organization (the UI
+// does not let an integrator create more), and the user may also administer the managed orgs it
+// created, so we select the one that is itself an integrator rather than the first org in the list.
+// Writes ErrNotAnIntegrator and returns ok=false when the user has no integrator organization. The
+// handlers still enforce the concrete role and quota eligibility on the resolved org.
+func (a *API) integratorAddress(w http.ResponseWriter, r *http.Request) (common.Address, bool) {
+	if key, ok := apicommon.APIKeyFromContext(r.Context()); ok {
+		return key.OrgAddress, true
+	}
+	user, ok := apicommon.UserFromContext(r.Context())
+	if !ok {
+		errors.ErrUnauthorized.Write(w)
 		return common.Address{}, false
 	}
-	return common.HexToAddress(addr), true
+	for _, orgUser := range user.Organizations {
+		if orgUser.Role != db.AdminRole && orgUser.Role != db.ManagerRole {
+			continue
+		}
+		org, err := a.db.Organization(orgUser.Address)
+		if err != nil {
+			continue
+		}
+		if a.subscriptions.IsIntegrator(org) {
+			return org.Address, true
+		}
+	}
+	errors.ErrNotAnIntegrator.Write(w)
+	return common.Address{}, false
 }
 
 // releaseManagedOrgSlot rolls back a managed-org slot reserved by
@@ -39,19 +59,19 @@ func (a *API) releaseManagedOrgSlot(integratorAddr common.Address) {
 // createManagedOrganizationHandler godoc
 //
 //	@Summary		Create a managed organization under an integrator
-//	@Description	Create a new organization managed by the integrator at the given address. The
-//	@Description	caller must be an admin of the integrator organization, which must be enabled as
-//	@Description	an integrator and within its managed-organizations quota. The managed org's on-chain
-//	@Description	account is always provisioned eagerly. The optional `ownerEmail` designates the managed
-//	@Description	org's owner/admin (defaults to the calling user); the per-user MaxOrgsPerUser cap is
-//	@Description	bypassed for managed orgs.
+//	@Description	Create a new organization managed by the caller's integrator organization. The
+//	@Description	integrator is resolved from the authenticated principal (the API key's org, or the
+//	@Description	user's organization for a session) — no address is passed in the URL. The caller must
+//	@Description	be an admin of that integrator organization, which must be enabled as an integrator and
+//	@Description	within its managed-organizations quota. The managed org's on-chain account is always
+//	@Description	provisioned eagerly. The optional `ownerEmail` designates the managed org's owner/admin
+//	@Description	(defaults to the calling user); the per-user MaxOrgsPerUser cap is bypassed for managed orgs.
 //	@Description
 //	@Description	Also callable with a scoped API key (scope: `managed:write`).
 //	@Tags			organizations
 //	@Accept			json
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			address	path		string										true	"Integrator organization address"
 //	@Param			request	body		apicommon.CreateManagedOrganizationRequest	true	"Managed organization information"
 //	@Success		200		{object}	apicommon.OrganizationInfo
 //	@Failure		400		{object}	errors.Error	"Invalid input data"
@@ -59,14 +79,14 @@ func (a *API) releaseManagedOrgSlot(integratorAddr common.Address) {
 //	@Failure		403		{object}	errors.Error	"Not an integrator or quota reached"
 //	@Failure		404		{object}	errors.Error	"Integrator organization not found"
 //	@Failure		500		{object}	errors.Error	"Internal server error"
-//	@Router			/organizations/{address}/managed [post]
+//	@Router			/integrator/organizations [post]
 func (a *API) createManagedOrganizationHandler(w http.ResponseWriter, r *http.Request) {
 	user, ok := apicommon.UserFromContext(r.Context())
 	if !ok {
 		errors.ErrUnauthorized.Write(w)
 		return
 	}
-	integratorAddr, ok := integratorAddressFromRequest(w, r)
+	integratorAddr, ok := a.integratorAddress(w, r)
 	if !ok {
 		return
 	}
@@ -190,28 +210,28 @@ func (a *API) createManagedOrganizationHandler(w http.ResponseWriter, r *http.Re
 // managedOrganizationsHandler godoc
 //
 //	@Summary		List organizations managed by an integrator
-//	@Description	Returns a paginated list of organizations managed by the integrator at the given
-//	@Description	address. The caller must be an admin or manager of the integrator organization.
+//	@Description	Returns a paginated list of organizations managed by the caller's integrator
+//	@Description	organization (resolved from the API key's org or the user session — no address in the
+//	@Description	URL). The caller must be an admin or manager of the integrator organization.
 //	@Description
 //	@Description	Also callable with a scoped API key (scope: `managed:read`).
 //	@Tags			organizations
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			address	path		string	true	"Integrator organization address"
 //	@Param			page	query		integer	false	"Page number (default: 1)"
 //	@Param			limit	query		integer	false	"Number of items per page (default: 10)"
 //	@Success		200		{object}	apicommon.ListManagedOrganizations
 //	@Failure		400		{object}	errors.Error	"Invalid input data"
 //	@Failure		401		{object}	errors.Error	"Unauthorized"
 //	@Failure		500		{object}	errors.Error	"Internal server error"
-//	@Router			/organizations/{address}/managed [get]
+//	@Router			/integrator/organizations [get]
 func (a *API) managedOrganizationsHandler(w http.ResponseWriter, r *http.Request) {
 	user, ok := apicommon.UserFromContext(r.Context())
 	if !ok {
 		errors.ErrUnauthorized.Write(w)
 		return
 	}
-	integratorAddr, ok := integratorAddressFromRequest(w, r)
+	integratorAddr, ok := a.integratorAddress(w, r)
 	if !ok {
 		return
 	}
@@ -247,30 +267,29 @@ func (a *API) managedOrganizationsHandler(w http.ResponseWriter, r *http.Request
 // integratorInfoHandler godoc
 //
 //	@Summary		Get integrator quota and usage
-//	@Description	Returns whether the organization at the given address is enabled as an integrator,
-//	@Description	along with its effective managed-resource limits and current usage. The caller must
-//	@Description	be an admin or manager of the organization. When the organization is not an integrator,
-//	@Description	`enabled` is false and `limits` is omitted (usage counters are still returned).
-//	@Description	A 0 in any limit field means unlimited for that dimension.
+//	@Description	Returns whether the caller's organization (resolved from the API key's org or the user
+//	@Description	session — no address in the URL) is enabled as an integrator, along with its effective
+//	@Description	managed-resource limits and current usage. The caller must be an admin or manager of the
+//	@Description	organization. When the organization is not an integrator, `enabled` is false and `limits`
+//	@Description	is omitted (usage counters are still returned). A 0 in any limit field means unlimited.
 //	@Description
 //	@Description	Also callable with a scoped API key (scope: `quota:read`).
 //	@Tags			organizations
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			address	path		string	true	"Integrator organization address"
-//	@Success		200		{object}	apicommon.IntegratorInfoResponse
-//	@Failure		400		{object}	errors.Error	"Invalid input data"
-//	@Failure		401		{object}	errors.Error	"Unauthorized"
-//	@Failure		404		{object}	errors.Error	"Organization not found"
-//	@Failure		500		{object}	errors.Error	"Internal server error"
-//	@Router			/organizations/{address}/integrator [get]
+//	@Success		200	{object}	apicommon.IntegratorInfoResponse
+//	@Failure		400	{object}	errors.Error	"Invalid input data"
+//	@Failure		401	{object}	errors.Error	"Unauthorized"
+//	@Failure		404	{object}	errors.Error	"Organization not found"
+//	@Failure		500	{object}	errors.Error	"Internal server error"
+//	@Router			/integrator [get]
 func (a *API) integratorInfoHandler(w http.ResponseWriter, r *http.Request) {
 	user, ok := apicommon.UserFromContext(r.Context())
 	if !ok {
 		errors.ErrUnauthorized.Write(w)
 		return
 	}
-	integratorAddr, ok := integratorAddressFromRequest(w, r)
+	integratorAddr, ok := a.integratorAddress(w, r)
 	if !ok {
 		return
 	}

--- a/api/routes.go
+++ b/api/routes.go
@@ -109,10 +109,13 @@ const (
 	organizationJobsEndpoint = "/organizations/{address}/jobs"
 	// GET /organizations/{address}/processes to get the organization bundle processes
 	organizationBundlesEndpoint = "/organizations/{address}/processes"
-	// POST /organizations/{address}/managed to create a managed org; GET to list them (integrator)
-	managedOrganizationsEndpoint = "/organizations/{address}/managed"
-	// GET /organizations/{address}/integrator to get integrator quota and usage
-	integratorEndpoint = "/organizations/{address}/integrator"
+	// GET /integrator to get integrator quota and usage for the caller's own integrator org.
+	// Path-less: the integrator org is resolved from the API key (its org) or the user session.
+	integratorEndpoint = "/integrator"
+	// POST /integrator/organizations to create a managed org; GET to list them, for the caller's
+	// own integrator org. Path-less: the integrator is resolved from the API key or the user
+	// session, so no organization address is passed in the URL.
+	managedOrganizationsEndpoint = "/integrator/organizations"
 	// POST /organizations/{address}/apikeys to create an API key; GET to list them
 	organizationAPIKeysEndpoint = "/organizations/{address}/apikeys"
 	// DELETE /organizations/{address}/apikeys/{keyID} to revoke an API key

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2378,6 +2378,137 @@ paths:
       summary: Get service information
       tags:
       - health
+  /integrator:
+    get:
+      description: |-
+        Returns whether the caller's organization (resolved from the API key's org or the user
+        session — no address in the URL) is enabled as an integrator, along with its effective
+        managed-resource limits and current usage. The caller must be an admin or manager of the
+        organization. When the organization is not an integrator, `enabled` is false and `limits`
+        is omitted (usage counters are still returned). A 0 in any limit field means unlimited.
+
+        Also callable with a scoped API key (scope: `quota:read`).
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apicommon.IntegratorInfoResponse'
+        "400":
+          description: Invalid input data
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "404":
+          description: Organization not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+      security:
+      - BearerAuth: []
+      summary: Get integrator quota and usage
+      tags:
+      - organizations
+  /integrator/organizations:
+    get:
+      description: |-
+        Returns a paginated list of organizations managed by the caller's integrator
+        organization (resolved from the API key's org or the user session — no address in the
+        URL). The caller must be an admin or manager of the integrator organization.
+
+        Also callable with a scoped API key (scope: `managed:read`).
+      parameters:
+      - description: 'Page number (default: 1)'
+        in: query
+        name: page
+        type: integer
+      - description: 'Number of items per page (default: 10)'
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apicommon.ListManagedOrganizations'
+        "400":
+          description: Invalid input data
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+      security:
+      - BearerAuth: []
+      summary: List organizations managed by an integrator
+      tags:
+      - organizations
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Create a new organization managed by the caller's integrator organization. The
+        integrator is resolved from the authenticated principal (the API key's org, or the
+        user's organization for a session) — no address is passed in the URL. The caller must
+        be an admin of that integrator organization, which must be enabled as an integrator and
+        within its managed-organizations quota. The managed org's on-chain account is always
+        provisioned eagerly. The optional `ownerEmail` designates the managed org's owner/admin
+        (defaults to the calling user); the per-user MaxOrgsPerUser cap is bypassed for managed orgs.
+
+        Also callable with a scoped API key (scope: `managed:write`).
+      parameters:
+      - description: Managed organization information
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/apicommon.CreateManagedOrganizationRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apicommon.OrganizationInfo'
+        "400":
+          description: Invalid input data
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "403":
+          description: Not an integrator or quota reached
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "404":
+          description: Integrator organization not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+      security:
+      - BearerAuth: []
+      summary: Create a managed organization under an integrator
+      tags:
+      - organizations
   /jobs/{jobId}:
     get:
       description: |-
@@ -3091,50 +3222,6 @@ paths:
       summary: Validate organization group members data
       tags:
       - organizations
-  /organizations/{address}/integrator:
-    get:
-      description: |-
-        Returns whether the organization at the given address is enabled as an integrator,
-        along with its effective managed-resource limits and current usage. The caller must
-        be an admin or manager of the organization. When the organization is not an integrator,
-        `enabled` is false and `limits` is omitted (usage counters are still returned).
-        A 0 in any limit field means unlimited for that dimension.
-
-        Also callable with a scoped API key (scope: `quota:read`).
-      parameters:
-      - description: Integrator organization address
-        in: path
-        name: address
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/apicommon.IntegratorInfoResponse'
-        "400":
-          description: Invalid input data
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "404":
-          description: Organization not found
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "500":
-          description: Internal server error
-          schema:
-            $ref: '#/definitions/errors.Error'
-      security:
-      - BearerAuth: []
-      summary: Get integrator quota and usage
-      tags:
-      - organizations
   /organizations/{address}/jobs:
     get:
       consumes:
@@ -3185,107 +3272,6 @@ paths:
       security:
       - BearerAuth: []
       summary: Get organization jobs
-      tags:
-      - organizations
-  /organizations/{address}/managed:
-    get:
-      description: |-
-        Returns a paginated list of organizations managed by the integrator at the given
-        address. The caller must be an admin or manager of the integrator organization.
-
-        Also callable with a scoped API key (scope: `managed:read`).
-      parameters:
-      - description: Integrator organization address
-        in: path
-        name: address
-        required: true
-        type: string
-      - description: 'Page number (default: 1)'
-        in: query
-        name: page
-        type: integer
-      - description: 'Number of items per page (default: 10)'
-        in: query
-        name: limit
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/apicommon.ListManagedOrganizations'
-        "400":
-          description: Invalid input data
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "500":
-          description: Internal server error
-          schema:
-            $ref: '#/definitions/errors.Error'
-      security:
-      - BearerAuth: []
-      summary: List organizations managed by an integrator
-      tags:
-      - organizations
-    post:
-      consumes:
-      - application/json
-      description: |-
-        Create a new organization managed by the integrator at the given address. The
-        caller must be an admin of the integrator organization, which must be enabled as
-        an integrator and within its managed-organizations quota. The managed org's on-chain
-        account is always provisioned eagerly. The optional `ownerEmail` designates the managed
-        org's owner/admin (defaults to the calling user); the per-user MaxOrgsPerUser cap is
-        bypassed for managed orgs.
-
-        Also callable with a scoped API key (scope: `managed:write`).
-      parameters:
-      - description: Integrator organization address
-        in: path
-        name: address
-        required: true
-        type: string
-      - description: Managed organization information
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/apicommon.CreateManagedOrganizationRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/apicommon.OrganizationInfo'
-        "400":
-          description: Invalid input data
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "403":
-          description: Not an integrator or quota reached
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "404":
-          description: Integrator organization not found
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "500":
-          description: Internal server error
-          schema:
-            $ref: '#/definitions/errors.Error'
-      security:
-      - BearerAuth: []
-      summary: Create a managed organization under an integrator
       tags:
       - organizations
   /organizations/{address}/member:


### PR DESCRIPTION
## Why

The integrator-scoped endpoints were addressed as `/organizations/{address}/...`, and the handlers read the integrator org from the path. But an **API key already uniquely identifies its integrator org**, and there's no key-accessible "whoami" — so a pure API-key client can't discover its own address to build the URL. The org should come from the authenticated principal, not the URL.

## What (⚠️ breaking)

The integrator endpoints become **path-less**:

| before | after |
|---|---|
| `GET /organizations/{address}/integrator` | `GET /integrator` |
| `GET /organizations/{address}/managed` | `GET /integrator/managed` |
| `POST /organizations/{address}/managed` | `POST /integrator/managed` |

The integrator organization is resolved from the caller:
- **API key** → the key's own org (`db.APIKey.OrgAddress`).
- **User session (JWT)** → the integrator org the user administers. Selected via `subscriptions.IsIntegrator` (not "first org") because the user may also administer the managed orgs it created. One user = one integrator org in practice — the UI doesn't let an integrator create more.

## How

- `apicommon.APIKeyFromContext` (mirrors `UserFromContext`).
- `a.integratorAddress(w, r)` resolves the org; the three handlers use it instead of the path param. Their role/quota checks are unchanged.
- `apiKeyAllowlist` + swagger updated. Constant names reused (`integratorEndpoint`, `managedOrganizationsEndpoint`) — only their values changed, to keep the diff small.

Member management is untouched: `POST /organizations/{managedAddr}/members` already works with a key (the managed org's owner defaults to the key owner), and the managed address comes from the create response.

## Tests

`make test` (api): `TestIntegratorManagedOrgs`, `TestIntegratorPlanSubscription`, `TestAPIKeysAPI`, `TestAPIKeysRequireIntegrator` updated to the path-less routes and passing; new `TestIntegratorAPIKeyPathless` covers create+list+quota with a key and no address. `make swagger` regenerated; gofumpt clean.

## Follow-up (not in this PR)

The integrator frontend (`vocdoni-app` `src/platform` — PR vocdoni-app#1700) still calls the old addressed routes and must be updated to the path-less ones before this is deployed to an environment the platform UI points at.