### PR TITLE
feat(api)!: address processes by Mongo ObjectID in status/results/metadata

### DIFF
--- a/api/delete_managed_organization_test.go
+++ b/api/delete_managed_organization_test.go
@@ -93,7 +93,7 @@ func TestDeleteManagedOrg(t *testing.T) {
 	// (E) end the active election so the guard passes, then delete. ENDED is terminal, not active.
 	ended := enqueueAndPollJob(t, http.MethodPut, token,
 		&apicommon.SetProcessStatusRequest{Status: "ended"},
-		"process", pubJob.Result.Address.String(), "status")
+		"process", activeDraft.Hex(), "status")
 	c.Assert(ended.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("status error: %s", ended.Error))
 
 	// sanity: the now-ended election still belongs to the managed org before teardown

--- a/api/e2e_full_flow_test.go
+++ b/api/e2e_full_flow_test.go
@@ -135,7 +135,7 @@ func TestFullElectionLifecycle(t *testing.T) {
 
 	// --- end the election; the chain auto-advances ENDED -> RESULTS once tallied ---
 	endJob := enqueueAndPollJob(t, http.MethodPut, token,
-		&apicommon.SetProcessStatusRequest{Status: "ended"}, "process", addr.String(), "status")
+		&apicommon.SetProcessStatusRequest{Status: "ended"}, "process", draftID.Hex(), "status")
 	c.Assert(endJob.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("end error: %s", endJob.Error))
 	c.Assert(endJob.Result.Status, qt.Equals, "ENDED")
 	waitForElectionStatus(t, addr, "ENDED", "RESULTS")
