### PR TITLE
docs(api): clarify group-census publish auth requirements in swagger

### DIFF
--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -891,10 +891,13 @@ type PublishedCensusResponse struct {
 // PublishCensusGroupRequest represents a request to publish a census group.
 // swagger:model PublishCensusGroupRequest
 type PublishCensusGroupRequest struct {
-	// Optional for defining which member data should be used for authentication
+	// Member data fields used for authentication (e.g. nationalId, birthDate). At least one
+	// of authFields or twoFaFields must be provided; supplying only authFields publishes an
+	// auth-only (no OTP) CSP census. A request with both empty is rejected (ErrCensusTypeNotFound).
 	AuthFields db.OrgMemberAuthFields `json:"authFields,omitempty"`
 
-	// Optional for defining which member data should be used for two-factor authentication
+	// Member data fields used for two-factor authentication (email and/or phone, sent as an OTP
+	// challenge). At least one of authFields or twoFaFields must be provided.
 	TwoFaFields db.OrgMemberTwoFaFields `json:"twoFaFields,omitempty"`
 
 	// Indicates if the census is weighted

--- a/api/census.go
+++ b/api/census.go
@@ -273,7 +273,10 @@ func (a *API) publishCensusHandler(w http.ResponseWriter, r *http.Request) {
 //
 //	@Summary		Publish a group-based census for voting
 //	@Description	Publish a census based on a specific organization members group for voting. Requires Manager/Admin role.
-//	@Description	Returns published census with credentials.
+//	@Description	The request body selects the CSP authentication: at least one of authFields or twoFaFields
+//	@Description	must be provided. Supplying only authFields yields an auth-only census (members authenticate
+//	@Description	with their data, no OTP); twoFaFields adds an email/SMS OTP challenge. A body with both empty
+//	@Description	is rejected with 404 (ErrCensusTypeNotFound). Returns the published census root and URI.
 //	@Tags			census
 //	@Accept			json
 //	@Produce		json
@@ -284,7 +287,7 @@ func (a *API) publishCensusHandler(w http.ResponseWriter, r *http.Request) {
 //	@Success		200		{object}	apicommon.PublishedCensusResponse
 //	@Failure		400		{object}	errors.Error	"Invalid census ID or group ID"
 //	@Failure		401		{object}	errors.Error	"Unauthorized"
-//	@Failure		404		{object}	errors.Error	"Census not found"
+//	@Failure		404		{object}	errors.Error	"Census not found, or neither authFields nor twoFaFields provided (ErrCensusTypeNotFound)"
 //	@Failure		500		{object}	errors.Error	"Internal server error"
 //	@Router			/census/{id}/group/{groupid}/publish [post]
 func (a *API) publishCensusGroupHandler(w http.ResponseWriter, r *http.Request) {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1090,13 +1090,17 @@ definitions:
   apicommon.PublishCensusGroupRequest:
     properties:
       authFields:
-        description: Optional for defining which member data should be used for authentication
+        description: |-
+          Member data fields used for authentication (e.g. nationalId, birthDate). At least one
+          of authFields or twoFaFields must be provided; supplying only authFields publishes an
+          auth-only (no OTP) CSP census. A request with both empty is rejected (ErrCensusTypeNotFound).
         items:
           $ref: '#/definitions/db.OrgMemberAuthField'
         type: array
       twoFaFields:
-        description: Optional for defining which member data should be used for two-factor
-          authentication
+        description: |-
+          Member data fields used for two-factor authentication (email and/or phone, sent as an OTP
+          challenge). At least one of authFields or twoFaFields must be provided.
         items:
           $ref: '#/definitions/db.OrgMemberTwoFaField'
         type: array
@@ -2243,7 +2247,10 @@ paths:
       - application/json
       description: |-
         Publish a census based on a specific organization members group for voting. Requires Manager/Admin role.
-        Returns published census with credentials.
+        The request body selects the CSP authentication: at least one of authFields or twoFaFields
+        must be provided. Supplying only authFields yields an auth-only census (members authenticate
+        with their data, no OTP); twoFaFields adds an email/SMS OTP challenge. A body with both empty
+        is rejected with 404 (ErrCensusTypeNotFound). Returns the published census root and URI.
       parameters:
       - description: Census ID
         in: path
@@ -2277,7 +2284,8 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
         "404":
-          description: Census not found
+          description: Census not found, or neither authFields nor twoFaFields provided
+            (ErrCensusTypeNotFound)
           schema:
             $ref: '#/definitions/errors.Error'
         "500":


### PR DESCRIPTION
## Problem

Reading **only** the swagger, an integrator cannot tell how `POST /census/{id}/group/{groupid}/publish` actually behaves regarding authentication:

- Both `authFields` and `twoFaFields` were documented as just **"Optional"**, implying you could send an empty body.
- In reality the handler (`api/census.go:372`) rejects a body with **both** empty (`ErrCensusTypeNotFound`, **404**).
- Conversely, sending **only `authFields`** is enough — it publishes an auth-only (no OTP) CSP census. Swagger said nothing about this either.

So the docs gave the wrong impression in two directions: "you can omit both" (false) and silence on whether auth-only is sufficient (it is).

## Fix (docs only)

- `PublishCensusGroupRequest` field docs now state the **"at least one of authFields or twoFaFields is required"** rule and the auth-only vs OTP distinction.
- The handler's swag `@Description` and `@Failure 404` now spell out the same rule and the `ErrCensusTypeNotFound` case.
- Regenerated `docs/swagger.yaml` via `make swagger`.

No behavior change.

## Verification

- `make swagger` regenerated cleanly.
- `golangci-lint run ./api/...` — no new findings (the one `plans_test.go` revive hit is pre-existing on `main`, untouched here).