### PR TITLE
fix(api): correct CSP sign-info field and clarify census→vote swagger

### DIFF
--- a/api/census.go
+++ b/api/census.go
@@ -277,6 +277,8 @@ func (a *API) publishCensusHandler(w http.ResponseWriter, r *http.Request) {
 //	@Description	must be provided. Supplying only authFields yields an auth-only census (members authenticate
 //	@Description	with their data, no OTP); twoFaFields adds an email/SMS OTP challenge. A body with both empty
 //	@Description	is rejected with 404 (ErrCensusTypeNotFound). Returns the published census root and URI.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `voting:write`).
 //	@Tags			census
 //	@Accept			json
 //	@Produce		json

--- a/api/process.go
+++ b/api/process.go
@@ -36,12 +36,11 @@ import (
 //	@Produce		json
 //	@Security		BearerAuth
 //	@Param			request	body		apicommon.CreateProcessRequest	true	"Process creation information (optionally with electionParams)"
-//	@Success		200		{object}	primitive.ObjectID				"24-hex draft ProcessID"
+//	@Success		200		{object}	primitive.ObjectID				"Bare JSON string: 24-hex draft ProcessID, e.g. 507f1f77bcf86cd799439011"
 //	@Failure		400		{object}	errors.Error					"Invalid input data"
 //	@Failure		401		{object}	errors.Error					"Unauthorized"
 //	@Failure		403		{object}	errors.Error					"Plan does not allow creating more drafts"
 //	@Failure		404		{object}	errors.Error					"Published census not found"
-//	@Failure		409		{object}	errors.Error					"Process already exists"
 //	@Failure		500		{object}	errors.Error					"Internal server error"
 //	@Router			/process [post]
 func (a *API) createProcessHandler(w http.ResponseWriter, r *http.Request) {

--- a/api/process_bundles.go
+++ b/api/process_bundles.go
@@ -28,6 +28,8 @@ type AddProcessesToBundleRequest struct {
 //	@Description	Create a new process bundle with the specified census and optional list of processes. Requires
 //	@Description	Manager/Admin role for the organization that owns the census. The census root will be the same as the
 //	@Description	account's public key.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `voting:write`).
 //	@Tags			process
 //	@Accept			json
 //	@Produce		json
@@ -177,6 +179,8 @@ func (a *API) createProcessBundleHandler(w http.ResponseWriter, r *http.Request)
 //	@Summary		Add processes to an existing bundle
 //	@Description	Add additional processes to an existing bundle. Requires Manager/Admin role for the organization
 //	@Description	that owns the bundle.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `voting:write`).
 //	@Tags			process
 //	@Accept			json
 //	@Produce		json

--- a/csp/handlers/handlers.go
+++ b/csp/handlers/handlers.go
@@ -129,12 +129,17 @@ func (c *CSPHandlers) handleAuthStep(w http.ResponseWriter, r *http.Request,
 //	@Description	- Step 1: The user sends the token and challenge solution back to the server.
 //	@Description	If valid, the token is marked as verified and returned.
 //	@Description	For auth-only censuses, verification may not require a challenge solution.
-//	@Tags			process
+//	@Description
+//	@Description	The request body depends on the step:
+//	@Description	- Step 0: handlers.AuthRequest — member identification fields (name, surname, memberNumber,
+//	@Description	nationalId, birthDate, email, phone); which are required depends on the census auth configuration.
+//	@Description	- Step 1: handlers.AuthChallengeRequest — { authToken, authData: [challenge solution] }.
+//	@Tags			csp
 //	@Accept			json
 //	@Produce		json
-//	@Param			bundleId	path		string		true	"Bundle ID"
-//	@Param			step		path		string		true	"Authentication step (0 or 1)"
-//	@Param			request		body		interface{}	true	"Authentication request (varies by step)"
+//	@Param			bundleId	path		string					true	"Bundle ID"
+//	@Param			step		path		string					true	"Authentication step (0 or 1)"
+//	@Param			request		body		handlers.AuthRequest	true	"Step 0 body; step 1 uses AuthChallengeRequest (see description)"
 //	@Success		200			{object}	handlers.AuthResponse
 //	@Failure		400			{object}	errors.Error	"Invalid input data"
 //	@Failure		401			{object}	errors.Error	"Unauthorized, cooldown time not reached (ErrAttemptCoolDownTime), or invalid challenge"
@@ -171,7 +176,7 @@ func (c *CSPHandlers) BundleAuthHandler(w http.ResponseWriter, r *http.Request) 
 //	@Description	The request must include the auth token and a valid contact method for the bundle census type
 //	@Description	(email, phone, or either depending on census configuration).
 //	@Description	The same token is returned if the challenge is queued successfully.
-//	@Tags			process
+//	@Tags			csp
 //	@Accept			json
 //	@Produce		json
 //	@Param			bundleId	path		string						true	"Bundle ID"
@@ -356,15 +361,17 @@ func (c *CSPHandlers) signAndRespond(w http.ResponseWriter, authToken, address, 
 //	@Description	and returns the signature. Once signed, the process is marked as consumed and cannot be signed again.
 //	@Description	The signing process includes verifying that the participant is in the census, that the process is part of
 //	@Description	the bundle, and that the authentication token is valid and verified.
-//	@Tags			process
+//	@Description
+//	@Description	Body: authToken, electionId (the process/election ID) and payload (the voter address). tokenR is unused.
+//	@Tags			csp
 //	@Accept			json
 //	@Produce		json
 //	@Param			bundleId	path		string					true	"Bundle ID"
-//	@Param			request		body		handlers.SignRequest	true	"Sign request with process ID, auth token, and payload (address)"
+//	@Param			request		body		handlers.SignRequest	true	"Sign request (see description for fields)"
 //	@Success		200			{object}	handlers.AuthResponse
 //	@Failure		400			{object}	errors.Error	"Invalid input data"
-//	@Failure		401			{object}	errors.Error	"Unauthorized, invalid token, or token not verified (ErrAuthTokenNotVerified)"
-//	@Failure		404			{object}	errors.Error	"Bundle not found, process not in bundle, or user not found"
+//	@Failure		401			{object}	errors.Error	"Unauthorized, invalid/unverified token, or process not in the bundle"
+//	@Failure		404			{object}	errors.Error	"Bundle not found or user not found"
 //	@Failure		500			{object}	errors.Error	"Internal server error"
 //	@Router			/process/bundle/{bundleId}/sign [post]
 func (c *CSPHandlers) BundleSignHandler(w http.ResponseWriter, r *http.Request) {
@@ -444,7 +451,7 @@ func (c *CSPHandlers) BundleSignHandler(w http.ResponseWriter, r *http.Request) 
 //
 //	@Summary		Get user weight for a bundle
 //	@Description	Get the weight of a user for a given bundle. Requires a verified token.
-//	@Tags			process
+//	@Tags			csp
 //	@Accept			json
 //	@Produce		json
 //	@Param			bundleId	path		string						true	"Bundle ID"
@@ -524,7 +531,7 @@ func (c *CSPHandlers) UserWeightHandler(w http.ResponseWriter, r *http.Request) 
 //	@Description	census. When electionId is provided, the response also reports whether the user already voted in that
 //	@Description	process. Ineligibility (unknown/unverified token, token from another bundle, not in census, zero weight
 //	@Description	on a weighted census) is reported as belongs=false with HTTP 200, not as an error.
-//	@Tags			process
+//	@Tags			csp
 //	@Accept			json
 //	@Produce		json
 //	@Param			bundleId	path		string							true	"Bundle ID"
@@ -637,7 +644,7 @@ func (c *CSPHandlers) BundleCheckHandler(w http.ResponseWriter, r *http.Request)
 //	@Description	Get the address used to sign a process. Requires a verified token. Returns the address, nullifier,
 //	@Description	and timestamp of the consumption. {processId} accepts the 24-hex ProcessID (preferred)
 //	@Description	or, for backwards compatibility, the 64-hex on-chain election id.
-//	@Tags			process
+//	@Tags			csp
 //	@Accept			json
 //	@Produce		json
 //	@Param			processId	path		string							true	"24-hex ProcessID (preferred); 64-hex on-chain id also accepted"

--- a/csp/handlers/types.go
+++ b/csp/handlers/types.go
@@ -103,7 +103,7 @@ type ConsumedAddressRequest struct {
 // It includes the address, the nullifier, and the timestamp of the
 // usage.
 type ConsumedAddressResponse struct {
-	Address   internal.HexBytes `json:"authToken" swaggertype:"string" format:"hex" example:"deadbeef"`
+	Address   internal.HexBytes `json:"address" swaggertype:"string" format:"hex" example:"deadbeef"`
 	Nullifier internal.HexBytes `json:"nullifier" swaggertype:"string" format:"hex" example:"deadbeef"`
 	At        time.Time         `json:"at"`
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1856,6 +1856,23 @@ definitions:
       subscription_status:
         type: string
     type: object
+  handlers.AuthRequest:
+    properties:
+      birthDate:
+        type: string
+      email:
+        type: string
+      memberNumber:
+        type: string
+      name:
+        type: string
+      nationalId:
+        type: string
+      phone:
+        type: string
+      surname:
+        type: string
+    type: object
   handlers.AuthResendRequest:
     properties:
       authToken:
@@ -1913,11 +1930,11 @@ definitions:
     type: object
   handlers.ConsumedAddressResponse:
     properties:
-      at:
-        type: string
-      authToken:
+      address:
         example: deadbeef
         format: hex
+        type: string
+      at:
         type: string
       nullifier:
         example: deadbeef
@@ -2251,6 +2268,8 @@ paths:
         must be provided. Supplying only authFields yields an auth-only census (members authenticate
         with their data, no OTP); twoFaFields adds an email/SMS OTP challenge. A body with both empty
         is rejected with 404 (ErrCensusTypeNotFound). Returns the published census root and URI.
+
+        Also callable with a scoped API key (scope: `voting:write`).
       parameters:
       - description: Census ID
         in: path
@@ -4338,7 +4357,7 @@ paths:
       - application/json
       responses:
         "200":
-          description: 24-hex draft ProcessID
+          description: 'Bare JSON string: 24-hex draft ProcessID, e.g. 507f1f77bcf86cd799439011'
           schema:
             type: string
         "400":
@@ -4355,10 +4374,6 @@ paths:
             $ref: '#/definitions/errors.Error'
         "404":
           description: Published census not found
-          schema:
-            $ref: '#/definitions/errors.Error'
-        "409":
-          description: Process already exists
           schema:
             $ref: '#/definitions/errors.Error'
         "500":
@@ -4670,7 +4685,7 @@ paths:
             $ref: '#/definitions/errors.Error'
       summary: Get the address used to sign a process
       tags:
-      - process
+      - csp
   /process/{processId}/status:
     put:
       consumes:
@@ -4735,6 +4750,8 @@ paths:
         Create a new process bundle with the specified census and optional list of processes. Requires
         Manager/Admin role for the organization that owns the census. The census root will be the same as the
         account's public key.
+
+        Also callable with a scoped API key (scope: `voting:write`).
       parameters:
       - description: Process bundle creation information
         in: body
@@ -4811,6 +4828,8 @@ paths:
       description: |-
         Add additional processes to an existing bundle. Requires Manager/Admin role for the organization
         that owns the bundle.
+
+        Also callable with a scoped API key (scope: `voting:write`).
       parameters:
       - description: Bundle ID
         in: path
@@ -4901,6 +4920,11 @@ paths:
         - Step 1: The user sends the token and challenge solution back to the server.
         If valid, the token is marked as verified and returned.
         For auth-only censuses, verification may not require a challenge solution.
+
+        The request body depends on the step:
+        - Step 0: handlers.AuthRequest — member identification fields (name, surname, memberNumber,
+        nationalId, birthDate, email, phone); which are required depends on the census auth configuration.
+        - Step 1: handlers.AuthChallengeRequest — { authToken, authData: [challenge solution] }.
       parameters:
       - description: Bundle ID
         in: path
@@ -4912,11 +4936,12 @@ paths:
         name: step
         required: true
         type: string
-      - description: Authentication request (varies by step)
+      - description: Step 0 body; step 1 uses AuthChallengeRequest (see description)
         in: body
         name: request
         required: true
-        schema: {}
+        schema:
+          $ref: '#/definitions/handlers.AuthRequest'
       produces:
       - application/json
       responses:
@@ -4943,7 +4968,7 @@ paths:
             $ref: '#/definitions/errors.Error'
       summary: Authenticate for a process bundle
       tags:
-      - process
+      - csp
   /process/bundle/{bundleId}/auth/resend:
     post:
       consumes:
@@ -4993,7 +5018,7 @@ paths:
             $ref: '#/definitions/errors.Error'
       summary: Resend authentication challenge for a process bundle
       tags:
-      - process
+      - csp
   /process/bundle/{bundleId}/check:
     post:
       consumes:
@@ -5038,7 +5063,7 @@ paths:
             $ref: '#/definitions/errors.Error'
       summary: Check census membership for a bundle
       tags:
-      - process
+      - csp
   /process/bundle/{bundleId}/participants/check:
     post:
       consumes:
@@ -5102,13 +5127,15 @@ paths:
         and returns the signature. Once signed, the process is marked as consumed and cannot be signed again.
         The signing process includes verifying that the participant is in the census, that the process is part of
         the bundle, and that the authentication token is valid and verified.
+
+        Body: authToken, electionId (the process/election ID) and payload (the voter address). tokenR is unused.
       parameters:
       - description: Bundle ID
         in: path
         name: bundleId
         required: true
         type: string
-      - description: Sign request with process ID, auth token, and payload (address)
+      - description: Sign request (see description for fields)
         in: body
         name: request
         required: true
@@ -5126,11 +5153,12 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
         "401":
-          description: Unauthorized, invalid token, or token not verified (ErrAuthTokenNotVerified)
+          description: Unauthorized, invalid/unverified token, or process not in the
+            bundle
           schema:
             $ref: '#/definitions/errors.Error'
         "404":
-          description: Bundle not found, process not in bundle, or user not found
+          description: Bundle not found or user not found
           schema:
             $ref: '#/definitions/errors.Error'
         "500":
@@ -5139,7 +5167,7 @@ paths:
             $ref: '#/definitions/errors.Error'
       summary: Sign a process in a bundle
       tags:
-      - process
+      - csp
   /process/bundle/{bundleId}/weight:
     post:
       consumes:
@@ -5183,7 +5211,7 @@ paths:
             $ref: '#/definitions/errors.Error'
       summary: Get user weight for a bundle
       tags:
-      - process
+      - csp
   /storage:
     post:
       consumes:


### PR DESCRIPTION
## What

Accuracy/readability pass over the Swagger annotations for the integrator + voter flow from **census creation through voting**, plus one response-shape fix surfaced during the review.

### API behaviour change (wire-visible)
- **`POST /process/{processId}/sign-info`** — the `ConsumedAddressResponse` field was mislabelled `json:"authToken"` but actually carries the **signing address**. Renamed the tag to `json:"address"`. Any client reading that field must switch `authToken` → `address`. (The struct field is unchanged, so the existing test round-trips.)

### Swagger annotations (no logic change)
**process**
- `POST /process` — removed the stale `409 "Process already exists"` (`SetProcess` is an upsert and never returns a conflict; the only 409 is in `updateProcess`), and added a concrete example to the bare-`ObjectID` success response.

**csp** (voter-facing handlers)
- `BundleAuthHandler` — documented the two step bodies (`AuthRequest` for step 0, `AuthChallengeRequest` for step 1) and gave the body param a real schema instead of `interface{}`.
- `BundleSignHandler` — moved *"process not in bundle"* from the `404` line to the `401` the handler actually returns; clarified the `SignRequest` fields (`authToken`, `electionId`, `payload`; `tokenR` unused).
- Regrouped the six voter-facing CSP handlers (`auth/{step}`, `auth/resend`, `weight`, `sign`, `check`, `sign-info`) under a new **`csp`** tag instead of the catch-all `process` tag.

**API key**
- Added the `voting:write` API-key note to the **group-census publish** and the **two process-bundle** endpoints (the create/add-participants/publish-census notes were intentionally left off).

Regenerated `docs/swagger.yaml`.

## Verification
- `golangci-lint run ./api/... ./csp/handlers/...` — clean on all changed lines (the lone pre-existing `revive` package-name finding is unrelated and not in this diff).
- `make swagger` regenerates clean; `go build ./...` passes.
- Full test suite not run (requires Docker); the only affected test (`process_read_test.go` sign-info) reads the struct field and round-trips through the new tag.