### PR TITLE
feat(api): accept ProcessID for process-bundle creation (non-breaking)

### DIFF
--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -1287,7 +1287,8 @@ type CreateProcessBundleRequest struct {
 	// Census ID
 	CensusID string `json:"censusId"`
 
-	// List of process Addresses to include in the bundle
+	// List of processes to include in the bundle. Each entry is either the 24-hex ProcessID or the
+	// 64-hex on-chain election id.
 	Processes []string `json:"processes"`
 }
 

--- a/api/process_bundles.go
+++ b/api/process_bundles.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	stderrors "errors"
 	"net/http"
@@ -11,7 +10,7 @@ import (
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
 	"github.com/vocdoni/saas-backend/internal"
-	"go.vocdoni.io/dvote/util"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 // Using types from apicommon package
@@ -19,7 +18,39 @@ import (
 // AddProcessesToBundleRequest represents the request body for adding processes to an existing bundle.
 // It contains an array of process IDs to add to the bundle.
 type AddProcessesToBundleRequest struct {
-	Processes []string `json:"processes"` // Array of process creation requests to add
+	// Process IDs to add — each is either the 24-hex ProcessID or the 64-hex on-chain election id.
+	Processes []string `json:"processes"`
+}
+
+// resolveBundleProcessID resolves a process identifier from a bundle request to its on-chain election
+// id. Mirroring the sign-info endpoint, it accepts either the 24-hex ProcessID (resolved through the
+// database) or the on-chain election id directly, so clients using either form keep working.
+func (a *API) resolveBundleProcessID(raw string) (internal.HexBytes, *errors.Error) {
+	// A ProcessID is exactly 24 hex chars, so it never collides with an on-chain id. Anything that
+	// isn't a 24-hex ObjectID is treated as the on-chain id directly, exactly as before.
+	if objID, err := primitive.ObjectIDFromHex(raw); err == nil {
+		process, err := a.db.Process(objID)
+		if err != nil {
+			if err == db.ErrNotFound {
+				e := errors.ErrProcessNotFound
+				return nil, &e
+			}
+			e := errors.ErrGenericInternalServerError.WithErr(err)
+			return nil, &e
+		}
+		if len(process.Address) == 0 {
+			e := errors.ErrMalformedBody.Withf("process %s is not published", raw)
+			return nil, &e
+		}
+		return process.Address, nil
+	}
+
+	var onChainID internal.HexBytes
+	if err := onChainID.ParseString(raw); err != nil {
+		e := errors.ErrMalformedBody.Withf("invalid process ID")
+		return nil, &e
+	}
+	return onChainID, nil
 }
 
 // createProcessBundleHandler godoc
@@ -121,12 +152,11 @@ func (a *API) createProcessBundleHandler(w http.ResponseWriter, r *http.Request)
 			errors.ErrMalformedBody.Withf("missing process ID").Write(w)
 			return
 		}
-		processID, err := hex.DecodeString(util.TrimHex(processReq))
-		if err != nil {
-			errors.ErrMalformedBody.Withf("invalid process ID").Write(w)
+		processID, aerr := a.resolveBundleProcessID(processReq)
+		if aerr != nil {
+			aerr.Write(w)
 			return
 		}
-
 		processes = append(processes, processID)
 	}
 
@@ -248,12 +278,11 @@ func (a *API) updateProcessBundleHandler(w http.ResponseWriter, r *http.Request)
 			errors.ErrMalformedBody.Withf("missing process ID").Write(w)
 			return
 		}
-		processID, err := hex.DecodeString(util.TrimHex(processReq))
-		if err != nil {
-			errors.ErrMalformedBody.Withf("invalid process ID").Write(w)
+		processID, aerr := a.resolveBundleProcessID(processReq)
+		if aerr != nil {
+			aerr.Write(w)
 			return
 		}
-
 		processesToAdd = append(processesToAdd, processID)
 	}
 

--- a/api/process_bundles_info_test.go
+++ b/api/process_bundles_info_test.go
@@ -122,3 +122,52 @@ func TestProcessBundleParticipantInfo(t *testing.T) {
 	requestAndAssertError(errors.ErrMalformedURLParam, t, http.MethodGet, "", nil,
 		"process", "bundle", unknownID, "p1")
 }