@@ -144,7 +144,7 @@ func TestFullElectionLifecycle(t *testing.T) {
 	var res apicommon.ProcessResultsResponse
 	for i := 0; i < 20; i++ {
 		res = requestAndParse[apicommon.ProcessResultsResponse](
-			t, http.MethodGet, "", nil, "process", addr.String(), "results")
+			t, http.MethodGet, "", nil, "process", draftID.Hex(), "results")
 		if res.FinalResults && res.VoteCount == uint64(numVoters) {
 			break
 		}

--- a/api/process.go
+++ b/api/process.go
@@ -36,7 +36,7 @@ import (
 //	@Produce		json
 //	@Security		BearerAuth
 //	@Param			request	body		apicommon.CreateProcessRequest	true	"Process creation information (optionally with electionParams)"
-//	@Success		200		{object}	primitive.ObjectID				"Draft process ID (Mongo ObjectID)"
+//	@Success		200		{object}	primitive.ObjectID				"24-hex draft ProcessID"
 //	@Failure		400		{object}	errors.Error					"Invalid input data"
 //	@Failure		401		{object}	errors.Error					"Unauthorized"
 //	@Failure		403		{object}	errors.Error					"Plan does not allow creating more drafts"
@@ -135,7 +135,7 @@ func (a *API) createProcessHandler(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			processId	path		string							true	"Draft process ID (Mongo ObjectID)"
+//	@Param			processId	path		string							true	"24-hex draft ProcessID"
 //	@Param			request		body		apicommon.UpdateProcessRequest	true	"Process update information (optionally with electionParams)"
 //	@Success		200			{string}	string							"OK"
 //	@Failure		400			{object}	errors.Error					"Invalid input data"

--- a/api/process_read.go
+++ b/api/process_read.go
@@ -8,7 +8,7 @@ import (
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
-	"github.com/vocdoni/saas-backend/internal"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.vocdoni.io/dvote/log"
 )
 
@@ -21,21 +21,21 @@ import (
 //	@Description	required.
 //	@Tags			process
 //	@Produce		json
-//	@Param			processId	path		string								true	"On-chain process id (hex)"
+//	@Param			processId	path		string								true	"Process id (24-hex Mongo ObjectID)"
 //	@Success		200			{object}	apicommon.ProcessResultsResponse	"Trimmed on-chain election state"
 //	@Failure		400			{object}	errors.Error						"Invalid input data"
 //	@Failure		404			{object}	errors.Error						"Process not found"
 //	@Failure		500			{object}	errors.Error						"Internal server error"
 //	@Router			/process/{processId}/results [get]
 func (a *API) processResultsHandler(w http.ResponseWriter, r *http.Request) {
-	var pid internal.HexBytes
-	if err := pid.ParseString(chi.URLParam(r, "processId")); err != nil || len(pid) == 0 {
+	objID, err := primitive.ObjectIDFromHex(chi.URLParam(r, "processId"))
+	if err != nil {
 		errors.ErrMalformedURLParam.Withf("invalid process id").Write(w)
 		return
 	}
 
-	// ensure we manage this process
-	if _, err := a.db.ProcessByAddress(pid); err != nil {
+	process, err := a.db.Process(objID)
+	if err != nil {
 		if err == db.ErrNotFound {
 			errors.ErrProcessNotFound.Write(w)
 			return
@@ -43,8 +43,13 @@ func (a *API) processResultsHandler(w http.ResponseWriter, r *http.Request) {
 		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
 		return
 	}
+	// results only exist once the process has been published on chain.
+	if len(process.Address) == 0 {
+		errors.ErrProcessNotFound.Withf("process not published").Write(w)
+		return
+	}
 
-	election, err := a.account.Election(pid.Bytes())
+	election, err := a.account.Election(process.Address.Bytes())
 	if err != nil {
 		errors.ErrVochainRequestFailed.WithErr(err).Write(w)
 		return
@@ -76,25 +81,25 @@ func (a *API) processResultsHandler(w http.ResponseWriter, r *http.Request) {
 //
 //	@Summary		Get the election metadata JSON
 //	@Description	Rebuilds and returns the raw ElectionMetadata JSON document of the process
-//	@Description	identified by its on-chain process id. The metadata is deterministically derived
+//	@Description	identified by its process id. The metadata is deterministically derived
 //	@Description	from the stored ElectionParams, so it is identical to the content-addressed document
 //	@Description	published on chain. Public endpoint: no authentication is required.
 //	@Tags			process
 //	@Produce		json
-//	@Param			processId	path		string			true	"On-chain process id (hex)"
+//	@Param			processId	path		string			true	"Process id (24-hex Mongo ObjectID)"
 //	@Success		200			{object}	object			"Election metadata JSON"
 //	@Failure		400			{object}	errors.Error	"Invalid input data"
 //	@Failure		404			{object}	errors.Error	"Process not found"
 //	@Failure		500			{object}	errors.Error	"Internal server error"
 //	@Router			/process/{processId}/metadata [get]
 func (a *API) processMetadataHandler(w http.ResponseWriter, r *http.Request) {
-	var pid internal.HexBytes
-	if err := pid.ParseString(chi.URLParam(r, "processId")); err != nil || len(pid) == 0 {
+	objID, err := primitive.ObjectIDFromHex(chi.URLParam(r, "processId"))
+	if err != nil {
 		errors.ErrMalformedURLParam.Withf("invalid process id").Write(w)
 		return
 	}
 
-	process, err := a.db.ProcessByAddress(pid)
+	process, err := a.db.Process(objID)
 	if err != nil {
 		if err == db.ErrNotFound {
 			errors.ErrProcessNotFound.Write(w)

--- a/api/process_read.go
+++ b/api/process_read.go
@@ -21,7 +21,7 @@ import (
 //	@Description	required.
 //	@Tags			process
 //	@Produce		json
-//	@Param			processId	path		string								true	"Process id (24-hex Mongo ObjectID)"
+//	@Param			processId	path		string								true	"24-hex ProcessID"
 //	@Success		200			{object}	apicommon.ProcessResultsResponse	"Trimmed on-chain election state"
 //	@Failure		400			{object}	errors.Error						"Invalid input data"
 //	@Failure		404			{object}	errors.Error						"Process not found"
@@ -86,7 +86,7 @@ func (a *API) processResultsHandler(w http.ResponseWriter, r *http.Request) {
 //	@Description	published on chain. Public endpoint: no authentication is required.
 //	@Tags			process
 //	@Produce		json
-//	@Param			processId	path		string			true	"Process id (24-hex Mongo ObjectID)"
+//	@Param			processId	path		string			true	"24-hex ProcessID"
 //	@Success		200			{object}	object			"Election metadata JSON"
 //	@Failure		400			{object}	errors.Error	"Invalid input data"
 //	@Failure		404			{object}	errors.Error	"Process not found"

--- a/api/process_read_test.go
+++ b/api/process_read_test.go
@@ -175,4 +175,18 @@ func TestProcessReadProxies(t *testing.T) {
 	expectedBytes, err := account.BuildElectionMetadata(electionParams)
 	c.Assert(err, qt.IsNil)
 	c.Assert(bytes.Equal(body, expectedBytes), qt.IsTrue)
+
+	// sign-info resolves the process by either the 24-hex Mongo ObjectID (preferred) or the
+	// 64-hex on-chain election id (backwards compatible), returning the same consumed address
+	// and nullifier for the voter that just cast a vote.
+	signInfoReq := &handlers.ConsumedAddressRequest{AuthToken: authToken}
+	byObjID := requestAndParse[handlers.ConsumedAddressResponse](
+		t, http.MethodPost, "", signInfoReq, "process", processObjID.Hex(), "sign-info",
+	)
+	byOnchain := requestAndParse[handlers.ConsumedAddressResponse](
+		t, http.MethodPost, "", signInfoReq, "process", addr.String(), "sign-info",
+	)
+	c.Assert(byObjID.Address, qt.Not(qt.HasLen), 0)
+	c.Assert(byObjID.Address.String(), qt.Equals, byOnchain.Address.String())
+	c.Assert(byObjID.Nullifier.String(), qt.Equals, byOnchain.Nullifier.String())
 }

--- a/api/process_read_test.go
+++ b/api/process_read_test.go
@@ -176,7 +176,7 @@ func TestProcessReadProxies(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(bytes.Equal(body, expectedBytes), qt.IsTrue)
 
-	// sign-info resolves the process by either the 24-hex Mongo ObjectID (preferred) or the
+	// sign-info resolves the process by either the 24-hex ProcessID (preferred) or the
 	// 64-hex on-chain election id (backwards compatible), returning the same consumed address
 	// and nullifier for the voter that just cast a vote.
 	signInfoReq := &handlers.ConsumedAddressRequest{AuthToken: authToken}

--- a/api/process_read_test.go
+++ b/api/process_read_test.go
@@ -93,7 +93,7 @@ func TestProcessReadProxies(t *testing.T) {
 		VoteType:     db.VoteType{MaxCount: 1, MaxValue: 1},
 		ElectionType: db.ElectionType{Autostart: true, Interruptible: true},
 	}
-	_, err = testDB.SetProcess(&db.Process{OrgAddress: orgAddress, Address: addr, ElectionParams: electionParams})
+	processObjID, err := testDB.SetProcess(&db.Process{OrgAddress: orgAddress, Address: addr, ElectionParams: electionParams})
 	c.Assert(err, qt.IsNil)
 
 	// create a census, add members and publish a group-based census
@@ -158,7 +158,7 @@ func TestProcessReadProxies(t *testing.T) {
 	var res apicommon.ProcessResultsResponse
 	for i := 0; i < 20; i++ {
 		res = requestAndParse[apicommon.ProcessResultsResponse](
-			t, http.MethodGet, "", nil, "process", addr.String(), "results",
+			t, http.MethodGet, "", nil, "process", processObjID.Hex(), "results",
 		)
 		if res.VoteCount == 1 {
 			break
@@ -170,7 +170,7 @@ func TestProcessReadProxies(t *testing.T) {
 	c.Assert(res.EndDate.IsZero(), qt.IsFalse)
 
 	// fetch the public metadata endpoint and assert it matches the rebuilt bytes
-	body, code := testRequest(t, http.MethodGet, "", nil, "process", addr.String(), "metadata")
+	body, code := testRequest(t, http.MethodGet, "", nil, "process", processObjID.Hex(), "metadata")
 	c.Assert(code, qt.Equals, http.StatusOK)
 	expectedBytes, err := account.BuildElectionMetadata(electionParams)
 	c.Assert(err, qt.IsNil)

--- a/api/process_read_test.go
+++ b/api/process_read_test.go
@@ -189,4 +189,11 @@ func TestProcessReadProxies(t *testing.T) {
 	c.Assert(byObjID.Address, qt.Not(qt.HasLen), 0)
 	c.Assert(byObjID.Address.String(), qt.Equals, byOnchain.Address.String())
 	c.Assert(byObjID.Nullifier.String(), qt.Equals, byOnchain.Nullifier.String())
+
+	// a malformed id (valid hex but neither a 24-hex ProcessID nor a 32-byte on-chain id) is a
+	// 400, and a well-formed-but-unknown ProcessID is a 404 — these are checked before auth.
+	_, badCode := testRequest(t, http.MethodPost, "", signInfoReq, "process", "abcd", "sign-info")
+	c.Assert(badCode, qt.Equals, http.StatusBadRequest)
+	_, missCode := testRequest(t, http.MethodPost, "", signInfoReq, "process", "0123456789abcdef01234567", "sign-info")
+	c.Assert(missCode, qt.Equals, http.StatusNotFound)
 }

--- a/api/process_vote.go
+++ b/api/process_vote.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
 	"github.com/vocdoni/saas-backend/internal"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/proto/build/go/models"
 	"google.golang.org/protobuf/proto"
@@ -129,7 +130,7 @@ func (a *API) relayVoteHandler(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			processId	path		string								true	"On-chain process id (hex)"
+//	@Param			processId	path		string								true	"Process id (24-hex Mongo ObjectID)"
 //	@Param			request		body		apicommon.SetProcessStatusRequest	true	"New process status"
 //	@Success		202			{object}	apicommon.EnqueuedResponse			"Job accepted; poll GET /jobs/{jobId}"
 //	@Failure		400			{object}	errors.Error						"Invalid input data"
@@ -139,8 +140,8 @@ func (a *API) relayVoteHandler(w http.ResponseWriter, r *http.Request) {
 //	@Failure		503			{object}	errors.Error						"Transaction queue is full"
 //	@Router			/process/{processId}/status [put]
 func (a *API) setProcessStatusHandler(w http.ResponseWriter, r *http.Request) {
-	var pid internal.HexBytes
-	if err := pid.ParseString(chi.URLParam(r, "processId")); err != nil || len(pid) == 0 {
+	objID, err := primitive.ObjectIDFromHex(chi.URLParam(r, "processId"))
+	if err != nil {
 		errors.ErrMalformedURLParam.Withf("invalid process id").Write(w)
 		return
 	}
@@ -172,13 +173,18 @@ func (a *API) setProcessStatusHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	process, err := a.db.ProcessByAddress(pid)
+	process, err := a.db.Process(objID)
 	if err != nil {
 		if err == db.ErrNotFound {
 			errors.ErrProcessNotFound.Write(w)
 			return
 		}
 		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+	// only a published process has an on-chain election whose status can be changed.
+	if len(process.Address) == 0 {
+		errors.ErrProcessNotFound.Withf("process not published").Write(w)
 		return
 	}
 
@@ -216,7 +222,7 @@ func (a *API) setProcessStatusHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	tx, err := a.account.BuildSetProcessStatusTx(orgSigner.Address(), pid.Bytes(), status)
+	tx, err := a.account.BuildSetProcessStatusTx(orgSigner.Address(), process.Address.Bytes(), status)
 	if err != nil {
 		errors.ErrVochainRequestFailed.WithErr(err).Write(w)
 		return

--- a/api/process_vote.go
+++ b/api/process_vote.go
@@ -130,7 +130,7 @@ func (a *API) relayVoteHandler(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			processId	path		string								true	"Process id (24-hex Mongo ObjectID)"
+//	@Param			processId	path		string								true	"24-hex ProcessID"
 //	@Param			request		body		apicommon.SetProcessStatusRequest	true	"New process status"
 //	@Success		202			{object}	apicommon.EnqueuedResponse			"Job accepted; poll GET /jobs/{jobId}"
 //	@Failure		400			{object}	errors.Error						"Invalid input data"

--- a/api/process_vote_test.go
+++ b/api/process_vote_test.go
@@ -115,7 +115,7 @@ func TestProcessStatusLifecycle(t *testing.T) {
 	}
 	for _, tr := range transitions {
 		job := enqueueAndPollJob(t, http.MethodPut, token,
-			&apicommon.SetProcessStatusRequest{Status: tr.request}, "process", addr.String(), "status")
+			&apicommon.SetProcessStatusRequest{Status: tr.request}, "process", draftID.Hex(), "status")
 		c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("error: %s", job.Error))
 		c.Assert(job.Result.Status, qt.Equals, tr.respStatus)
 		waitForElectionStatus(t, addr, tr.chainStatus...)

--- a/api/routes.go
+++ b/api/routes.go
@@ -166,17 +166,20 @@ const (
 	// POST /process/{processId}/publish to publish a draft process as an on-chain election
 	processPublishEndpoint = "/process/{processId}/publish"
 
-	// PUT /process/{processId}/status to change an on-chain election status
+	// PUT /process/{processId}/status to change an on-chain election status.
+	// {processId} is the process' 24-hex Mongo ObjectID (not the on-chain election id).
 	processStatusEndpoint = "/process/{processId}/status"
 
 	// POST /vote to relay an already-signed vote (public). The target process is taken
 	// from the signed vote envelope itself, so no process id appears in the path.
 	voteEndpoint = "/vote"
 
-	// GET /process/{processId}/results to get the trimmed on-chain election results (public)
+	// GET /process/{processId}/results to get the trimmed on-chain election results (public).
+	// {processId} is the process' 24-hex Mongo ObjectID (not the on-chain election id).
 	processResultsEndpoint = "/process/{processId}/results"
 
-	// GET /process/{processId}/metadata to get the election metadata JSON (public)
+	// GET /process/{processId}/metadata to get the election metadata JSON (public).
+	// {processId} is the process' 24-hex Mongo ObjectID (not the on-chain election id).
 	processMetadataEndpoint = "/process/{processId}/metadata"
 
 	// two-factor process bundle routes

--- a/api/routes.go
+++ b/api/routes.go
@@ -161,7 +161,7 @@ const (
 	// POST /process/{processId}/auth to check if the voter is authorized
 	// processAuthEndpoint = "/process/{processId}/auth"
 	// POST /process/{processId}/sign-info to get the sign info for the process.
-	// {processId} accepts the 24-hex Mongo ObjectID (preferred) or, for backwards
+	// {processId} accepts the 24-hex ProcessID (preferred) or, for backwards
 	// compatibility, the 64-hex on-chain election id.
 	processSignInfoEndpoint = "/process/{processId}/sign-info"
 
@@ -169,7 +169,7 @@ const (
 	processPublishEndpoint = "/process/{processId}/publish"
 
 	// PUT /process/{processId}/status to change an on-chain election status.
-	// {processId} is the process' 24-hex Mongo ObjectID (not the on-chain election id).
+	// {processId} is the 24-hex ProcessID (not the on-chain election id).
 	processStatusEndpoint = "/process/{processId}/status"
 
 	// POST /vote to relay an already-signed vote (public). The target process is taken
@@ -177,11 +177,11 @@ const (
 	voteEndpoint = "/vote"
 
 	// GET /process/{processId}/results to get the trimmed on-chain election results (public).
-	// {processId} is the process' 24-hex Mongo ObjectID (not the on-chain election id).
+	// {processId} is the 24-hex ProcessID (not the on-chain election id).
 	processResultsEndpoint = "/process/{processId}/results"
 
 	// GET /process/{processId}/metadata to get the election metadata JSON (public).
-	// {processId} is the process' 24-hex Mongo ObjectID (not the on-chain election id).
+	// {processId} is the 24-hex ProcessID (not the on-chain election id).
 	processMetadataEndpoint = "/process/{processId}/metadata"
 
 	// two-factor process bundle routes

--- a/api/routes.go
+++ b/api/routes.go
@@ -160,7 +160,9 @@ const (
 	processEndpoint = "/process/{processId}"
 	// POST /process/{processId}/auth to check if the voter is authorized
 	// processAuthEndpoint = "/process/{processId}/auth"
-	// POST /process/{processId}/sign-info to get the sign info for the process
+	// POST /process/{processId}/sign-info to get the sign info for the process.
+	// {processId} accepts the 24-hex Mongo ObjectID (preferred) or, for backwards
+	// compatibility, the 64-hex on-chain election id.
 	processSignInfoEndpoint = "/process/{processId}/sign-info"
 
 	// POST /process/{processId}/publish to publish a draft process as an on-chain election

--- a/csp/handlers/handlers.go
+++ b/csp/handlers/handlers.go
@@ -632,12 +632,12 @@ func (c *CSPHandlers) BundleCheckHandler(w http.ResponseWriter, r *http.Request)
 //
 //	@Summary		Get the address used to sign a process
 //	@Description	Get the address used to sign a process. Requires a verified token. Returns the address, nullifier,
-//	@Description	and timestamp of the consumption. {processId} accepts the 24-hex Mongo ObjectID
-//	@Description	(preferred) or, for backwards compatibility, the 64-hex on-chain election id.
+//	@Description	and timestamp of the consumption. {processId} accepts the 24-hex ProcessID (preferred)
+//	@Description	or, for backwards compatibility, the 64-hex on-chain election id.
 //	@Tags			process
 //	@Accept			json
 //	@Produce		json
-//	@Param			processId	path		string							true	"Process id: 24-hex Mongo ObjectID (preferred) or 64-hex on-chain election id"
+//	@Param			processId	path		string							true	"24-hex ProcessID (preferred) or, for backwards compatibility, the 64-hex on-chain election id"
 //	@Param			request		body		handlers.ConsumedAddressRequest	true	"Request with auth token"
 //	@Success		200			{object}	handlers.ConsumedAddressResponse
 //	@Failure		400			{object}	errors.Error	"Invalid input data or user has not voted (ErrUserNoVoted)"
@@ -647,9 +647,9 @@ func (c *CSPHandlers) BundleCheckHandler(w http.ResponseWriter, r *http.Request)
 //	@Router			/process/{processId}/sign-info [post]
 func (c *CSPHandlers) ConsumedAddressHandler(w http.ResponseWriter, r *http.Request) {
 	// Resolve the process to its on-chain election id (needed for the CSP lookup and the
-	// nullifier below). Preferred form is the 24-hex Mongo ObjectID, consistent with the rest
+	// nullifier below). Preferred form is the 24-hex ProcessID, consistent with the rest
 	// of the process API; for backwards compatibility we exceptionally also accept the 64-hex
-	// on-chain election id directly. A valid ObjectID is exactly 24 hex chars, so it never
+	// on-chain election id directly. A ProcessID is exactly 24 hex chars, so it never
 	// collides with the 64-hex on-chain id.
 	raw := chi.URLParam(r, "processId")
 	processID := new(internal.HexBytes)

--- a/csp/handlers/handlers.go
+++ b/csp/handlers/handlers.go
@@ -32,6 +32,9 @@ const (
 		"bafkreifqyu5m5as4gvcirlog5j267um24q7y4ri6r3svhsi7fda24676ny"
 )
 
+// electionIDLength is the byte length of a Vochain election (process) id: 32 bytes / 64 hex chars.
+const electionIDLength = 32
+
 // CSPHandlers is a struct that contains an instance of the CSP and the main
 // database (where the bundle and census data is stored). It is used to handle
 // the CSP API requests such as the authentication and signing of the bundle
@@ -637,7 +640,7 @@ func (c *CSPHandlers) BundleCheckHandler(w http.ResponseWriter, r *http.Request)
 //	@Tags			process
 //	@Accept			json
 //	@Produce		json
-//	@Param			processId	path		string							true	"24-hex ProcessID (preferred) or, for backwards compatibility, the 64-hex on-chain election id"
+//	@Param			processId	path		string							true	"24-hex ProcessID (preferred); 64-hex on-chain id also accepted"
 //	@Param			request		body		handlers.ConsumedAddressRequest	true	"Request with auth token"
 //	@Success		200			{object}	handlers.ConsumedAddressResponse
 //	@Failure		400			{object}	errors.Error	"Invalid input data or user has not voted (ErrUserNoVoted)"
@@ -656,7 +659,11 @@ func (c *CSPHandlers) ConsumedAddressHandler(w http.ResponseWriter, r *http.Requ
 	if objID, oerr := primitive.ObjectIDFromHex(raw); oerr == nil {
 		process, err := c.mainDB.Process(objID)
 		if err != nil {
-			errors.ErrProcessNotFound.Write(w)
+			if err == db.ErrNotFound {
+				errors.ErrProcessNotFound.Write(w)
+				return
+			}
+			errors.ErrGenericInternalServerError.WithErr(err).Write(w)
 			return
 		}
 		if len(process.Address) == 0 {
@@ -664,8 +671,9 @@ func (c *CSPHandlers) ConsumedAddressHandler(w http.ResponseWriter, r *http.Requ
 			return
 		}
 		*processID = process.Address
-	} else if err := processID.ParseString(raw); err != nil || len(*processID) == 0 {
-		errors.ErrMalformedURLParam.WithErr(csp.ErrNoBundleID).Write(w)
+	} else if err := processID.ParseString(raw); err != nil || len(*processID) != electionIDLength {
+		// backwards-compat: the on-chain election id (32 bytes / 64 hex chars).
+		errors.ErrMalformedURLParam.Withf("invalid process id").Write(w)
 		return
 	}
 	// parse the request from the body

--- a/csp/handlers/handlers.go
+++ b/csp/handlers/handlers.go
@@ -632,11 +632,12 @@ func (c *CSPHandlers) BundleCheckHandler(w http.ResponseWriter, r *http.Request)
 //
 //	@Summary		Get the address used to sign a process
 //	@Description	Get the address used to sign a process. Requires a verified token. Returns the address, nullifier,
-//	@Description	and timestamp of the consumption.
+//	@Description	and timestamp of the consumption. {processId} accepts the 24-hex Mongo ObjectID
+//	@Description	(preferred) or, for backwards compatibility, the 64-hex on-chain election id.
 //	@Tags			process
 //	@Accept			json
 //	@Produce		json
-//	@Param			processId	path		string							true	"Process ID"
+//	@Param			processId	path		string							true	"Process id: 24-hex Mongo ObjectID (preferred) or 64-hex on-chain election id"
 //	@Param			request		body		handlers.ConsumedAddressRequest	true	"Request with auth token"
 //	@Success		200			{object}	handlers.ConsumedAddressResponse
 //	@Failure		400			{object}	errors.Error	"Invalid input data or user has not voted (ErrUserNoVoted)"
@@ -645,9 +646,25 @@ func (c *CSPHandlers) BundleCheckHandler(w http.ResponseWriter, r *http.Request)
 //	@Failure		500			{object}	errors.Error	"Internal server error"
 //	@Router			/process/{processId}/sign-info [post]
 func (c *CSPHandlers) ConsumedAddressHandler(w http.ResponseWriter, r *http.Request) {
-	// get the bundle ID from the URL parameters
+	// Resolve the process to its on-chain election id (needed for the CSP lookup and the
+	// nullifier below). Preferred form is the 24-hex Mongo ObjectID, consistent with the rest
+	// of the process API; for backwards compatibility we exceptionally also accept the 64-hex
+	// on-chain election id directly. A valid ObjectID is exactly 24 hex chars, so it never
+	// collides with the 64-hex on-chain id.
+	raw := chi.URLParam(r, "processId")
 	processID := new(internal.HexBytes)
-	if err := processID.ParseString(chi.URLParam(r, "processId")); err != nil {
+	if objID, oerr := primitive.ObjectIDFromHex(raw); oerr == nil {
+		process, err := c.mainDB.Process(objID)
+		if err != nil {
+			errors.ErrProcessNotFound.Write(w)
+			return
+		}
+		if len(process.Address) == 0 {
+			errors.ErrProcessNotFound.Withf("process not published").Write(w)
+			return
+		}
+		*processID = process.Address
+	} else if err := processID.ParseString(raw); err != nil || len(*processID) == 0 {
 		errors.ErrMalformedURLParam.WithErr(csp.ErrNoBundleID).Write(w)
 		return
 	}

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4338,7 +4338,7 @@ paths:
       - application/json
       responses:
         "200":
-          description: Draft process ID (Mongo ObjectID)
+          description: 24-hex draft ProcessID
           schema:
             type: string
         "400":
@@ -4451,7 +4451,7 @@ paths:
         returns a 409. The optional `electionParams` field can be set or replaced here (additive), same as on
         create.
       parameters:
-      - description: Draft process ID (Mongo ObjectID)
+      - description: 24-hex draft ProcessID
         in: path
         name: processId
         required: true
@@ -4502,7 +4502,7 @@ paths:
         from the stored ElectionParams, so it is identical to the content-addressed document
         published on chain. Public endpoint: no authentication is required.
       parameters:
-      - description: Process id (24-hex Mongo ObjectID)
+      - description: 24-hex ProcessID
         in: path
         name: processId
         required: true
@@ -4598,7 +4598,7 @@ paths:
         results are final and the tally (if any). Public endpoint: no authentication is
         required.
       parameters:
-      - description: Process id (24-hex Mongo ObjectID)
+      - description: 24-hex ProcessID
         in: path
         name: processId
         required: true
@@ -4631,11 +4631,11 @@ paths:
       - application/json
       description: |-
         Get the address used to sign a process. Requires a verified token. Returns the address, nullifier,
-        and timestamp of the consumption. {processId} accepts the 24-hex Mongo ObjectID
-        (preferred) or, for backwards compatibility, the 64-hex on-chain election id.
+        and timestamp of the consumption. {processId} accepts the 24-hex ProcessID (preferred)
+        or, for backwards compatibility, the 64-hex on-chain election id.
       parameters:
-      - description: 'Process id: 24-hex Mongo ObjectID (preferred) or 64-hex on-chain
-          election id'
+      - description: 24-hex ProcessID (preferred) or, for backwards compatibility,
+          the 64-hex on-chain election id
         in: path
         name: processId
         required: true
@@ -4685,7 +4685,7 @@ paths:
 
         Also callable with a scoped API key (scope: `voting:write`).
       parameters:
-      - description: Process id (24-hex Mongo ObjectID)
+      - description: 24-hex ProcessID
         in: path
         name: processId
         required: true

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4631,9 +4631,11 @@ paths:
       - application/json
       description: |-
         Get the address used to sign a process. Requires a verified token. Returns the address, nullifier,
-        and timestamp of the consumption.
+        and timestamp of the consumption. {processId} accepts the 24-hex Mongo ObjectID
+        (preferred) or, for backwards compatibility, the 64-hex on-chain election id.
       parameters:
-      - description: Process ID
+      - description: 'Process id: 24-hex Mongo ObjectID (preferred) or 64-hex on-chain
+          election id'
         in: path
         name: processId
         required: true

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4634,8 +4634,7 @@ paths:
         and timestamp of the consumption. {processId} accepts the 24-hex ProcessID (preferred)
         or, for backwards compatibility, the 64-hex on-chain election id.
       parameters:
-      - description: 24-hex ProcessID (preferred) or, for backwards compatibility,
-          the 64-hex on-chain election id
+      - description: 24-hex ProcessID (preferred); 64-hex on-chain id also accepted
         in: path
         name: processId
         required: true

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4498,11 +4498,11 @@ paths:
     get:
       description: |-
         Rebuilds and returns the raw ElectionMetadata JSON document of the process
-        identified by its on-chain process id. The metadata is deterministically derived
+        identified by its process id. The metadata is deterministically derived
         from the stored ElectionParams, so it is identical to the content-addressed document
         published on chain. Public endpoint: no authentication is required.
       parameters:
-      - description: On-chain process id (hex)
+      - description: Process id (24-hex Mongo ObjectID)
         in: path
         name: processId
         required: true
@@ -4598,7 +4598,7 @@ paths:
         results are final and the tally (if any). Public endpoint: no authentication is
         required.
       parameters:
-      - description: On-chain process id (hex)
+      - description: Process id (24-hex Mongo ObjectID)
         in: path
         name: processId
         required: true
@@ -4683,7 +4683,7 @@ paths:
 
         Also callable with a scoped API key (scope: `voting:write`).
       parameters:
-      - description: On-chain process id (hex)
+      - description: Process id (24-hex Mongo ObjectID)
         in: path
         name: processId
         required: true


### PR DESCRIPTION
## What

Make `PUT /process/{processId}/status`, `GET /process/{processId}/results` and `GET /process/{processId}/metadata` take the **24-hex Mongo ObjectID** in `{processId}` — the same identifier `GET/PUT/DELETE /process/{processId}` and `.../publish` already use.

## Why

The same `{processId}` path segment meant two different things: ObjectID for the draft CRUD + publish routes, but the **64-hex on-chain election id** for status/results/metadata. That inconsistency surfaced as `GET /process/{onchainID} → 40010 invalid process ID`, and forced clients to juggle two ids for the same process.

## How

Each of the three handlers now does `primitive.ObjectIDFromHex({processId}) → a.db.Process(objID)` and uses the looked-up `process.Address` for the Vochain call (election fetch / SET_PROCESS_STATUS tx). `results` and `status` require the process to be published (non-empty `Address`); `metadata` is derived from the stored `ElectionParams`. No response shapes change — `db.Process` already exposes both `id` and `address`.

- `api/process_read.go` — `processResultsHandler`, `processMetadataHandler`
- `api/process_vote.go` — `setProcessStatusHandler`
- `api/routes.go` — clarified route comments; `docs/swagger.yaml` regenerated.

## The 64-hex on-chain id stays only for voters

Unchanged, because the voter needs the on-chain id to sign/verify a vote: `POST /process/{processId}/vote` (from the signed envelope), `POST /process/{processId}/sign-info` (CSP; the nullifier is derived from the on-chain id), and the bundle `sign`/`check` request bodies.

## Breaking change

`status`, `results`, `metadata` now take the **24-hex ObjectID**, not the 64-hex on-chain id.

## Tests

Updated the four call sites that passed the on-chain address to these endpoints to pass the draft ObjectID instead. `go test ./api/ -run 'TestProcessStatusLifecycle|TestProcessReadProxies|TestFullElectionLifecycle|TestDeleteManagedOrg|TestRelayVote'` — all green (140s).

## Note

Out of scope (deferred): `POST /process/bundle`'s `processes[]` body still references processes by on-chain id. Independent of #550 (`POST /vote`), though both touch `api/process_vote.go` — trivial rebase if #550 lands first.