### PR TITLE
feat(api)!: relay votes at POST /vote instead of /process/{processId}/vote

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -373,7 +373,7 @@ func (a *API) initRouter() http.Handler {
 		handle(r, http.MethodGet, censusIDEndpoint, a.censusInfoHandler)
 		handle(r, http.MethodGet, jobStatusEndpoint, a.jobStatusHandler)
 		handle(r, http.MethodGet, processEndpoint, a.processInfoHandler)
-		handle(r, http.MethodPost, processVoteEndpoint, a.relayVoteHandler)
+		handle(r, http.MethodPost, voteEndpoint, a.relayVoteHandler)
 		handle(r, http.MethodGet, processResultsEndpoint, a.processResultsHandler)
 		handle(r, http.MethodGet, processMetadataEndpoint, a.processMetadataHandler)
 		handle(r, http.MethodPost, processSignInfoEndpoint, cspHandlers.ConsumedAddressHandler)

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -1159,16 +1159,17 @@ type ProcessResultsResponse struct {
 	Results      [][]string `json:"results,omitempty"`
 }
 
-// RelayVoteRequest is the body of POST /process/{processId}/vote: a hex-encoded,
-// already-signed voter transaction (a marshaled models.SignedTx wrapping a Vote tx).
+// RelayVoteRequest is the body of POST /vote: a hex-encoded, already-signed voter
+// transaction (a marshaled models.SignedTx wrapping a Vote tx). The target process
+// is taken from the inner Vote envelope.
 // swagger:model RelayVoteRequest
 type RelayVoteRequest struct {
 	// Hex of a marshaled models.SignedTx whose inner Tx is a Vote
 	TxPayload internal.HexBytes `json:"txPayload" swaggertype:"string" format:"hex" example:"deadbeef"`
 }
 
-// RelayVoteResponse is returned by POST /process/{processId}/vote with the vote
-// nullifier (voteID) assigned on chain.
+// RelayVoteResponse is returned by POST /vote with the vote nullifier (voteID)
+// assigned on chain.
 // swagger:model RelayVoteResponse
 type RelayVoteResponse struct {
 	// On-chain vote nullifier

--- a/api/docs.md
+++ b/api/docs.md
@@ -2398,7 +2398,7 @@ If the worker queue is saturated the handler returns `503` and the client should
   (idempotent, no transaction sent).
 * **Change process status** — `PUT /process/{processId}/status` (Manager/Admin).
   Body `{ "status": "ready|paused|ended|canceled" }`. Returns `202` + `{ "jobId" }`.
-* **Relay a signed vote** — `POST /process/{processId}/vote` (public).
+* **Relay a signed vote** — `POST /vote` (public).
   Body `{ "txPayload": "<hex>" }`. Returns `202` + `{ "jobId" }`; the job result carries
   the vote nullifier (`voteID`).
 

--- a/api/process_vote.go
+++ b/api/process_vote.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"bytes"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -22,27 +21,24 @@ import (
 //	@Summary		Relay an already-signed vote to the Vochain
 //	@Description	Relays a voter transaction that has already been signed by the voter to the
 //	@Description	Vochain. The body carries a marshaled models.SignedTx whose inner Tx is a Vote
-//	@Description	envelope. Public endpoint: no authentication is required. The vote is validated
-//	@Description	synchronously and then submitted on a background worker; the call returns 202 with
-//	@Description	a job id. Poll GET /jobs/{jobId} for the resulting vote nullifier (voteID).
+//	@Description	envelope; the target process is taken from that envelope, so no process id is
+//	@Description	passed in the path. Public endpoint: no authentication is required. The request is
+//	@Description	checked synchronously — the body must decode to a Vote envelope (else 400) for a
+//	@Description	process the backend knows (else 404) — then enqueued for submission on a background
+//	@Description	worker; the call returns 202 with a job id. The chain's acceptance or rejection of
+//	@Description	the vote (proof, nullifier, election state) is decided when the worker submits it and
+//	@Description	reported on the job: poll GET /jobs/{jobId} for the voteID on success, or a failure.
 //	@Tags			process
 //	@Accept			json
 //	@Produce		json
-//	@Param			processId	path		string						true	"On-chain process id (hex)"
-//	@Param			request		body		apicommon.RelayVoteRequest	true	"Signed vote transaction payload"
-//	@Success		202			{object}	apicommon.EnqueuedResponse	"Job accepted; poll GET /jobs/{jobId}"
-//	@Failure		400			{object}	errors.Error				"Invalid input data"
-//	@Failure		404			{object}	errors.Error				"Process not found"
-//	@Failure		500			{object}	errors.Error				"Internal server error"
-//	@Failure		503			{object}	errors.Error				"Transaction queue is full"
-//	@Router			/process/{processId}/vote [post]
+//	@Param			request	body		apicommon.RelayVoteRequest	true	"Signed vote transaction payload"
+//	@Success		202		{object}	apicommon.EnqueuedResponse	"Job accepted; poll GET /jobs/{jobId}"
+//	@Failure		400		{object}	errors.Error				"Invalid input data"
+//	@Failure		404		{object}	errors.Error				"Process not found"
+//	@Failure		500		{object}	errors.Error				"Internal server error"
+//	@Failure		503		{object}	errors.Error				"Transaction queue is full"
+//	@Router			/vote [post]
 func (a *API) relayVoteHandler(w http.ResponseWriter, r *http.Request) {
-	var pid internal.HexBytes
-	if err := pid.ParseString(chi.URLParam(r, "processId")); err != nil || len(pid) == 0 {
-		errors.ErrMalformedURLParam.Withf("invalid process id").Write(w)
-		return
-	}
-
 	var req apicommon.RelayVoteRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		errors.ErrMalformedBody.Write(w)
@@ -69,8 +65,10 @@ func (a *API) relayVoteHandler(w http.ResponseWriter, r *http.Request) {
 		errors.ErrInvalidTxFormat.With("not a vote tx").Write(w)
 		return
 	}
-	if !bytes.Equal(vote.ProcessId, pid.Bytes()) {
-		errors.ErrInvalidTxFormat.With("vote process id does not match url").Write(w)
+	// the target process is the one named in the signed vote envelope.
+	pid := internal.HexBytes(vote.ProcessId)
+	if len(pid) == 0 {
+		errors.ErrInvalidTxFormat.With("vote has no process id").Write(w)
 		return
 	}
 
@@ -85,8 +83,10 @@ func (a *API) relayVoteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// submit + confirm on the worker pool; the vote nullifier (voteID) is recorded on
-	// the job. Validation above already ran synchronously, so a bad vote got a 400.
+	// submit + confirm on the worker pool; the vote nullifier (voteID) is recorded on the
+	// job. The structural checks above ran synchronously (a malformed vote got a 400, an
+	// unknown process a 404); the chain's acceptance of the vote is decided here, async, and
+	// surfaced on the job.
 	jobID, err := apicommon.NewJobID()
 	if err != nil {
 		errors.ErrGenericInternalServerError.WithErr(err).Write(w)

--- a/api/process_vote_test.go
+++ b/api/process_vote_test.go
@@ -123,7 +123,7 @@ func TestProcessStatusLifecycle(t *testing.T) {
 }
 
 // testRelayVoteRequest signs a vote tx, wraps it as a SignedTx, posts it to
-// POST /process/{processId}/vote, and returns the relayed vote nullifier.
+// POST /vote, and returns the relayed vote nullifier.
 func testRelayVoteRequest(t *testing.T, signer *ethereum.SignKeys, processID internal.HexBytes,
 	proof *models.Proof, votePackage []byte,
 ) internal.HexBytes {
@@ -140,7 +140,7 @@ func testRelayVoteRequest(t *testing.T, signer *ethereum.SignKeys, processID int
 	stx, err := proto.Marshal(&models.SignedTx{Tx: txBytes, Signature: signature})
 	c.Assert(err, qt.IsNil)
 	job := enqueueAndPollJob(t, http.MethodPost, "",
-		&apicommon.RelayVoteRequest{TxPayload: stx}, "process", processID.String(), "vote")
+		&apicommon.RelayVoteRequest{TxPayload: stx}, "vote")
 	c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("error: %s", job.Error))
 	c.Assert(job.Result.VoteID, qt.Not(qt.HasLen), 0)
 	return job.Result.VoteID

--- a/api/routes.go
+++ b/api/routes.go
@@ -169,8 +169,9 @@ const (
 	// PUT /process/{processId}/status to change an on-chain election status
 	processStatusEndpoint = "/process/{processId}/status"
 
-	// POST /process/{processId}/vote to relay an already-signed vote (public)
-	processVoteEndpoint = "/process/{processId}/vote"
+	// POST /vote to relay an already-signed vote (public). The target process is taken
+	// from the signed vote envelope itself, so no process id appears in the path.
+	voteEndpoint = "/vote"
 
 	// GET /process/{processId}/results to get the trimmed on-chain election results (public)
 	processResultsEndpoint = "/process/{processId}/results"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4718,54 +4718,6 @@ paths:
       summary: Change an on-chain election status
       tags:
       - process
-  /process/{processId}/vote:
-    post:
-      consumes:
-      - application/json
-      description: |-
-        Relays a voter transaction that has already been signed by the voter to the
-        Vochain. The body carries a marshaled models.SignedTx whose inner Tx is a Vote
-        envelope. Public endpoint: no authentication is required. The vote is validated
-        synchronously and then submitted on a background worker; the call returns 202 with
-        a job id. Poll GET /jobs/{jobId} for the resulting vote nullifier (voteID).
-      parameters:
-      - description: On-chain process id (hex)
-        in: path
-        name: processId
-        required: true
-        type: string
-      - description: Signed vote transaction payload
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/apicommon.RelayVoteRequest'
-      produces:
-      - application/json
-      responses:
-        "202":
-          description: Job accepted; poll GET /jobs/{jobId}
-          schema:
-            $ref: '#/definitions/apicommon.EnqueuedResponse'
-        "400":
-          description: Invalid input data
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "404":
-          description: Process not found
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "500":
-          description: Internal server error
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "503":
-          description: Transaction queue is full
-          schema:
-            $ref: '#/definitions/errors.Error'
-      summary: Relay an already-signed vote to the Vochain
-      tags:
-      - process
   /process/bundle:
     post:
       consumes:
@@ -5844,6 +5796,53 @@ paths:
       summary: Resend verification code
       tags:
       - users
+  /vote:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Relays a voter transaction that has already been signed by the voter to the
+        Vochain. The body carries a marshaled models.SignedTx whose inner Tx is a Vote
+        envelope; the target process is taken from that envelope, so no process id is
+        passed in the path. Public endpoint: no authentication is required. The request is
+        checked synchronously — the body must decode to a Vote envelope (else 400) for a
+        process the backend knows (else 404) — then enqueued for submission on a background
+        worker; the call returns 202 with a job id. The chain's acceptance or rejection of
+        the vote (proof, nullifier, election state) is decided when the worker submits it and
+        reported on the job: poll GET /jobs/{jobId} for the voteID on success, or a failure.
+      parameters:
+      - description: Signed vote transaction payload
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/apicommon.RelayVoteRequest'
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Job accepted; poll GET /jobs/{jobId}
+          schema:
+            $ref: '#/definitions/apicommon.EnqueuedResponse'
+        "400":
+          description: Invalid input data
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "404":
+          description: Process not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "503":
+          description: Transaction queue is full
+          schema:
+            $ref: '#/definitions/errors.Error'
+      summary: Relay an already-signed vote to the Vochain
+      tags:
+      - process
 schemes:
 - http
 - https

--- a/plan/APP_SDK_PLAN.md
+++ b/plan/APP_SDK_PLAN.md
@@ -9,7 +9,7 @@ Design decisions already locked:
 - **Standalone**: no `@vocdoni/sdk` dependency. The one piece of Vochain crypto needed —
   building + signing the vote envelope — is a **minimal ported module** (see §5).
 - **Thin vote relay**: the SDK builds + signs the vote locally and POSTs the opaque envelope
-  to the SaaS `/process/{id}/vote`; the SaaS never sees plaintext.
+  to the SaaS `/vote`; the SaaS never sees plaintext.
 - Organizer flows are **plain REST** (the SaaS forges all txs).
 
 ## 1. Tooling & conventions (match vocdoni-sdk exactly)
@@ -37,7 +37,7 @@ src/
     census.ts              //   /census, members, groups
     process.ts             //   /process create/update/publish/status/results
     csp.ts                 //   /process/bundle/{id}/auth|sign|check|weight
-    vote.ts                //   /process/{id}/vote (relay)
+    vote.ts                //   /vote (relay)
     index.ts
   services/                // business logic over api/ (like vocdoni-sdk services)
     auth.ts organization.ts census.ts election.ts vote.ts csp.ts
@@ -156,7 +156,7 @@ hidden.
    and the CSP auth token from the completed `csp.auth` → CSP blind-sign → unblinded signature.
 3. `core/vote.ts` builds `VoteEnvelope` with `ProofCA` (CSP), packages votes, signs with the
    internal voter key → hex `SignedTx`.
-4. `voteService.relay(processId, txPayload)` → `POST /process/{processId}/vote` → `202 {jobId}`,
+4. `voteService.relay(processId, txPayload)` → `POST /vote` → `202 {jobId}`,
    then `awaitJob(jobId)` → `{voteID}` (the receipt). The poll is internal to `vote()`.
 
 **Non-CSP (`weighted`/`zkweighted`) census:**
@@ -167,7 +167,7 @@ hidden.
 3. `core/vote.ts` builds `VoteEnvelope` with the **Merkle proof** (`ProofArbo`) in place of
    `ProofCA`, packages votes, signs with the internal voter key → hex `SignedTx`. (For
    `zkweighted`/anonymous, the ZK proof path is out of scope for this round — see §5.)
-4. `voteService.relay(processId, txPayload)` → the **same** `POST /process/{processId}/vote` →
+4. `voteService.relay(processId, txPayload)` → the **same** `POST /vote` →
    `202 {jobId}`, then `awaitJob(jobId)` → `{voteID}`. The relay accepts CSP- or proof-authorized
    envelopes; the poll is internal to `vote()`.
 

--- a/plan/BACKEND_PLAN.md
+++ b/plan/BACKEND_PLAN.md
@@ -15,7 +15,7 @@ This document is the build plan for:
 - an optional `electionParams` field on draft create/update,
 - **chain-abstracted organization creation** (the SaaS forges `CreateAccount` for the org),
 - the managed election endpoints: `POST /process/{draftId}/publish`,
-  `PUT /process/{processId}/status`, `POST /process/{processId}/vote`,
+  `PUT /process/{processId}/status`, `POST /vote`,
   `GET /process/{processId}/results`, `GET /process/{processId}/metadata`,
 - the **integrator** layer: managed-organization creation/listing, plan + manual quota, and
   quota enforcement that rolls election/census usage up to the integrator.
@@ -227,7 +227,7 @@ submitted, but the `processId` is only known **after** submit. So the URL cannot
 ```go
 processPublishEndpoint       = "/process/{processId}/publish"   // POST  (processId = draftId here)
 processStatusEndpoint        = "/process/{processId}/status"    // PUT
-processVoteEndpoint          = "/process/{processId}/vote"      // POST  (public)
+voteEndpoint                 = "/vote"                          // POST  (public; process id is read from the signed envelope)
 processResultsEndpoint       = "/process/{processId}/results"   // GET   (public)
 processMetadataEndpoint      = "/process/{processId}/metadata"  // GET   (public)
 processCensusProofEndpoint   = "/process/{processId}/census/proof"  // GET   (public; Phase 6)
@@ -295,9 +295,10 @@ existing `GET /process/{processId}`, **on-chain election id** for `status`/`vote
   `api/csp_voting_test.go`).
 
 ### Phase 3 — vote relay + status lifecycle
-- `POST /process/{processId}/vote` (public): decode `txPayload` (base64 → `models.SignedTx`),
-  unmarshal inner `Tx`, assert `Tx_Vote` and matching `processId`; submit + confirm; return
-  `{voteId}` (the nullifier). Never decode the VotePackage; never expose the tx hash.
+- `POST /vote` (public): decode `txPayload` (hex → `models.SignedTx`),
+  unmarshal inner `Tx`, assert `Tx_Vote` and read the target `processId` from the envelope
+  (no id in the path); submit + confirm; return `{voteId}` (the nullifier). Never decode the
+  VotePackage; never expose the tx hash.
 - `PUT /process/{processId}/status`: map `ready|paused|ended|canceled` → `models.ProcessStatus`;
   `BuildSetProcessStatusTx` → fund/sign/submit. Manager/Admin.
 - **Tests:** drive CSP `auth`→`sign`, build a vote envelope (as in `api/csp_voting_test.go`),
@@ -376,7 +377,7 @@ Six changes:
    `EnvelopeType.Anonymous`.
 4. **`GET /process/{processId}/census/proof?key=<addr>`** (new, public): proxies `CensusGenProof`.
    The voter fetches the proof, builds + signs the envelope client-side, then posts it.
-5. **`POST /process/{processId}/vote`** (existing relay, Phase 3): generalize so it accepts a
+5. **`POST /vote`** (existing relay, Phase 3): generalize so it accepts a
    CSP-authorized envelope **OR** a merkle-proof-carrying envelope, and relays either. It still
    verifies the tx is a `Vote` for `processId` and **never decodes the ballot**.
 6. **`PUT /process/{processId}/census`** (new): dynamic add — `CensusAddParticipants` +

--- a/plan/NEW_API.md
+++ b/plan/NEW_API.md
@@ -26,7 +26,7 @@ Integrators additionally create and manage client organizations under a quota.
 | `POST` | `/process/{draftId}/publish` | Bearer (Manager/Admin) | optional `{ startDate }` (overrides the draft's start) | Publish a draft to the chain: forge → fund → sign → submit → confirm `NewProcess`. **Async:** validates synchronously, returns `202` + `jobId`; poll `GET /jobs/{jobId}` for the `processId`. |
 | `PUT`  | `/process/{processId}/status` | Bearer (Manager/Admin) | `{ status }` (`ready`/`paused`/`ended`/`canceled`) | Change lifecycle status. **Async:** returns `202` + `jobId`. |
 | `PUT`  | `/process/{processId}/census` | Bearer (Manager/Admin) | `{ participants }` (`{key, weight}[]`) | **Non-CSP only.** Dynamic-census add: append participants and grow the election census size. Gated behind the `DynamicCensus` mode flag. **Async:** returns `202` + `jobId`; poll for the new census size. |
-| `POST` | `/process/{processId}/vote` | Public | `{ txPayload }` (hex of the signed `Vote` envelope) | Relay an already-signed vote envelope to the chain — a **CSP- or proof-authorized** envelope. **Async:** returns `202` + `jobId`; poll for the `voteID` receipt. |
+| `POST` | `/vote` | Public | `{ txPayload }` (hex of the signed `Vote` envelope) | Relay an already-signed vote envelope to the chain — a **CSP- or proof-authorized** envelope. **Async:** returns `202` + `jobId`; poll for the `voteID` receipt. |
 | `GET`  | `/process/{processId}/census/proof` | Public | `?key=<addr>` | **Non-CSP only.** Proxy a Merkle census proof for the voter key, so the voter can build + sign the envelope. |
 | `GET`  | `/jobs/{jobId}` | Public (capability) | — (none) | Poll an async tx job (publish/status/census/vote). Always `200`; `status` is `pending`/`completed`/`failed`, with the on-chain `result` when completed. |
 | `GET`  | `/process/{processId}/results` | Public | — (none) | Read live status, vote count and tally. |
@@ -279,7 +279,7 @@ for `processId` and forwards it**; it never decrypts or inspects the ballot (bal
 preserved at the operator).
 
 ```
-POST /process/{processId}/vote
+POST /vote
 ```
 
 - **Auth:** Public. The voter is authorized by the proof embedded inside the envelope — either a
@@ -519,7 +519,7 @@ GET /organizations/{address}/integrator
 2. `POST /process/bundle/{bundleId}/sign` — CSP blind signature (existing).
 3. The client builds + signs the `Vote` envelope locally using the CSP signature (the only
    client-side crypto).
-4. `POST /process/{processId}/vote` — **new** relay endpoint queues it; returns `202` + `jobId`.
+4. `POST /vote` — **new** relay endpoint queues it; returns `202` + `jobId`.
 5. `GET /jobs/{jobId}` — poll until `completed`; the result's `voteID` is the vote receipt.
 6. `GET /process/{processId}/results` — **new** read endpoint for live tally.
 
@@ -528,7 +528,7 @@ GET /organizations/{address}/integrator
    the voter key (§4a).
 2. The client builds + signs the `Vote` envelope locally, embedding the Merkle proof in place of
    the CSP `ProofCA` (the only client-side crypto).
-3. `POST /process/{processId}/vote` — same relay endpoint; it accepts the proof-authorized envelope,
+3. `POST /vote` — same relay endpoint; it accepts the proof-authorized envelope,
    queues it and returns `202` + `jobId`.
 4. `GET /jobs/{jobId}` — poll until `completed`; the result's `voteID` is the vote receipt.
 5. `GET /process/{processId}/results` — live tally.
@@ -541,7 +541,7 @@ GET /organizations/{address}/integrator
 | `PublishProcessRequest` / `PublishProcessResponse` (idempotent 200 only) / `EnqueuedResponse` (202) | `POST /process/{id}/publish` |
 | `SetProcessStatusRequest` / `EnqueuedResponse` (202) | `PUT /process/{id}/status` |
 | `AddCensusParticipantsRequest` / `EnqueuedResponse` (202) | `PUT /process/{id}/census` (non-CSP dynamic add) |
-| `RelayVoteRequest` / `EnqueuedResponse` (202) | `POST /process/{id}/vote` (CSP- or proof-authorized) |
+| `RelayVoteRequest` / `EnqueuedResponse` (202) | `POST /vote` (CSP- or proof-authorized) |
 | `CensusProofResponse` | `GET /process/{id}/census/proof` (non-CSP) |
 | `EnqueuedResponse` (`jobId`) / `JobStatusResponse` (`jobId`, `type`, `status`, `result`, `error`) | `GET /jobs/{jobId}` |
 | `ProcessResultsResponse` | `GET /process/{id}/results` |

--- a/plan/SUMMARY.md
+++ b/plan/SUMMARY.md
@@ -49,7 +49,7 @@ RemoteSigner path) keeps working throughout, so old and new can coexist during m
 | Election | `POST /process` / `PUT /process/{id}` *(+ optional `electionParams`)* | organizer |
 | Publish | `POST /process/{draftId}/publish` → `{processId}` | manager/admin |
 | Lifecycle | `PUT /process/{processId}/status` (ready/paused/ended/canceled) | manager/admin |
-| Vote relay | `POST /process/{processId}/vote` → `{voteId}` | public (CSP- or proof-authorized) |
+| Vote relay | `POST /vote` → `{voteId}` | public (CSP- or proof-authorized) |
 | Non-CSP census | `GET /process/{processId}/census/proof` · `PUT /process/{processId}/census` (dynamic add) | public proof · manager/admin |
 | Reads | `GET /process/{processId}/results` · `GET /process/{processId}/metadata` | public |
 | Integrator | `POST`/`GET /organizations/{address}/managed` · `GET /organizations/{address}/integrator` | integrator admin |


### PR DESCRIPTION
## What

Move the signed-vote relay endpoint from `POST /process/{processId}/vote` to a flat **`POST /vote`**.

## Why

The relay body is a signed `models.SignedTx` whose inner `Vote` envelope **already names its target process**. The path `{processId}` was redundant — the handler only used it to (a) re-check it equaled the envelope's `ProcessId` and (b) look the process up. We now take the process id straight from the decoded envelope, so the URL carries no process id.

## Changes

- `api/routes.go`: `processVoteEndpoint = "/process/{processId}/vote"` → `voteEndpoint = "/vote"`.
- `api/process_vote.go`: `relayVoteHandler` derives `pid` from `vote.ProcessId` (drops the `chi.URLParam` + the now-moot URL/envelope match check); godoc `@Router /vote [post]`, `processId` path param removed.
- `api/api.go`: route registration updated.
- `api/apicommon/types.go`: doc comments on `RelayVoteRequest`/`RelayVoteResponse`.
- `api/process_vote_test.go`: post to `"vote"`.
- `docs/swagger.yaml`: regenerated.

## Breaking change

`POST /process/{processId}/vote` is **removed**; relay signed votes to `POST /vote`. The request body (`RelayVoteRequest.txPayload`) is unchanged, as is the 202 + `GET /jobs/{jobId}` → `voteID` flow.

## Test

`go test ./api/ -run TestRelayVote` passes (full org→census→bundle→on-chain process→relayed vote), exercising the new endpoint end to end.