+
+// TestCreateProcessBundleAcceptsProcessID exercises POST /process/bundle accepting either the 24-hex
+// ProcessID or the 64-hex on-chain election id for each process (dual-accept, mirroring sign-info).
+// The ProcessID resolves to the process' on-chain id; the on-chain id keeps working (non-breaking).
+func TestCreateProcessBundleAcceptsProcessID(t *testing.T) {
+	c := qt.New(t)
+	defer func() {
+		if err := testDB.DeleteAllDocuments(); err != nil {
+			c.Logf("cleanup: %v", err)
+		}
+	}()
+
+	token := testCreateUser(t, "bundlepidpass123")
+	orgAddress := testCreateOrganization(t, token)
+	censusID := postCensus(t, token, orgAddress,
+		db.OrgMemberAuthFields{db.OrgMemberAuthFieldsMemberNumber},
+		db.OrgMemberTwoFaFields{db.OrgMemberTwoFaFieldEmail})
+
+	// A published process has a 32-byte on-chain Address.
+	onChain := internal.HexBytes(util.RandomBytes(32))
+	processObjID, err := testDB.SetProcess(&db.Process{OrgAddress: orgAddress, Address: onChain})
+	c.Assert(err, qt.IsNil)
+
+	assertBundleHasOnChainID := func(bundleID string) {
+		got := requestAndParse[db.ProcessesBundle](t, http.MethodGet, "", nil, "process", "bundle", bundleID)
+		c.Assert(got.Processes, qt.HasLen, 1)
+		c.Assert(got.Processes[0].String(), qt.Equals, onChain.String())
+	}
+
+	// (1) The 24-hex ProcessID is resolved to the process' on-chain id.
+	byProcessID, _ := postProcessBundle(t, token, censusID, processObjID[:])
+	assertBundleHasOnChainID(byProcessID)
+
+	// (2) The 64-hex on-chain id keeps working directly (non-breaking).
+	byOnChain, _ := postProcessBundle(t, token, censusID, onChain)
+	assertBundleHasOnChainID(byOnChain)
+
+	// (3) An existing but unpublished process (no on-chain id) → 400.
+	unpublished, err := testDB.SetProcess(&db.Process{OrgAddress: orgAddress})
+	c.Assert(err, qt.IsNil)
+	requestAndAssertError(errors.ErrMalformedBody, t, http.MethodPost, token,
+		&apicommon.CreateProcessBundleRequest{CensusID: censusID, Processes: []string{unpublished.Hex()}},
+		"process", "bundle")
+
+	// (4) A well-formed but unknown ProcessID → 404.
+	requestAndAssertError(errors.ErrProcessNotFound, t, http.MethodPost, token,
+		&apicommon.CreateProcessBundleRequest{CensusID: censusID, Processes: []string{"0123456789abcdef01234567"}},
+		"process", "bundle")
+}

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3,7 +3,8 @@ definitions:
   api.AddProcessesToBundleRequest:
     properties:
       processes:
-        description: Array of process creation requests to add
+        description: Process IDs to add — each is either the 24-hex ProcessID or the
+          64-hex on-chain election id.
         items:
           type: string
         type: array
@@ -378,7 +379,9 @@ definitions:
         description: Census ID
         type: string
       processes:
-        description: List of process Addresses to include in the bundle
+        description: |-
+          List of processes to include in the bundle. Each entry is either the 24-hex ProcessID or the
+          64-hex on-chain election id.
         items:
           type: string
         type: array


### PR DESCRIPTION
## What

`POST /process/bundle` (and the bundle-update path) hex-decoded each `processes[]` entry directly into raw on-chain bytes. A 24-hex **ProcessID** would silently decode to 12 garbage bytes and produce a broken bundle. This makes the bundle endpoints **dual-accept**, the same way `sign-info` does — non-breaking.

## How

New helper `resolveBundleProcessID`, used by both `createProcessBundleHandler` and `updateProcessBundleHandler`:
- A **24-hex ProcessID** → looked up in the DB, mapped to its on-chain election id (`process.Address`).
- **Anything else** → treated as the on-chain id directly, **exactly as before** (no length constraint added — `result.address` is a 20-byte `common.Address` in this codebase, and `TestFullElectionLifecycle` passes one through, so a strict 32-byte check would have broken it).

The discriminator is `ObjectIDFromHex` (exactly 24 hex chars); real on-chain ids are never 24 hex, so there's no collision — same reasoning as sign-info.

Error mapping: unknown ProcessID → **404**, existing-but-unpublished → **400**, DB error → **500**.

## Tests

`TestCreateProcessBundleAcceptsProcessID`:
- bundle created with the 24-hex ProcessID resolves to the process' on-chain id;
- bundle created with the on-chain id still works (non-breaking);
- unpublished process → 400; unknown ProcessID → 404.

Verified `TestFullElectionLifecycle` and the other bundle tests still pass (the 20-byte-address path is unchanged).

Follow-up to #551 — noticed while updating the integrator demo that the bundle was the one process endpoint still requiring the on-chain id.