### PR TITLE
fix(api): resolve election metadata from a stored reference on GET /process/{id}

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -52,6 +52,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -145,6 +146,9 @@ func New(ctx context.Context, conf *Config) *API {
 	if conf == nil {
 		return nil
 	}
+	// normalize once so every storage reference built from it — and the local-reference
+	// match on read — is consistent and never yields a "//storage/" prefix.
+	conf.ServerURL = strings.TrimSuffix(conf.ServerURL, "/")
 	// Set the ServerURL for the ObjectStorageClient
 	if conf.ObjectStorage != nil {
 		conf.ObjectStorage.ServerURL = conf.ServerURL

--- a/api/api.go
+++ b/api/api.go
@@ -148,7 +148,7 @@ func New(ctx context.Context, conf *Config) *API {
 	}
 	// normalize once so every storage reference built from it — and the local-reference
 	// match on read — is consistent and never yields a "//storage/" prefix.
-	conf.ServerURL = strings.TrimSuffix(conf.ServerURL, "/")
+	conf.ServerURL = strings.TrimRight(conf.ServerURL, "/")
 	// Set the ServerURL for the ObjectStorageClient
 	if conf.ObjectStorage != nil {
 		conf.ObjectStorage.ServerURL = conf.ServerURL

--- a/api/process.go
+++ b/api/process.go
@@ -269,7 +269,7 @@ func (a *API) processInfoHandler(w http.ResponseWriter, r *http.Request) {
 	// resolve the canonical metadata from its reference (best-effort): the Vochain only
 	// resolves ipfs:// pointers, so the https /storage pointer this service publishes is
 	// resolved here instead.
-	if md := a.resolveProcessMetadata(process); md != nil {
+	if md := a.resolveProcessMetadata(r.Context(), process); md != nil {
 		process.Metadata = md
 	}
 
@@ -286,7 +286,7 @@ const metadataObjectUserID = "system"
 // resolveProcessMetadata returns the canonical metadata for a published process,
 // consulting process.MetadataURL. Returns nil (caller keeps the stored value) for
 // drafts or on any error. Persists the reference inline only when it changed.
-func (a *API) resolveProcessMetadata(p *db.Process) map[string]any {
+func (a *API) resolveProcessMetadata(ctx context.Context, p *db.Process) map[string]any {
 	if p.Address.Equals(nil) { // draft, nothing on chain
 		return nil
 	}
@@ -329,7 +329,7 @@ func (a *API) resolveProcessMetadata(p *db.Process) map[string]any {
 			}
 		}
 	case strings.HasPrefix(p.MetadataURL, "http://"), strings.HasPrefix(p.MetadataURL, "https://"):
-		m = fetchExternalMetadata(p.MetadataURL)
+		m = fetchExternalMetadata(ctx, p.MetadataURL)
 	default:
 		// unrecognized scheme — leave m nil; a bootstrapped reference is still persisted below
 	}
@@ -358,8 +358,8 @@ func (a *API) resolveProcessMetadata(p *db.Process) map[string]any {
 // fetchExternalMetadata best-effort downloads and JSON-decodes a metadata document from
 // an external http(s) reference (one that does not point at our own object storage).
 // Returns nil on any failure.
-func fetchExternalMetadata(url string) map[string]any {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+func fetchExternalMetadata(ctx context.Context, url string) map[string]any {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/api/process.go
+++ b/api/process.go
@@ -306,9 +306,12 @@ func (a *API) resolveProcessMetadata(p *db.Process) map[string]any {
 	name, isLocal := a.objectStorage.LocalName(p.MetadataURL)
 	switch {
 	case isLocal:
-		// our own object storage — resolve locally
+		// our own object storage — resolve locally; treat a corrupt/non-JSON object as a
+		// resolution failure (m stays nil) so the stored metadata is kept.
 		if obj, err := a.objectStorage.GetByName(name); err == nil {
-			_ = json.Unmarshal(obj.Data, &m)
+			if json.Unmarshal(obj.Data, &m) != nil {
+				m = nil
+			}
 		}
 	case strings.HasPrefix(p.MetadataURL, "ipfs://"):
 		// the Vochain resolves ipfs; reuse the election if already fetched

--- a/api/process.go
+++ b/api/process.go
@@ -302,6 +302,9 @@ func (a *API) resolveProcessMetadata(p *db.Process) map[string]any {
 		election, p.MetadataURL, changed = el, el.MetadataURL, true
 	}
 
+	// resolve the document. Branches set m on success and leave it nil on failure; no
+	// early return, so a bootstrapped reference is still persisted below (avoids
+	// re-deriving it from the chain on every read).
 	var m map[string]any
 	name, isLocal := a.objectStorage.LocalName(p.MetadataURL)
 	switch {
@@ -316,29 +319,25 @@ func (a *API) resolveProcessMetadata(p *db.Process) map[string]any {
 	case strings.HasPrefix(p.MetadataURL, "ipfs://"):
 		// the Vochain resolves ipfs; reuse the election if already fetched
 		if election == nil {
-			el, err := a.account.Election(p.Address.Bytes())
-			if err != nil {
-				return nil
+			if el, err := a.account.Election(p.Address.Bytes()); err == nil {
+				election = el
 			}
-			election = el
 		}
-		mm, ok := election.Metadata.(map[string]any)
-		if !ok || len(mm) == 0 {
-			return nil
+		if election != nil {
+			if mm, ok := election.Metadata.(map[string]any); ok && len(mm) > 0 {
+				m = mm
+			}
 		}
-		m = mm
 	case strings.HasPrefix(p.MetadataURL, "http://"), strings.HasPrefix(p.MetadataURL, "https://"):
 		m = fetchExternalMetadata(p.MetadataURL)
 	default:
-		return nil
+		// unrecognized scheme — leave m nil; a bootstrapped reference is still persisted below
 	}
-	if m == nil {
-		return nil
-	}
+
 	// metadata is immutable (a change is a republish through this API), so cache any
 	// remotely-resolved document locally and promote the reference — later reads then
 	// resolve from our own storage with no Vochain or external round-trip.
-	if !isLocal {
+	if m != nil && !isLocal {
 		if b, err := json.Marshal(m); err == nil {
 			if stored, err := a.objectStorage.PutJSON(b, metadataObjectUserID); err == nil {
 				p.MetadataURL, changed = a.objectStorage.LocalURL(stored), true
@@ -346,7 +345,8 @@ func (a *API) resolveProcessMetadata(p *db.Process) map[string]any {
 		}
 	}
 	// persist a learned/promoted reference with a targeted update (not a full rewrite) so
-	// a concurrent change to other process fields is not clobbered by this read path.
+	// a concurrent change to other process fields is not clobbered by this read path. This
+	// runs even when resolution failed, so a bootstrapped reference is stored once.
 	if changed {
 		if err := a.db.SetProcessMetadataURL(p.ID, p.MetadataURL); err != nil {
 			log.Warnw("metadata: could not persist metadataURL", "process", p.Address.String(), "error", err)

--- a/api/process.go
+++ b/api/process.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -18,7 +17,7 @@ import (
 	"github.com/vocdoni/saas-backend/internal"
 	"github.com/vocdoni/saas-backend/subscriptions"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.vocdoni.io/dvote/api"
+	dvoteapi "go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/proto/build/go/models"
 )
@@ -291,7 +290,7 @@ func (a *API) resolveProcessMetadata(p *db.Process) map[string]any {
 	if p.Address.Equals(nil) { // draft, nothing on chain
 		return nil
 	}
-	var election *api.Election
+	var election *dvoteapi.Election
 	changed := false
 	// bootstrap the reference from the on-chain pointer if we don't have one yet
 	if p.MetadataURL == "" {
@@ -687,7 +686,9 @@ func (a *API) publishProcessHandler(w http.ResponseWriter, r *http.Request) {
 		errors.ErrInternalStorageError.WithErr(err).Write(w)
 		return
 	}
-	metadataURL := fmt.Sprintf("%s/storage/%s", a.serverURL, objectName)
+	// build the reference via the storage client so the URL format (and trailing-slash
+	// handling) matches what the read path's local-reference match expects.
+	metadataURL := a.objectStorage.LocalURL(objectName)
 	// persist the reference so the read path resolves it locally without a chain round-trip.
 	draft.MetadataURL = metadataURL
 

--- a/api/process.go
+++ b/api/process.go
@@ -325,12 +325,6 @@ func (a *API) resolveProcessMetadata(p *db.Process) map[string]any {
 			return nil
 		}
 		m = mm
-		// cache locally and promote the reference so the next request resolves locally
-		if b, err := json.Marshal(m); err == nil {
-			if name, err := a.objectStorage.PutJSON(b, metadataObjectUserID); err == nil {
-				p.MetadataURL, changed = storagePrefix+name, true
-			}
-		}
 	case strings.HasPrefix(p.MetadataURL, "http"):
 		m = fetchExternalMetadata(p.MetadataURL)
 	default:
@@ -338,6 +332,16 @@ func (a *API) resolveProcessMetadata(p *db.Process) map[string]any {
 	}
 	if m == nil {
 		return nil
+	}
+	// metadata is immutable (a change is a republish through this API), so cache any
+	// remotely-resolved document locally and promote the reference — later reads then
+	// resolve from our own storage with no Vochain or external round-trip.
+	if !strings.HasPrefix(p.MetadataURL, storagePrefix) {
+		if b, err := json.Marshal(m); err == nil {
+			if name, err := a.objectStorage.PutJSON(b, metadataObjectUserID); err == nil {
+				p.MetadataURL, changed = storagePrefix+name, true
+			}
+		}
 	}
 	// persist a learned/promoted reference inline, so following requests resolve locally
 	if changed {

--- a/api/process.go
+++ b/api/process.go
@@ -324,7 +324,7 @@ func (a *API) resolveProcessMetadata(p *db.Process) map[string]any {
 			return nil
 		}
 		m = mm
-	case strings.HasPrefix(p.MetadataURL, "http"):
+	case strings.HasPrefix(p.MetadataURL, "http://"), strings.HasPrefix(p.MetadataURL, "https://"):
 		m = fetchExternalMetadata(p.MetadataURL)
 	default:
 		return nil

--- a/api/process.go
+++ b/api/process.go
@@ -1,9 +1,12 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -15,6 +18,7 @@ import (
 	"github.com/vocdoni/saas-backend/internal"
 	"github.com/vocdoni/saas-backend/subscriptions"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/proto/build/go/models"
 )
@@ -263,10 +267,110 @@ func (a *API) processInfoHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// resolve the canonical metadata from its reference (best-effort): the Vochain only
+	// resolves ipfs:// pointers, so the https /storage pointer this service publishes is
+	// resolved here instead.
+	if md := a.resolveProcessMetadata(process); md != nil {
+		process.Metadata = md
+	}
+
 	apicommon.HTTPWriteJSON(w, &apicommon.ProcessInfo{
 		Process: process,
 		ChainID: a.account.ChainID(),
 	})
+}
+
+// metadataObjectUserID is the object-storage owner recorded for server-generated
+// metadata documents cached on read.
+const metadataObjectUserID = "system"
+
+// resolveProcessMetadata returns the canonical metadata for a published process,
+// consulting process.MetadataURL. Returns nil (caller keeps the stored value) for
+// drafts or on any error. Persists the reference inline only when it changed.
+func (a *API) resolveProcessMetadata(p *db.Process) map[string]any {
+	if p.Address.Equals(nil) { // draft, nothing on chain
+		return nil
+	}
+	var election *api.Election
+	changed := false
+	// bootstrap the reference from the on-chain pointer if we don't have one yet
+	if p.MetadataURL == "" {
+		el, err := a.account.Election(p.Address.Bytes())
+		if err != nil {
+			log.Warnw("metadata: election fetch failed", "process", p.Address.String(), "error", err)
+			return nil
+		}
+		election, p.MetadataURL, changed = el, el.MetadataURL, true
+	}
+
+	var m map[string]any
+	storagePrefix := a.serverURL + "/storage/"
+	switch {
+	case strings.HasPrefix(p.MetadataURL, storagePrefix):
+		// our own object storage — resolve locally
+		if obj, err := a.objectStorage.GetByName(strings.TrimPrefix(p.MetadataURL, storagePrefix)); err == nil {
+			_ = json.Unmarshal(obj.Data, &m)
+		}
+	case strings.HasPrefix(p.MetadataURL, "ipfs://"):
+		// the Vochain resolves ipfs; reuse the election if already fetched
+		if election == nil {
+			el, err := a.account.Election(p.Address.Bytes())
+			if err != nil {
+				return nil
+			}
+			election = el
+		}
+		mm, ok := election.Metadata.(map[string]any)
+		if !ok || len(mm) == 0 {
+			return nil
+		}
+		m = mm
+		// cache locally and promote the reference so the next request resolves locally
+		if b, err := json.Marshal(m); err == nil {
+			if name, err := a.objectStorage.PutJSON(b, metadataObjectUserID); err == nil {
+				p.MetadataURL, changed = storagePrefix+name, true
+			}
+		}
+	case strings.HasPrefix(p.MetadataURL, "http"):
+		m = fetchExternalMetadata(p.MetadataURL)
+	default:
+		return nil
+	}
+	if m == nil {
+		return nil
+	}
+	// persist a learned/promoted reference inline, so following requests resolve locally
+	if changed {
+		if _, err := a.db.SetProcess(p); err != nil {
+			log.Warnw("metadata: could not persist metadataURL", "process", p.Address.String(), "error", err)
+		}
+	}
+	return m
+}
+
+// fetchExternalMetadata best-effort downloads and JSON-decodes a metadata document from
+// an external http(s) reference (one that does not point at our own object storage).
+// Returns nil on any failure.
+func fetchExternalMetadata(url string) map[string]any {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+	var m map[string]any
+	if json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&m) != nil { // 1 MiB cap
+		return nil
+	}
+	return m
 }
 
 // organizationListProcessDraftsHandler godoc
@@ -579,6 +683,8 @@ func (a *API) publishProcessHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	metadataURL := fmt.Sprintf("%s/storage/%s", a.serverURL, objectName)
+	// persist the reference so the read path resolves it locally without a chain round-trip.
+	draft.MetadataURL = metadataURL
 
 	// serialize build->sign->submit per organization so a concurrent publish or status
 	// change for the same org cannot read the same account nonce and sign a conflicting

--- a/api/process.go
+++ b/api/process.go
@@ -304,11 +304,11 @@ func (a *API) resolveProcessMetadata(p *db.Process) map[string]any {
 	}
 
 	var m map[string]any
-	storagePrefix := a.serverURL + "/storage/"
+	name, isLocal := a.objectStorage.LocalName(p.MetadataURL)
 	switch {
-	case strings.HasPrefix(p.MetadataURL, storagePrefix):
+	case isLocal:
 		// our own object storage — resolve locally
-		if obj, err := a.objectStorage.GetByName(strings.TrimPrefix(p.MetadataURL, storagePrefix)); err == nil {
+		if obj, err := a.objectStorage.GetByName(name); err == nil {
 			_ = json.Unmarshal(obj.Data, &m)
 		}
 	case strings.HasPrefix(p.MetadataURL, "ipfs://"):
@@ -336,16 +336,17 @@ func (a *API) resolveProcessMetadata(p *db.Process) map[string]any {
 	// metadata is immutable (a change is a republish through this API), so cache any
 	// remotely-resolved document locally and promote the reference — later reads then
 	// resolve from our own storage with no Vochain or external round-trip.
-	if !strings.HasPrefix(p.MetadataURL, storagePrefix) {
+	if !isLocal {
 		if b, err := json.Marshal(m); err == nil {
-			if name, err := a.objectStorage.PutJSON(b, metadataObjectUserID); err == nil {
-				p.MetadataURL, changed = storagePrefix+name, true
+			if stored, err := a.objectStorage.PutJSON(b, metadataObjectUserID); err == nil {
+				p.MetadataURL, changed = a.objectStorage.LocalURL(stored), true
 			}
 		}
 	}
-	// persist a learned/promoted reference inline, so following requests resolve locally
+	// persist a learned/promoted reference with a targeted update (not a full rewrite) so
+	// a concurrent change to other process fields is not clobbered by this read path.
 	if changed {
-		if _, err := a.db.SetProcess(p); err != nil {
+		if err := a.db.SetProcessMetadataURL(p.ID, p.MetadataURL); err != nil {
 			log.Warnw("metadata: could not persist metadataURL", "process", p.Address.String(), "error", err)
 		}
 	}

--- a/api/process_metadata_test.go
+++ b/api/process_metadata_test.go
@@ -24,7 +24,7 @@ func TestFetchExternalMetadata(t *testing.T) {
 			_, _ = w.Write([]byte(`{"title":"hello","version":"1.0"}`))
 		}))
 		defer ts.Close()
-		m := fetchExternalMetadata(ts.URL)
+		m := fetchExternalMetadata(t.Context(), ts.URL)
 		c.Assert(m, qt.Not(qt.IsNil))
 		c.Assert(m["title"], qt.Equals, "hello")
 	})
@@ -34,7 +34,7 @@ func TestFetchExternalMetadata(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 		}))
 		defer ts.Close()
-		c.Assert(fetchExternalMetadata(ts.URL), qt.IsNil)
+		c.Assert(fetchExternalMetadata(t.Context(), ts.URL), qt.IsNil)
 	})
 
 	t.Run("over size cap", func(_ *testing.T) {
@@ -46,7 +46,7 @@ func TestFetchExternalMetadata(t *testing.T) {
 			_, _ = w.Write(big)
 		}))
 		defer ts.Close()
-		c.Assert(fetchExternalMetadata(ts.URL), qt.IsNil)
+		c.Assert(fetchExternalMetadata(t.Context(), ts.URL), qt.IsNil)
 	})
 }
 
@@ -64,6 +64,14 @@ func TestResolveMetadataPromotesRemote(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write(body)
 	}))
+	// the test closes ts mid-run to prove local resolution; this cleanup closes it if an
+	// assertion fails first, and the guard avoids a double close.
+	tsClosed := false
+	t.Cleanup(func() {
+		if !tsClosed {
+			ts.Close()
+		}
+	})
 
 	// seed a published process whose metadata reference points at the external server
 	// (no on-chain lookup happens because the reference is already set).
@@ -89,6 +97,7 @@ func TestResolveMetadataPromotesRemote(t *testing.T) {
 
 	// second read resolves from local storage even after the external source disappears
 	ts.Close()
+	tsClosed = true
 	info2 := requestAndParse[apicommon.ProcessInfo](t, http.MethodGet, token, nil, "process", id.Hex())
 	c.Assert(info2.Metadata["title"], qt.Equals, "Remote election")
 }

--- a/api/process_metadata_test.go
+++ b/api/process_metadata_test.go
@@ -67,7 +67,7 @@ func TestResolveMetadataPromotesRemote(t *testing.T) {
 
 	// seed a published process whose metadata reference points at the external server
 	// (no on-chain lookup happens because the reference is already set).
-	addr := common.HexToAddress(internal.RandomHex(100000))
+	addr := common.HexToAddress(internal.RandomHex(20))
 	id, err := testDB.SetProcess(&db.Process{
 		OrgAddress:  orgAddress,
 		Address:     internal.HexBytes(addr.Bytes()),

--- a/api/process_metadata_test.go
+++ b/api/process_metadata_test.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/api/apicommon"
+	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/internal"
+)
+
+// TestFetchExternalMetadata covers the external http(s) fetch helper: a valid JSON
+// document is decoded, a non-200 yields nil, and a body over the 1 MiB cap is rejected.
+func TestFetchExternalMetadata(t *testing.T) {
+	c := qt.New(t)
+
+	t.Run("ok", func(_ *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"title":"hello","version":"1.0"}`))
+		}))
+		defer ts.Close()
+		m := fetchExternalMetadata(ts.URL)
+		c.Assert(m, qt.Not(qt.IsNil))
+		c.Assert(m["title"], qt.Equals, "hello")
+	})
+
+	t.Run("non-200", func(_ *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer ts.Close()
+		c.Assert(fetchExternalMetadata(ts.URL), qt.IsNil)
+	})
+
+	t.Run("over size cap", func(_ *testing.T) {
+		// a valid JSON document larger than the 1 MiB read cap is truncated and fails to
+		// decode, so it must be rejected rather than partially parsed.
+		big, err := json.Marshal(map[string]any{"x": strings.Repeat("a", 2<<20)})
+		c.Assert(err, qt.IsNil)
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write(big)
+		}))
+		defer ts.Close()
+		c.Assert(fetchExternalMetadata(ts.URL), qt.IsNil)
+	})
+}
+
+// TestResolveMetadataPromotesRemote asserts that a remote (external http) metadata
+// reference is resolved, cached locally and the reference promoted to a /storage/ URL,
+// so a later read resolves from local storage even when the external source is gone.
+func TestResolveMetadataPromotesRemote(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "password123")
+	orgAddress := testCreateOrganization(t, token)
+
+	served := map[string]any{"title": "Remote election", "version": "1.0"}
+	body, err := json.Marshal(served)
+	c.Assert(err, qt.IsNil)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+
+	// seed a published process whose metadata reference points at the external server
+	// (no on-chain lookup happens because the reference is already set).
+	addr := common.HexToAddress(internal.RandomHex(100000))
+	id, err := testDB.SetProcess(&db.Process{
+		OrgAddress:  orgAddress,
+		Address:     internal.HexBytes(addr.Bytes()),
+		Status:      "READY",
+		MetadataURL: ts.URL,
+	})
+	c.Assert(err, qt.IsNil)
+
+	// first read: resolves externally, caches locally, promotes the reference
+	info := requestAndParse[apicommon.ProcessInfo](t, http.MethodGet, token, nil, "process", id.Hex())
+	c.Assert(info.Metadata["title"], qt.Equals, "Remote election")
+	c.Assert(strings.HasPrefix(info.MetadataURL, "/storage/"), qt.IsTrue,
+		qt.Commentf("reference should be promoted to local storage, got %q", info.MetadataURL))
+
+	// the promoted reference must be persisted
+	stored, err := testDB.Process(id)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stored.MetadataURL, qt.Equals, info.MetadataURL)
+
+	// second read resolves from local storage even after the external source disappears
+	ts.Close()
+	info2 := requestAndParse[apicommon.ProcessInfo](t, http.MethodGet, token, nil, "process", id.Hex())
+	c.Assert(info2.Metadata["title"], qt.Equals, "Remote election")
+}

--- a/api/process_publish_test.go
+++ b/api/process_publish_test.go
@@ -81,6 +81,13 @@ func TestPublishProcess(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(election, qt.Not(qt.IsNil))
 
+	// the info endpoint resolves the canonical metadata from its (https /storage)
+	// reference — the Vochain itself only resolves ipfs pointers.
+	info := requestAndParse[apicommon.ProcessInfo](t, http.MethodGet, token, nil, "process", draftID.Hex())
+	c.Assert(info.MetadataURL, qt.Not(qt.Equals), "")
+	c.Assert(info.Metadata, qt.Not(qt.HasLen), 0)
+	c.Assert(info.Metadata["title"], qt.Not(qt.IsNil))
+
 	// idempotency: once published the endpoint returns 200 with the same address (no tx)
 	resp2 := requestAndParse[apicommon.PublishProcessResponse](
 		t, http.MethodPost, token, nil, "process", draftID.Hex(), "publish")

--- a/db/process.go
+++ b/db/process.go
@@ -113,6 +113,23 @@ func (ms *MongoStorage) ClearProcessPublishing(processID primitive.ObjectID) err
 	return nil
 }
 
+// SetProcessMetadataURL sets only the metadataURL field of the process identified by
+// processID, leaving every other field untouched so a concurrent update to the same
+// process (status, publishedAt, counters...) is not clobbered by a stale full rewrite.
+func (ms *MongoStorage) SetProcessMetadataURL(processID primitive.ObjectID, metadataURL string) error {
+	if processID == primitive.NilObjectID {
+		return ErrInvalidData
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	filter := bson.M{"_id": processID}
+	if _, err := ms.processes.UpdateOne(ctx, filter, bson.M{"$set": bson.M{"metadataURL": metadataURL}}); err != nil {
+		return fmt.Errorf("failed to set process metadataURL: %w", err)
+	}
+	return nil
+}
+
 // DeleteProcess removes a process
 func (ms *MongoStorage) DelProcess(processID primitive.ObjectID) error {
 	if processID == primitive.NilObjectID {

--- a/db/process.go
+++ b/db/process.go
@@ -124,8 +124,12 @@ func (ms *MongoStorage) SetProcessMetadataURL(processID primitive.ObjectID, meta
 	defer cancel()
 
 	filter := bson.M{"_id": processID}
-	if _, err := ms.processes.UpdateOne(ctx, filter, bson.M{"$set": bson.M{"metadataURL": metadataURL}}); err != nil {
+	res, err := ms.processes.UpdateOne(ctx, filter, bson.M{"$set": bson.M{"metadataURL": metadataURL}})
+	if err != nil {
 		return fmt.Errorf("failed to set process metadataURL: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return ErrNotFound
 	}
 	return nil
 }

--- a/db/types.go
+++ b/db/types.go
@@ -508,14 +508,20 @@ type ElectionParams struct {
 //
 //nolint:lll
 type Process struct {
-	ID             primitive.ObjectID `json:"id" bson:"_id"`
-	Address        internal.HexBytes  `json:"address" bson:"address"  swaggertype:"string" format:"hex" example:"deadbeef"`
-	OrgAddress     common.Address     `json:"orgAdress" bson:"orgAddress"`
-	Census         Census             `json:"census" bson:"census"`
-	Metadata       map[string]any     `json:"metadata"  bson:"metadata"`
-	ElectionParams *ElectionParams    `json:"electionParams,omitempty" bson:"electionParams,omitempty"`
-	Status         string             `json:"status,omitempty" bson:"status,omitempty"`
-	PublishedAt    time.Time          `json:"publishedAt,omitempty" bson:"publishedAt,omitempty"`
+	ID         primitive.ObjectID `json:"id" bson:"_id"`
+	Address    internal.HexBytes  `json:"address" bson:"address"  swaggertype:"string" format:"hex" example:"deadbeef"`
+	OrgAddress common.Address     `json:"orgAdress" bson:"orgAddress"`
+	Census     Census             `json:"census" bson:"census"`
+	Metadata   map[string]any     `json:"metadata"  bson:"metadata"`
+	// MetadataURL is the generic reference to this process's canonical ElectionMetadata
+	// document. https references are fetched (locally when they point at this service's
+	// object storage, otherwise externally); ipfs references are resolved via the Vochain
+	// and then cached locally. Bootstrapped from the on-chain pointer on first read when
+	// empty; empty for unpublished drafts.
+	MetadataURL    string          `json:"metadataURL,omitempty" bson:"metadataURL,omitempty"`
+	ElectionParams *ElectionParams `json:"electionParams,omitempty" bson:"electionParams,omitempty"`
+	Status         string          `json:"status,omitempty" bson:"status,omitempty"`
+	PublishedAt    time.Time       `json:"publishedAt,omitempty" bson:"publishedAt,omitempty"`
 }
 
 // ProcessesBundle represents a group of voting processes that share a common census.

--- a/db/types.go
+++ b/db/types.go
@@ -514,10 +514,11 @@ type Process struct {
 	Census     Census             `json:"census" bson:"census"`
 	Metadata   map[string]any     `json:"metadata"  bson:"metadata"`
 	// MetadataURL is the generic reference to this process's canonical ElectionMetadata
-	// document. https references are fetched (locally when they point at this service's
-	// object storage, otherwise externally); ipfs references are resolved via the Vochain
-	// and then cached locally. Bootstrapped from the on-chain pointer on first read when
-	// unset. Unset for unpublished drafts, and omitted from JSON in that case (omitempty).
+	// document. http(s) references are fetched — locally when they point at this service's
+	// object storage (including a relative "/storage/{name}" reference), otherwise via an
+	// external request; ipfs references are resolved via the Vochain and then cached
+	// locally. Bootstrapped from the on-chain pointer on first read when unset. Unset for
+	// unpublished drafts, and omitted from JSON in that case (omitempty).
 	MetadataURL    string          `json:"metadataURL,omitempty" bson:"metadataURL,omitempty"`
 	ElectionParams *ElectionParams `json:"electionParams,omitempty" bson:"electionParams,omitempty"`
 	Status         string          `json:"status,omitempty" bson:"status,omitempty"`

--- a/db/types.go
+++ b/db/types.go
@@ -517,7 +517,7 @@ type Process struct {
 	// document. https references are fetched (locally when they point at this service's
 	// object storage, otherwise externally); ipfs references are resolved via the Vochain
 	// and then cached locally. Bootstrapped from the on-chain pointer on first read when
-	// empty; empty for unpublished drafts.
+	// unset. Unset for unpublished drafts, and omitted from JSON in that case (omitempty).
 	MetadataURL    string          `json:"metadataURL,omitempty" bson:"metadataURL,omitempty"`
 	ElectionParams *ElectionParams `json:"electionParams,omitempty" bson:"electionParams,omitempty"`
 	Status         string          `json:"status,omitempty" bson:"status,omitempty"`

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1059,6 +1059,14 @@ definitions:
       metadata:
         additionalProperties: {}
         type: object
+      metadataURL:
+        description: |-
+          MetadataURL is the generic reference to this process's canonical ElectionMetadata
+          document. https references are fetched (locally when they point at this service's
+          object storage, otherwise externally); ipfs references are resolved via the Vochain
+          and then cached locally. Bootstrapped from the on-chain pointer on first read when
+          empty; empty for unpublished drafts.
+        type: string
       orgAdress:
         items:
           type: integer
@@ -1756,6 +1764,14 @@ definitions:
       metadata:
         additionalProperties: {}
         type: object
+      metadataURL:
+        description: |-
+          MetadataURL is the generic reference to this process's canonical ElectionMetadata
+          document. https references are fetched (locally when they point at this service's
+          object storage, otherwise externally); ipfs references are resolved via the Vochain
+          and then cached locally. Bootstrapped from the on-chain pointer on first read when
+          empty; empty for unpublished drafts.
+        type: string
       orgAdress:
         items:
           type: integer

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1062,10 +1062,11 @@ definitions:
       metadataURL:
         description: |-
           MetadataURL is the generic reference to this process's canonical ElectionMetadata
-          document. https references are fetched (locally when they point at this service's
-          object storage, otherwise externally); ipfs references are resolved via the Vochain
-          and then cached locally. Bootstrapped from the on-chain pointer on first read when
-          unset. Unset for unpublished drafts, and omitted from JSON in that case (omitempty).
+          document. http(s) references are fetched — locally when they point at this service's
+          object storage (including a relative "/storage/{name}" reference), otherwise via an
+          external request; ipfs references are resolved via the Vochain and then cached
+          locally. Bootstrapped from the on-chain pointer on first read when unset. Unset for
+          unpublished drafts, and omitted from JSON in that case (omitempty).
         type: string
       orgAdress:
         items:
@@ -1767,10 +1768,11 @@ definitions:
       metadataURL:
         description: |-
           MetadataURL is the generic reference to this process's canonical ElectionMetadata
-          document. https references are fetched (locally when they point at this service's
-          object storage, otherwise externally); ipfs references are resolved via the Vochain
-          and then cached locally. Bootstrapped from the on-chain pointer on first read when
-          unset. Unset for unpublished drafts, and omitted from JSON in that case (omitempty).
+          document. http(s) references are fetched — locally when they point at this service's
+          object storage (including a relative "/storage/{name}" reference), otherwise via an
+          external request; ipfs references are resolved via the Vochain and then cached
+          locally. Bootstrapped from the on-chain pointer on first read when unset. Unset for
+          unpublished drafts, and omitted from JSON in that case (omitempty).
         type: string
       orgAdress:
         items:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1065,7 +1065,7 @@ definitions:
           document. https references are fetched (locally when they point at this service's
           object storage, otherwise externally); ipfs references are resolved via the Vochain
           and then cached locally. Bootstrapped from the on-chain pointer on first read when
-          empty; empty for unpublished drafts.
+          unset. Unset for unpublished drafts, and omitted from JSON in that case (omitempty).
         type: string
       orgAdress:
         items:
@@ -1770,7 +1770,7 @@ definitions:
           document. https references are fetched (locally when they point at this service's
           object storage, otherwise externally); ipfs references are resolved via the Vochain
           and then cached locally. Bootstrapped from the on-chain pointer on first read when
-          empty; empty for unpublished drafts.
+          unset. Unset for unpublished drafts, and omitted from JSON in that case (omitempty).
         type: string
       orgAdress:
         items:

--- a/objectstorage/localname_test.go
+++ b/objectstorage/localname_test.go
@@ -1,0 +1,37 @@
+package objectstorage
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestLocalName(t *testing.T) {
+	c := qt.New(t)
+
+	cases := []struct {
+		name      string
+		serverURL string
+		url       string
+		wantName  string
+		wantOK    bool
+	}{
+		{"canonical", "https://host", "https://host/storage/abc.json", "abc.json", true},
+		{"trailing slash on serverURL", "https://host/", "https://host/storage/abc.json", "abc.json", true},
+		{"legacy double slash pointer", "https://host", "https://host//storage/abc.json", "abc.json", true},
+		{"relative reference", "https://host", "/storage/abc.json", "abc.json", true},
+		{"relative with empty serverURL", "", "/storage/abc.json", "abc.json", true},
+		{"different host", "https://host", "https://other/storage/abc.json", "", false},
+		{"host-prefix false positive", "https://host", "https://hoststorage/abc.json", "", false},
+		{"external absolute, empty serverURL", "", "https://other/storage/abc.json", "", false},
+		{"ipfs reference", "https://host", "ipfs://bafy.../meta", "", false},
+	}
+	for _, tc := range cases {
+		c.Run(tc.name, func(c *qt.C) {
+			osc := &Client{ServerURL: tc.serverURL}
+			name, ok := osc.LocalName(tc.url)
+			c.Assert(ok, qt.Equals, tc.wantOK)
+			c.Assert(name, qt.Equals, tc.wantName)
+		})
+	}
+}

--- a/objectstorage/localname_test.go
+++ b/objectstorage/localname_test.go
@@ -25,6 +25,9 @@ func TestLocalName(t *testing.T) {
 		{"host-prefix false positive", "https://host", "https://hoststorage/abc.json", "", false},
 		{"external absolute, empty serverURL", "", "https://other/storage/abc.json", "", false},
 		{"ipfs reference", "https://host", "ipfs://bafy.../meta", "", false},
+		{"storage path with no name (absolute)", "https://host", "https://host/storage/", "", false},
+		{"storage path with no name (relative)", "", "/storage/", "", false},
+		{"relative non-storage path", "https://host", "/foo", "", false},
 	}
 	for _, tc := range cases {
 		c.Run(tc.name, func(c *qt.C) {

--- a/objectstorage/objectstorage.go
+++ b/objectstorage/objectstorage.go
@@ -117,6 +117,28 @@ func (osc *Client) GetByName(objectName string) (*db.Object, error) {
 	return osc.Get(objectID)
 }
 
+// LocalName returns the object name when url refers to an object served by this storage
+// client — either an absolute "{ServerURL}/storage/{name}" reference or a relative
+// "/storage/{name}" one. The relative form keeps a reference resolvable even if
+// ServerURL later changes. The boolean reports whether url is a local storage reference.
+func (osc *Client) LocalName(url string) (string, bool) {
+	if name, ok := strings.CutPrefix(url, osc.storagePrefix()); ok {
+		return name, true
+	}
+	return strings.CutPrefix(url, "/storage/")
+}
+
+// LocalURL returns the canonical local reference URL for the given object name.
+func (osc *Client) LocalURL(objectName string) string {
+	return osc.storagePrefix() + objectName
+}
+
+// storagePrefix is the "{ServerURL}/storage/" prefix, with any trailing slash on
+// ServerURL trimmed so a misconfigured value never yields a "//storage/" prefix.
+func (osc *Client) storagePrefix() string {
+	return strings.TrimSuffix(osc.ServerURL, "/") + "/storage/"
+}
+
 // uploadObject uploads the object image with the given objectID, associated to
 // the user with the given userFID and the community with the given communityID.
 // If the objectID is empty, it calculates the objectID from the data. It returns

--- a/objectstorage/objectstorage.go
+++ b/objectstorage/objectstorage.go
@@ -133,10 +133,10 @@ func (osc *Client) LocalURL(objectName string) string {
 	return osc.storagePrefix() + objectName
 }
 
-// storagePrefix is the "{ServerURL}/storage/" prefix, with any trailing slash on
+// storagePrefix is the "{ServerURL}/storage/" prefix, with any trailing slashes on
 // ServerURL trimmed so a misconfigured value never yields a "//storage/" prefix.
 func (osc *Client) storagePrefix() string {
-	return strings.TrimSuffix(osc.ServerURL, "/") + "/storage/"
+	return strings.TrimRight(osc.ServerURL, "/") + "/storage/"
 }
 
 // uploadObject uploads the object image with the given objectID, associated to

--- a/objectstorage/objectstorage.go
+++ b/objectstorage/objectstorage.go
@@ -124,18 +124,25 @@ func (osc *Client) GetByName(objectName string) (*db.Object, error) {
 // trailing slash) still resolves locally; a relative reference keeps resolving even if
 // ServerURL later changes. The boolean reports whether url is a local storage reference.
 func (osc *Client) LocalName(url string) (string, bool) {
+	// extract the object name from a "{slashes}storage/{name}" path tail, requiring a
+	// non-empty name so a bare ".../storage/" never reports as a (useless) local match.
+	extract := func(pathTail string) (string, bool) {
+		name, ok := strings.CutPrefix(strings.TrimLeft(pathTail, "/"), "storage/")
+		if !ok || name == "" {
+			return "", false
+		}
+		return name, true
+	}
 	// absolute reference under our host, tolerating extra slashes at the host/path
 	// boundary (the leading "/" check rejects "hoststorage/..."-style false prefixes).
 	if base := strings.TrimRight(osc.ServerURL, "/"); base != "" {
 		if rest, ok := strings.CutPrefix(url, base); ok && strings.HasPrefix(rest, "/") {
-			if name, ok := strings.CutPrefix(strings.TrimLeft(rest, "/"), "storage/"); ok {
-				return name, true
-			}
+			return extract(rest)
 		}
 	}
 	// relative reference (also resolvable if ServerURL changes)
 	if strings.HasPrefix(url, "/") {
-		return strings.CutPrefix(strings.TrimLeft(url, "/"), "storage/")
+		return extract(url)
 	}
 	return "", false
 }

--- a/objectstorage/objectstorage.go
+++ b/objectstorage/objectstorage.go
@@ -118,14 +118,26 @@ func (osc *Client) GetByName(objectName string) (*db.Object, error) {
 }
 
 // LocalName returns the object name when url refers to an object served by this storage
-// client — either an absolute "{ServerURL}/storage/{name}" reference or a relative
-// "/storage/{name}" one. The relative form keeps a reference resolvable even if
+// client — an absolute "{ServerURL}/storage/{name}" reference or a relative
+// "/storage/{name}" one. Any number of slashes are tolerated at the host/path boundary
+// so a legacy "{ServerURL}//storage/{name}" pointer (written when ServerURL had a
+// trailing slash) still resolves locally; a relative reference keeps resolving even if
 // ServerURL later changes. The boolean reports whether url is a local storage reference.
 func (osc *Client) LocalName(url string) (string, bool) {
-	if name, ok := strings.CutPrefix(url, osc.storagePrefix()); ok {
-		return name, true
+	// absolute reference under our host, tolerating extra slashes at the host/path
+	// boundary (the leading "/" check rejects "hoststorage/..."-style false prefixes).
+	if base := strings.TrimRight(osc.ServerURL, "/"); base != "" {
+		if rest, ok := strings.CutPrefix(url, base); ok && strings.HasPrefix(rest, "/") {
+			if name, ok := strings.CutPrefix(strings.TrimLeft(rest, "/"), "storage/"); ok {
+				return name, true
+			}
+		}
 	}
-	return strings.CutPrefix(url, "/storage/")
+	// relative reference (also resolvable if ServerURL changes)
+	if strings.HasPrefix(url, "/") {
+		return strings.CutPrefix(strings.TrimLeft(url, "/"), "storage/")
+	}
+	return "", false
 }
 
 // LocalURL returns the canonical local reference URL for the given object name.

--- a/objectstorage/objectstorage.go
+++ b/objectstorage/objectstorage.go
@@ -107,6 +107,16 @@ func (osc *Client) Get(objectID string) (*db.Object, error) {
 	return object, nil
 }
 
+// GetByName returns the stored object addressed by its "{id}.{ext}" name (the last
+// path segment of a /storage/{name} URL).
+func (osc *Client) GetByName(objectName string) (*db.Object, error) {
+	objectID, ok := objectIDfromName(objectName)
+	if !ok {
+		return nil, ErrorInvalidObjectID
+	}
+	return osc.Get(objectID)
+}
+
 // uploadObject uploads the object image with the given objectID, associated to
 // the user with the given userFID and the community with the given communityID.
 // If the objectID is empty, it calculates the objectID from the data. It returns


### PR DESCRIPTION
## Problem

`GET /process/{processId}` is supposed to return the election metadata, but it goes missing for some elections. The Vochain node only resolves **`ipfs://`** metadata pointers (its storage layer is IPFS-only), while this service publishes its metadata at an **`https://.../storage/...`** pointer — which the node never resolves. So downstream the `metadata` comes back empty for saas-published elections.

## Approach

Keep one source of truth (the canonical `ElectionMetadata` JSON already in object storage) and store a **generic reference** on the process, then resolve it on read — mirroring how the Vochain stores an `ipfs://` reference.

### Changes
- **`db.Process.MetadataURL`** — new generic reference field.
- **Publish path** persists the `https /storage` reference (the same URL written on chain), so reads resolve locally without a chain round-trip.
- **`processInfoHandler`** resolves the reference (best-effort, never fails the request):
  - **our own object storage** (matched first, so it works even when `serverURL` is empty) → read locally;
  - **`ipfs://`** → resolve via the Vochain;
  - **other `http(s)`** → best-effort external fetch (3s timeout, 1 MiB cap).
  - Any document resolved from a **remote** source (ipfs or external http) is then **cached locally and the reference promoted** to a local `/storage` URL, so every later read resolves from our own storage with no Vochain/external round-trip. This is safe because metadata is immutable — a change is a republish through this API. The local-storage branch is skipped (already local).
  - The reference is **bootstrapped from the on-chain pointer** when missing, covering pre-existing/external processes — no migration needed.
- **`objectstorage` helpers** — `GetByName` (wraps the existing `objectIDfromName` + `Get`), plus `LocalName`/`LocalURL` so the parse and format of `/storage/{name}` references (incl. relative refs and trailing-slash handling on `serverURL`) live in the storage layer rather than the api package.

### Notes / scope
- **Drafts** (no on-chain address) are untouched — they keep their stored `metadata` map.
- **Caching trade-off:** after the first read the stored/returned `metadataURL` becomes the local `https` copy (the on-chain pointer is unchanged). That's the "store it so following reads hit it locally" behaviour, applied uniformly to ipfs and external references.
- The existing `db.Process.Metadata` map is intentionally **kept** (still the draft store / response carrier); it's only redundant for published processes. Fully unifying on `electionParams` would be a separate, breaking change requiring the frontend to migrate first.

## Tests
- `make swagger` regenerated (`MetadataURL` added to `db.Process` → `ProcessInfo`).
- `golangci-lint` clean on the changed files (only pre-existing repo-wide `goconst` noise remains).
- `TestPublishProcess` extended to assert `GET /process/{id}` returns a non-empty `metadata` plus a `metadataURL`. `TestProcess*` suite green against the Voconed test stack.