### PR TITLE
fix(api): persist org Meta on creation

### DIFF
--- a/api/organizations.go
+++ b/api/organizations.go
@@ -145,6 +145,7 @@ func (a *API) createOrganizationHandler(w http.ResponseWriter, r *http.Request) 
 		Timezone:        orgInfo.Timezone,
 		Active:          true,
 		Communications:  orgInfo.Communications,
+		Meta:            orgInfo.Meta,
 		TokensPurchased: 0,
 		TokensRemaining: 0,
 		Parent:          parentOrg,

--- a/api/organizations_managed.go
+++ b/api/organizations_managed.go
@@ -166,6 +166,7 @@ func (a *API) createManagedOrganizationHandler(w http.ResponseWriter, r *http.Re
 		Timezone:       req.Timezone,
 		Active:         true,
 		Communications: req.Communications,
+		Meta:           req.Meta,
 		ManagedBy:      integratorAddr,
 		Subscription: db.OrganizationSubscription{
 			PlanID:    defaultPlan.ID,


### PR DESCRIPTION
## What

Copy the request's `Meta` map into the persisted `db.Organization` in both org-creation handlers:

- `createManagedOrganizationHandler` (`POST /integrator/organizations`) → `Meta: req.Meta`
- `createOrganizationHandler` (`POST /organizations`, self-serve) → `Meta: orgInfo.Meta`

## Why

Both handlers built the `db.Organization` struct field-by-field but never copied `Meta`. As a result, any metadata sent at creation — notably `meta.name`, an org's display name — was silently dropped, and every org was persisted with empty `meta`. `OrganizationFromDB` then always returned an empty/`{}` meta on reads.

This surfaced in the integrator portal: the Managed organizations list now uses `meta.name` as each org's primary label (falling back to `website`, then the address), but the name was always blank because it never got stored.

## How verified

- `go build ./...` — OK
- `go vet ./api/` — OK
- gofmt-clean
- `db.Organization.Meta` is `map[string]any`, matching `OrganizationInfo.Meta`, so the assignment is a direct copy.

Integration tests were not run locally (require MongoDB/services). Happy to add a create→fetch round-trip test asserting `meta.name` persists if reviewers want it in this PR.

## Notes

- Persistence only — callers still have to actually send `meta.name` at creation (e.g. the integrator's API integration). No behavior change for callers that send no meta.