### PR TITLE
fix(subscriptions): govern managed-org limits by the integrator's plan

### DIFF
--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -651,14 +651,10 @@ type SubscriptionPlanLimits struct {
 // integrator plan.
 // swagger:model SubscriptionIntegratorLimits
 type SubscriptionIntegratorLimits struct {
-	// Maximum number of organizations the integrator may manage
+	// Maximum number of organizations the integrator may manage. The aggregate
+	// process and census-size caps across managed orgs come from the plan's
+	// top-level limits (maxProcesses / maxCensus).
 	MaxManagedOrgs int `json:"maxManagedOrgs"`
-
-	// Maximum number of voting processes across managed organizations
-	MaxManagedProcesses int `json:"maxManagedProcesses"`
-
-	// Maximum total census size across managed organizations
-	MaxManagedCensusSize int `json:"maxManagedCensusSize"`
 }
 
 // SubscriptionVotingTypes represents the voting types available in a subscription plan.

--- a/api/apikeys_api_test.go
+++ b/api/apikeys_api_test.go
@@ -25,7 +25,7 @@ func TestAPIKeysAPI(t *testing.T) {
 	// make the org an integrator (override) so the integrator endpoints are usable
 	org, err := testDB.Organization(orgAddr)
 	c.Assert(err, qt.IsNil)
-	org.IntegratorLimits = &db.IntegratorLimits{MaxManagedOrgs: 2, MaxManagedProcesses: 5, MaxManagedCensusSize: 100}
+	org.IntegratorLimits = &db.IntegratorLimits{MaxManagedOrgs: 2}
 	c.Assert(testDB.SetOrganization(org), qt.IsNil)
 
 	// create a key scoped to quota:read + managed:read
@@ -90,7 +90,7 @@ func TestIntegratorAPIKeyPathless(t *testing.T) {
 
 	org, err := testDB.Organization(orgAddr)
 	c.Assert(err, qt.IsNil)
-	org.IntegratorLimits = &db.IntegratorLimits{MaxManagedOrgs: 2, MaxManagedProcesses: 5, MaxManagedCensusSize: 100}
+	org.IntegratorLimits = &db.IntegratorLimits{MaxManagedOrgs: 2}
 	c.Assert(testDB.SetOrganization(org), qt.IsNil)
 
 	// mint a key with the integrator scopes
@@ -136,7 +136,7 @@ func TestIntegratorAPIKeyDeletesProcessDraft(t *testing.T) {
 	// make the org an integrator (override)
 	org, err := testDB.Organization(orgAddr)
 	c.Assert(err, qt.IsNil)
-	org.IntegratorLimits = &db.IntegratorLimits{MaxManagedOrgs: 2, MaxManagedProcesses: 5, MaxManagedCensusSize: 100}
+	org.IntegratorLimits = &db.IntegratorLimits{MaxManagedOrgs: 2}
 	c.Assert(testDB.SetOrganization(org), qt.IsNil)
 
 	// mint a key with the scopes needed to create a managed org and act on its processes

--- a/api/delete_managed_organization_test.go
+++ b/api/delete_managed_organization_test.go
@@ -29,9 +29,7 @@ func TestDeleteManagedOrg(t *testing.T) {
 	integratorOrg, err := testDB.Organization(integratorAddr)
 	c.Assert(err, qt.IsNil)
 	integratorOrg.IntegratorLimits = &db.IntegratorLimits{
-		MaxManagedOrgs:       1,
-		MaxManagedProcesses:  2,
-		MaxManagedCensusSize: 1000,
+		MaxManagedOrgs: 1,
 	}
 	c.Assert(testDB.SetOrganization(integratorOrg), qt.IsNil)
 

--- a/api/integrator_subscription_test.go
+++ b/api/integrator_subscription_test.go
@@ -32,9 +32,7 @@ func TestIntegratorPlanSubscription(t *testing.T) {
 		ID:   "prod_test_integrator",
 		Name: "Integrator Plan",
 		IntegratorLimits: db.IntegratorLimits{
-			MaxManagedOrgs:       maxManagedOrgs,
-			MaxManagedProcesses:  5,
-			MaxManagedCensusSize: 5000,
+			MaxManagedOrgs: maxManagedOrgs,
 		},
 	}
 	c.Assert(testDB.SetPlan(integratorPlan), qt.IsNil)

--- a/api/integrator_test.go
+++ b/api/integrator_test.go
@@ -29,16 +29,29 @@ func TestIntegratorManagedOrgs(t *testing.T) {
 	_, code := testRequest(t, http.MethodPost, token, body, "integrator", "organizations")
 	c.Assert(code, qt.Equals, http.StatusForbidden) // ErrNotAnIntegrator
 
-	// enable integrator with an override (override beats plan):
-	// MaxManagedOrgs 2, MaxManagedProcesses 1, MaxManagedCensusSize 1000
+	// enable integrator with an override (MaxManagedOrgs); the aggregate process/census
+	// caps come from the integrator's subscription plan top-level limits below.
 	integratorOrg, err := testDB.Organization(integratorAddr)
 	c.Assert(err, qt.IsNil)
-	integratorOrg.IntegratorLimits = &db.IntegratorLimits{
-		MaxManagedOrgs:       2,
-		MaxManagedProcesses:  1,
-		MaxManagedCensusSize: 1000,
-	}
+	integratorOrg.IntegratorLimits = &db.IntegratorLimits{MaxManagedOrgs: 2}
 	c.Assert(testDB.SetOrganization(integratorOrg), qt.IsNil)
+
+	// subscribe the integrator to a plan whose top-level limits bound managed publishing:
+	// MaxProcesses 1, MaxCensus 1000.
+	integratorPlan := &db.Plan{
+		ID:           "prod_test_integrator_caps",
+		Name:         "Integrator Caps",
+		Organization: db.PlanLimits{MaxProcesses: 1, MaxCensus: 1000, MaxDuration: 30},
+	}
+	c.Assert(testDB.SetPlan(integratorPlan), qt.IsNil)
+	defer func() { _ = testDB.DelPlan(&db.Plan{ID: integratorPlan.ID}) }()
+	c.Assert(testDB.SetOrganizationSubscription(integratorAddr, &db.OrganizationSubscription{
+		PlanID:          integratorPlan.ID,
+		StartDate:       time.Now(),
+		RenewalDate:     time.Now().Add(24 * time.Hour),
+		LastPaymentDate: time.Now(),
+		Active:          true,
+	}), qt.IsNil)
 
 	// create managed orgs up to the cap
 	var firstManaged common.Address
@@ -120,7 +133,7 @@ func TestIntegratorManagedOrgs(t *testing.T) {
 	c.Assert(integratorOrg.Counters.ManagedProcesses, qt.Equals, 1)
 	c.Assert(integratorOrg.Counters.ManagedCensusSize, qt.Equals, 100)
 
-	// a second publish is blocked by the aggregate quota (MaxManagedProcesses == 1)
+	// a second publish is blocked by the aggregate quota (plan MaxProcesses == 1)
 	draftID2, err := testDB.SetProcess(&db.Process{
 		OrgAddress: firstManaged,
 		ElectionParams: &db.ElectionParams{

--- a/api/process.go
+++ b/api/process.go
@@ -683,7 +683,7 @@ func (a *API) publishProcessHandler(w http.ResponseWriter, r *http.Request) {
 			errors.ErrGenericInternalServerError.Withf("could not get integrator organization: %v", err).Write(w)
 			return
 		}
-		limits, err := a.subscriptions.EffectiveIntegratorLimits(integrator)
+		maxProcesses, maxCensus, err := a.subscriptions.ManagedPublishLimits(integrator)
 		if err != nil {
 			if apiErr, ok := err.(errors.Error); ok {
 				apiErr.Write(w)
@@ -693,7 +693,7 @@ func (a *API) publishProcessHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := a.db.ReserveManagedPublish(integrator.Address,
-			limits.MaxManagedProcesses, limits.MaxManagedCensusSize, int(draft.ElectionParams.MaxCensusSize)); err != nil {
+			maxProcesses, maxCensus, int(draft.ElectionParams.MaxCensusSize)); err != nil {
 			if err == db.ErrManagedQuotaReached {
 				errors.ErrIntegratorQuotaExceeded.Write(w)
 				return

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -236,9 +236,7 @@ func TestUserInfoIsIntegrator(t *testing.T) {
 	org, err := testDB.Organization(orgAddr)
 	c.Assert(err, qt.IsNil)
 	org.IntegratorLimits = &db.IntegratorLimits{
-		MaxManagedOrgs:       1,
-		MaxManagedProcesses:  1,
-		MaxManagedCensusSize: 100,
+		MaxManagedOrgs: 1,
 	}
 	c.Assert(testDB.SetOrganization(org), qt.IsNil)
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -26,11 +26,9 @@ func main() {
 	flag.StringP("mongoURL", "m", "", "MongoDB connection URL")
 	flag.StringP("mongoDB", "d", "", "MongoDB database name")
 	flag.StringP("vocdoniAPI", "v", "https://api-dev.vocdoni.net/v2", "Vocdoni node API URL")
-	flag.Bool("setIntegrator", false, "enable the given organization as an integrator and set its limits")
+	flag.Bool("setIntegrator", false, "enable the given organization as an integrator and set its managed-org limit")
 	flag.String("orgAddress", "", "organization address (hex) for --setIntegrator")
 	flag.Int("maxManagedOrgs", 0, "integrator limit: max managed organizations")
-	flag.Int("maxManagedProcesses", 0, "integrator limit: max managed processes")
-	flag.Int("maxManagedCensusSize", 0, "integrator limit: max managed census size")
 
 	// Parse flags
 	flag.Parse()
@@ -61,7 +59,7 @@ func main() {
 		}
 		defer database.Close()
 		if err := setIntegrator(database, viper.GetString("orgAddress"),
-			viper.GetInt("maxManagedOrgs"), viper.GetInt("maxManagedProcesses"), viper.GetInt("maxManagedCensusSize")); err != nil {
+			viper.GetInt("maxManagedOrgs")); err != nil {
 			log.Fatalf("could not set integrator: %v", err)
 		}
 		return
@@ -116,8 +114,9 @@ func main() {
 }
 
 // setIntegrator enables the organization at the given address as an integrator and
-// sets its integrator-limits override.
-func setIntegrator(database *db.MongoStorage, orgAddress string, maxOrgs, maxProcesses, maxCensus int) error {
+// sets its managed-org limit override. The aggregate process/census caps come from the
+// integrator's subscription plan (Plan.Organization.MaxProcesses / MaxCensus).
+func setIntegrator(database *db.MongoStorage, orgAddress string, maxOrgs int) error {
 	if orgAddress == "" {
 		return fmt.Errorf("orgAddress is required")
 	}
@@ -130,20 +129,16 @@ func setIntegrator(database *db.MongoStorage, orgAddress string, maxOrgs, maxPro
 		return fmt.Errorf("could not get organization: %w", err)
 	}
 	// Setting a per-organization limits override both enables integrator status and
-	// caps its managed resources (see Subscriptions.IsIntegrator).
+	// caps how many organizations it may manage (see Subscriptions.IsIntegrator).
 	org.IntegratorLimits = &db.IntegratorLimits{
-		MaxManagedOrgs:       maxOrgs,
-		MaxManagedProcesses:  maxProcesses,
-		MaxManagedCensusSize: maxCensus,
+		MaxManagedOrgs: maxOrgs,
 	}
 	if err := database.SetOrganization(org); err != nil {
 		return fmt.Errorf("could not update organization: %w", err)
 	}
 	log.Infow("organization is now an integrator",
 		"address", addr.Hex(),
-		"maxManagedOrgs", maxOrgs,
-		"maxManagedProcesses", maxProcesses,
-		"maxManagedCensusSize", maxCensus)
+		"maxManagedOrgs", maxOrgs)
 	return nil
 }
 

--- a/db/managed_org_limits_test.go
+++ b/db/managed_org_limits_test.go
@@ -1,0 +1,76 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	qt "github.com/frankban/quicktest"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// TestManagedOrgAggregates exercises the live integrator shared-pool readers against real
+// Mongo: members and 2FA sends are summed across the integrator's managed orgs only, and an
+// integrator with no managed orgs reads as zero rather than erroring.
+func TestManagedOrgAggregates(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	integrator := common.Address{0xA0}
+	managed1 := common.Address{0xA1}
+	managed2 := common.Address{0xA2}
+	other := common.Address{0xB0} // unrelated standalone org — must be excluded
+
+	c.Assert(testDB.SetOrganization(&Organization{Address: integrator, Country: "ES"}), qt.IsNil)
+	c.Assert(testDB.SetOrganization(&Organization{Address: managed1, ManagedBy: integrator, Country: "ES"}), qt.IsNil)
+	c.Assert(testDB.SetOrganization(&Organization{Address: managed2, ManagedBy: integrator, Country: "ES"}), qt.IsNil)
+	c.Assert(testDB.SetOrganization(&Organization{Address: other, Country: "ES"}), qt.IsNil)
+
+	addMember := func(addr common.Address, suffix string) {
+		_, err := testDB.SetOrgMember("test_salt", &OrgMember{
+			ID:           primitive.NewObjectID(),
+			OrgAddress:   addr,
+			MemberNumber: "mn-" + suffix,
+			Email:        "m-" + suffix + "@x.test",
+			CreatedAt:    time.Now(),
+			UpdatedAt:    time.Now(),
+		})
+		c.Assert(err, qt.IsNil)
+	}
+	// 2 members in managed1, 1 in managed2, 3 in the unrelated org.
+	addMember(managed1, "1a")
+	addMember(managed1, "1b")
+	addMember(managed2, "2a")
+	addMember(other, "o1")
+	addMember(other, "o2")
+	addMember(other, "o3")
+
+	incN := func(fn func(common.Address) error, addr common.Address, n int) {
+		for range n {
+			c.Assert(fn(addr), qt.IsNil)
+		}
+	}
+	// 2FA sends: managed1 = 3 sms + 5 emails, managed2 = 2 sms + 1 email, other = 9 sms.
+	incN(testDB.IncrementOrganizationSentSMSCounter, managed1, 3)
+	incN(testDB.IncrementOrganizationSentEmailsCounter, managed1, 5)
+	incN(testDB.IncrementOrganizationSentSMSCounter, managed2, 2)
+	incN(testDB.IncrementOrganizationSentEmailsCounter, managed2, 1)
+	incN(testDB.IncrementOrganizationSentSMSCounter, other, 9)
+
+	members, err := testDB.CountMembersManagedBy(integrator)
+	c.Assert(err, qt.IsNil)
+	c.Assert(members, qt.Equals, int64(3)) // 2 + 1, the unrelated org's 3 are excluded
+
+	sms, err := testDB.SumSentSMSManagedBy(integrator)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sms, qt.Equals, 5) // 3 + 2, the unrelated org's 9 are excluded
+
+	emails, err := testDB.SumSentEmailsManagedBy(integrator)
+	c.Assert(err, qt.IsNil)
+	c.Assert(emails, qt.Equals, 6) // 5 + 1
+
+	// an integrator with no managed orgs reads as zero, not an error
+	none, err := testDB.CountMembersManagedBy(other)
+	c.Assert(err, qt.IsNil)
+	c.Assert(none, qt.Equals, int64(0))
+}

--- a/db/organizations.go
+++ b/db/organizations.go
@@ -516,6 +516,9 @@ func (ms *MongoStorage) managedOrgAddresses(ctx context.Context, integratorAddr 
 // across all organizations managed by integratorAddr, computed server-side so only the
 // total crosses the wire.
 func (ms *MongoStorage) sumManagedCounter(integratorAddr common.Address, field string) (int, error) {
+	if integratorAddr.Cmp(common.Address{}) == 0 {
+		return 0, ErrInvalidData
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 

--- a/db/organizations.go
+++ b/db/organizations.go
@@ -487,6 +487,84 @@ func (ms *MongoStorage) ListManagedOrganizations(
 	return paginatedDocuments[Organization](ms.organizations, page, limit, filter, options.Find())
 }
 
+// managedOrgsProjected returns the organizations managed by integratorAddr, projected
+// to just their address and counters. It backs the integrator shared-pool aggregates
+// (members, 2FA sends) computed live across all of an integrator's managed orgs.
+func (ms *MongoStorage) managedOrgsProjected(ctx context.Context, integratorAddr common.Address) ([]Organization, error) {
+	if integratorAddr.Cmp(common.Address{}) == 0 {
+		return nil, ErrInvalidData
+	}
+	filter := bson.M{"managedBy": integratorAddr}
+	opts := options.Find().SetProjection(bson.M{"_id": 1, "counters": 1})
+	cursor, err := ms.organizations.Find(ctx, filter, opts)
+	if err != nil {
+		return nil, fmt.Errorf("could not list managed organizations: %w", err)
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	var orgs []Organization
+	if err := cursor.All(ctx, &orgs); err != nil {
+		return nil, fmt.Errorf("could not decode managed organizations: %w", err)
+	}
+	return orgs, nil
+}
+
+// CountMembersManagedBy returns the total org-member count across all organizations
+// managed by integratorAddr. It is the shared-pool denominator for the member limit
+// of an integrator's managed orgs.
+func (ms *MongoStorage) CountMembersManagedBy(integratorAddr common.Address) (int64, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	orgs, err := ms.managedOrgsProjected(ctx, integratorAddr)
+	if err != nil {
+		return 0, err
+	}
+	var total int64
+	for i := range orgs {
+		n, err := ms.CountOrgMembers(orgs[i].Address)
+		if err != nil {
+			return 0, err
+		}
+		total += n
+	}
+	return total, nil
+}
+
+// SumSentEmailsManagedBy returns the total 2FA emails sent across all organizations
+// managed by integratorAddr (the integrator's shared 2FA-email pool consumption).
+func (ms *MongoStorage) SumSentEmailsManagedBy(integratorAddr common.Address) (int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	orgs, err := ms.managedOrgsProjected(ctx, integratorAddr)
+	if err != nil {
+		return 0, err
+	}
+	total := 0
+	for i := range orgs {
+		total += orgs[i].Counters.SentEmails
+	}
+	return total, nil
+}
+
+// SumSentSMSManagedBy returns the total 2FA SMS sent across all organizations managed
+// by integratorAddr (the integrator's shared 2FA-SMS pool consumption).
+func (ms *MongoStorage) SumSentSMSManagedBy(integratorAddr common.Address) (int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	orgs, err := ms.managedOrgsProjected(ctx, integratorAddr)
+	if err != nil {
+		return 0, err
+	}
+	total := 0
+	for i := range orgs {
+		total += orgs[i].Counters.SentSMS
+	}
+	return total, nil
+}
+
 func (ms *MongoStorage) fetchOrganizationAndPlan(orgAddress common.Address) (*Organization, *Plan, error) {
 	org, err := ms.Organization(orgAddress)
 	if err != nil {

--- a/db/organizations.go
+++ b/db/organizations.go
@@ -487,15 +487,14 @@ func (ms *MongoStorage) ListManagedOrganizations(
 	return paginatedDocuments[Organization](ms.organizations, page, limit, filter, options.Find())
 }
 
-// managedOrgsProjected returns the organizations managed by integratorAddr, projected
-// to just their address and counters. It backs the integrator shared-pool aggregates
-// (members, 2FA sends) computed live across all of an integrator's managed orgs.
-func (ms *MongoStorage) managedOrgsProjected(ctx context.Context, integratorAddr common.Address) ([]Organization, error) {
+// managedOrgAddresses returns the addresses of all organizations managed by
+// integratorAddr, projected to just their _id to keep the read lightweight.
+func (ms *MongoStorage) managedOrgAddresses(ctx context.Context, integratorAddr common.Address) ([]common.Address, error) {
 	if integratorAddr.Cmp(common.Address{}) == 0 {
 		return nil, ErrInvalidData
 	}
 	filter := bson.M{"managedBy": integratorAddr}
-	opts := options.Find().SetProjection(bson.M{"_id": 1, "counters": 1})
+	opts := options.Find().SetProjection(bson.M{"_id": 1})
 	cursor, err := ms.organizations.Find(ctx, filter, opts)
 	if err != nil {
 		return nil, fmt.Errorf("could not list managed organizations: %w", err)
@@ -506,7 +505,40 @@ func (ms *MongoStorage) managedOrgsProjected(ctx context.Context, integratorAddr
 	if err := cursor.All(ctx, &orgs); err != nil {
 		return nil, fmt.Errorf("could not decode managed organizations: %w", err)
 	}
-	return orgs, nil
+	addrs := make([]common.Address, len(orgs))
+	for i := range orgs {
+		addrs[i] = orgs[i].Address
+	}
+	return addrs, nil
+}
+
+// sumManagedCounter returns the sum of the given counters subfield (e.g. "sentEmails")
+// across all organizations managed by integratorAddr, computed server-side so only the
+// total crosses the wire.
+func (ms *MongoStorage) sumManagedCounter(integratorAddr common.Address, field string) (int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	pipeline := mongo.Pipeline{
+		{{Key: "$match", Value: bson.M{"managedBy": integratorAddr}}},
+		{{Key: "$group", Value: bson.M{"_id": nil, "total": bson.M{"$sum": "$counters." + field}}}},
+	}
+	cursor, err := ms.organizations.Aggregate(ctx, pipeline)
+	if err != nil {
+		return 0, fmt.Errorf("could not aggregate managed counter %q: %w", field, err)
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	var results []struct {
+		Total int `bson:"total"`
+	}
+	if err := cursor.All(ctx, &results); err != nil {
+		return 0, fmt.Errorf("could not decode managed counter %q: %w", field, err)
+	}
+	if len(results) == 0 {
+		return 0, nil
+	}
+	return results[0].Total, nil
 }
 
 // CountMembersManagedBy returns the total org-member count across all organizations
@@ -516,16 +548,12 @@ func (ms *MongoStorage) CountMembersManagedBy(integratorAddr common.Address) (in
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
-	orgs, err := ms.managedOrgsProjected(ctx, integratorAddr)
+	addrs, err := ms.managedOrgAddresses(ctx, integratorAddr)
 	if err != nil {
 		return 0, err
 	}
-	if len(orgs) == 0 {
+	if len(addrs) == 0 {
 		return 0, nil
-	}
-	addrs := make([]common.Address, len(orgs))
-	for i := range orgs {
-		addrs[i] = orgs[i].Address
 	}
 	// single query over all managed orgs rather than one CountOrgMembers per org
 	return ms.orgMembers.CountDocuments(ctx, bson.M{"orgAddress": bson.M{"$in": addrs}}) //nolint:goconst
@@ -534,35 +562,13 @@ func (ms *MongoStorage) CountMembersManagedBy(integratorAddr common.Address) (in
 // SumSentEmailsManagedBy returns the total 2FA emails sent across all organizations
 // managed by integratorAddr (the integrator's shared 2FA-email pool consumption).
 func (ms *MongoStorage) SumSentEmailsManagedBy(integratorAddr common.Address) (int, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-	defer cancel()
-
-	orgs, err := ms.managedOrgsProjected(ctx, integratorAddr)
-	if err != nil {
-		return 0, err
-	}
-	total := 0
-	for i := range orgs {
-		total += orgs[i].Counters.SentEmails
-	}
-	return total, nil
+	return ms.sumManagedCounter(integratorAddr, "sentEmails")
 }
 
 // SumSentSMSManagedBy returns the total 2FA SMS sent across all organizations managed
 // by integratorAddr (the integrator's shared 2FA-SMS pool consumption).
 func (ms *MongoStorage) SumSentSMSManagedBy(integratorAddr common.Address) (int, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-	defer cancel()
-
-	orgs, err := ms.managedOrgsProjected(ctx, integratorAddr)
-	if err != nil {
-		return 0, err
-	}
-	total := 0
-	for i := range orgs {
-		total += orgs[i].Counters.SentSMS
-	}
-	return total, nil
+	return ms.sumManagedCounter(integratorAddr, "sentSMS")
 }
 
 func (ms *MongoStorage) fetchOrganizationAndPlan(orgAddress common.Address) (*Organization, *Plan, error) {

--- a/db/organizations.go
+++ b/db/organizations.go
@@ -520,15 +520,15 @@ func (ms *MongoStorage) CountMembersManagedBy(integratorAddr common.Address) (in
 	if err != nil {
 		return 0, err
 	}
-	var total int64
-	for i := range orgs {
-		n, err := ms.CountOrgMembers(orgs[i].Address)
-		if err != nil {
-			return 0, err
-		}
-		total += n
+	if len(orgs) == 0 {
+		return 0, nil
 	}
-	return total, nil
+	addrs := make([]common.Address, len(orgs))
+	for i := range orgs {
+		addrs[i] = orgs[i].Address
+	}
+	// single query over all managed orgs rather than one CountOrgMembers per org
+	return ms.orgMembers.CountDocuments(ctx, bson.M{"orgAddress": bson.M{"$in": addrs}}) //nolint:goconst
 }
 
 // SumSentEmailsManagedBy returns the total 2FA emails sent across all organizations

--- a/db/plans_test.go
+++ b/db/plans_test.go
@@ -80,7 +80,7 @@ func TestPlans(t *testing.T) {
 		c.Assert(testDB.SetPlan(&Plan{
 			ID:               "prod_free_integrator",
 			Name:             "Free Integrator",
-			IntegratorLimits: IntegratorLimits{MaxManagedOrgs: 1, MaxManagedProcesses: 5, MaxManagedCensusSize: 100},
+			IntegratorLimits: IntegratorLimits{MaxManagedOrgs: 1},
 		}), qt.IsNil)
 
 		plan, err := testDB.FreeIntegratorPlan()

--- a/db/types.go
+++ b/db/types.go
@@ -99,12 +99,12 @@ type Organization struct {
 	IntegratorLimits *IntegratorLimits `json:"integratorLimits,omitempty" bson:"integratorLimits,omitempty"`
 }
 
-// IntegratorLimits caps the resources an integrator organization may consume
-// across the organizations it manages.
+// IntegratorLimits caps how many organizations an integrator may manage. The
+// aggregate process and census-size caps across those managed orgs are taken from
+// the integrator's plan top-level limits (Plan.Organization.MaxProcesses /
+// MaxCensus), not duplicated here.
 type IntegratorLimits struct {
-	MaxManagedOrgs       int `json:"maxManagedOrgs" bson:"maxManagedOrgs"`
-	MaxManagedProcesses  int `json:"maxManagedProcesses" bson:"maxManagedProcesses"`
-	MaxManagedCensusSize int `json:"maxManagedCensusSize" bson:"maxManagedCensusSize"`
+	MaxManagedOrgs int `json:"maxManagedOrgs" bson:"maxManagedOrgs"`
 }
 
 type PlanLimits struct {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1245,14 +1245,11 @@ definitions:
     type: object
   apicommon.SubscriptionIntegratorLimits:
     properties:
-      maxManagedCensusSize:
-        description: Maximum total census size across managed organizations
-        type: integer
       maxManagedOrgs:
-        description: Maximum number of organizations the integrator may manage
-        type: integer
-      maxManagedProcesses:
-        description: Maximum number of voting processes across managed organizations
+        description: |-
+          Maximum number of organizations the integrator may manage. The aggregate
+          process and census-size caps across managed orgs come from the plan's
+          top-level limits (maxProcesses / maxCensus).
         type: integer
     type: object
   apicommon.SubscriptionPlan:
@@ -1654,11 +1651,7 @@ definitions:
     type: object
   db.IntegratorLimits:
     properties:
-      maxManagedCensusSize:
-        type: integer
       maxManagedOrgs:
-        type: integer
-      maxManagedProcesses:
         type: integer
     type: object
   db.JobResult:

--- a/stripe/service_test.go
+++ b/stripe/service_test.go
@@ -27,7 +27,7 @@ func TestProcessProductToPlanIntegratorLimits(t *testing.T) {
 
 	t.Run("parses integrator limits when present", func(_ *testing.T) {
 		md := baseMetadata()
-		md["integratorLimits"] = `{"maxManagedOrgs":3,"maxManagedProcesses":30,"maxManagedCensusSize":300}`
+		md["integratorLimits"] = `{"maxManagedOrgs":3}`
 		product := &stripeapi.Product{
 			ID:           "prod_integrator",
 			Name:         "Integrator",
@@ -38,8 +38,6 @@ func TestProcessProductToPlanIntegratorLimits(t *testing.T) {
 		plan, err := processProductToPlan(product, testPrices())
 		c.Assert(err, qt.IsNil)
 		c.Assert(plan.IntegratorLimits.MaxManagedOrgs, qt.Equals, 3)
-		c.Assert(plan.IntegratorLimits.MaxManagedProcesses, qt.Equals, 30)
-		c.Assert(plan.IntegratorLimits.MaxManagedCensusSize, qt.Equals, 300)
 	})
 
 	t.Run("leaves zero limits when metadata is absent", func(_ *testing.T) {
@@ -53,8 +51,6 @@ func TestProcessProductToPlanIntegratorLimits(t *testing.T) {
 		plan, err := processProductToPlan(product, testPrices())
 		c.Assert(err, qt.IsNil)
 		c.Assert(plan.IntegratorLimits.MaxManagedOrgs, qt.Equals, 0)
-		c.Assert(plan.IntegratorLimits.MaxManagedProcesses, qt.Equals, 0)
-		c.Assert(plan.IntegratorLimits.MaxManagedCensusSize, qt.Equals, 0)
 	})
 
 	t.Run("errors on malformed integrator limits", func(_ *testing.T) {

--- a/subscriptions/subscriptions.go
+++ b/subscriptions/subscriptions.go
@@ -287,7 +287,7 @@ func (p *Subscriptions) OrgCanAddNMembers(orgAddress common.Address, memberNumbe
 		return errors.ErrGenericInternalServerError.WithErr(err)
 	}
 
-	if int(count)+memberNumber > plan.Organization.MaxCensus {
+	if count+int64(memberNumber) > int64(plan.Organization.MaxCensus) {
 		return errors.ErrExceedsOrganizationMembersLimit.Withf("(%d)", plan.Organization.MaxCensus)
 	}
 	return nil
@@ -349,13 +349,10 @@ func (p *Subscriptions) OrgCanAddCensusParticipants(orgAddress common.Address, c
 		return errors.ErrOrganizationNotFound.WithErr(err)
 	}
 
-	// For a managed org, census size is governed by the integrator's aggregate
-	// ManagedCensusSize quota (ReserveManagedPublish) at publish time, so the per-org
-	// census-size limit is not enforced here.
-	if managed(org) {
-		return nil
-	}
-
+	// Per-census size is bounded by the governing plan's MaxCensus: the integrator's plan
+	// for a managed org, otherwise the org's own. This keeps the participant-add path
+	// bounded (the integrator-wide ManagedCensusSize total is additionally reserved at
+	// publish) rather than relying on the publish-time check alone.
 	_, plan, err := p.limitsOwner(org)
 	if err != nil {
 		return err
@@ -366,7 +363,7 @@ func (p *Subscriptions) OrgCanAddCensusParticipants(orgAddress common.Address, c
 		return errors.ErrGenericInternalServerError.WithErr(err)
 	}
 
-	if int(count)+participantsCount > plan.Organization.MaxCensus {
+	if count+int64(participantsCount) > int64(plan.Organization.MaxCensus) {
 		return errors.ErrProcessCensusSizeExceedsPlanLimit.Withf("(%d)", plan.Organization.MaxCensus)
 	}
 	return nil

--- a/subscriptions/subscriptions.go
+++ b/subscriptions/subscriptions.go
@@ -325,26 +325,31 @@ func (p *Subscriptions) OrgCanPublishGroupCensus(census *db.Census, groupID stri
 		memberCount = int(count)
 	}
 
-	// For a managed org the 2FA allowance is a shared pool: consumption is summed across
-	// all of the integrator's managed orgs. For a standalone org it is the org's own
-	// sent counters.
-	sentEmails, sentSMS := org.Counters.SentEmails, org.Counters.SentSMS
-	if managed(org) {
-		if sentEmails, err = p.db.SumSentEmailsManagedBy(owner.Address); err != nil {
-			return errors.ErrGenericInternalServerError.WithErr(err)
+	// Only check (and, for managed orgs, aggregate) the 2FA channels the census actually
+	// requests. For a managed org the allowance is a shared pool summed across all of the
+	// integrator's managed orgs; for a standalone org it is the org's own sent counter.
+	if census.TwoFaFields.Contains(db.OrgMemberTwoFaFieldEmail) {
+		sentEmails := org.Counters.SentEmails
+		if managed(org) {
+			if sentEmails, err = p.db.SumSentEmailsManagedBy(owner.Address); err != nil {
+				return errors.ErrGenericInternalServerError.WithErr(err)
+			}
 		}
-		if sentSMS, err = p.db.SumSentSMSManagedBy(owner.Address); err != nil {
-			return errors.ErrGenericInternalServerError.WithErr(err)
+		if remainingEmails := max(0, plan.Features.TwoFaEmail-sentEmails); memberCount > remainingEmails {
+			return errors.ErrProcessCensusSizeExceedsEmailAllowance.Withf("remaining emails: %d", remainingEmails)
 		}
 	}
 
-	remainingEmails := max(0, plan.Features.TwoFaEmail-sentEmails)
-	if census.TwoFaFields.Contains(db.OrgMemberTwoFaFieldEmail) && memberCount > remainingEmails {
-		return errors.ErrProcessCensusSizeExceedsEmailAllowance.Withf("remaining emails: %d", remainingEmails)
-	}
-	remainingSMS := max(0, plan.Features.TwoFaSms-sentSMS)
-	if census.TwoFaFields.Contains(db.OrgMemberTwoFaFieldPhone) && memberCount > remainingSMS {
-		return errors.ErrProcessCensusSizeExceedsSMSAllowance.Withf("remaining sms: %d", remainingSMS)
+	if census.TwoFaFields.Contains(db.OrgMemberTwoFaFieldPhone) {
+		sentSMS := org.Counters.SentSMS
+		if managed(org) {
+			if sentSMS, err = p.db.SumSentSMSManagedBy(owner.Address); err != nil {
+				return errors.ErrGenericInternalServerError.WithErr(err)
+			}
+		}
+		if remainingSMS := max(0, plan.Features.TwoFaSms-sentSMS); memberCount > remainingSMS {
+			return errors.ErrProcessCensusSizeExceedsSMSAllowance.Withf("remaining sms: %d", remainingSMS)
+		}
 	}
 
 	return nil

--- a/subscriptions/subscriptions.go
+++ b/subscriptions/subscriptions.go
@@ -441,21 +441,38 @@ func (p *Subscriptions) CanCreateManagedOrg(integrator *db.Organization) error {
 	return nil
 }
 
+// ManagedPublishLimits returns the integrator's aggregate caps for publishing under its
+// managed organizations: the integrator plan's top-level process and census-size limits.
+// These bound the ManagedProcesses / ManagedCensusSize counters across all managed orgs.
+func (p *Subscriptions) ManagedPublishLimits(integrator *db.Organization) (maxProcesses, maxCensus int, err error) {
+	if !p.IsIntegrator(integrator) {
+		return 0, 0, errors.ErrNotAnIntegrator
+	}
+	if integrator.Subscription.PlanID == "" {
+		return 0, 0, errors.ErrPlanNotFound.With("integrator has no subscription plan")
+	}
+	plan, err := p.db.Plan(integrator.Subscription.PlanID)
+	if err != nil {
+		if stderrors.Is(err, db.ErrNotFound) {
+			return 0, 0, errors.ErrPlanNotFound.WithErr(err)
+		}
+		return 0, 0, errors.ErrGenericInternalServerError.WithErr(err)
+	}
+	return plan.Organization.MaxProcesses, plan.Organization.MaxCensus, nil
+}
+
 // CanPublishForManagedOrg checks the integrator's aggregate process/census quota
 // before publishing an election (with the given census size) under a managed org.
 func (p *Subscriptions) CanPublishForManagedOrg(integrator *db.Organization, censusSize int) error {
-	if !p.IsIntegrator(integrator) {
-		return errors.ErrNotAnIntegrator
-	}
-	limits, err := p.EffectiveIntegratorLimits(integrator)
+	maxProcesses, maxCensus, err := p.ManagedPublishLimits(integrator)
 	if err != nil {
 		return err
 	}
-	if integrator.Counters.ManagedProcesses >= limits.MaxManagedProcesses {
-		return errors.ErrIntegratorQuotaExceeded.Withf("max managed processes %d", limits.MaxManagedProcesses)
+	if integrator.Counters.ManagedProcesses >= maxProcesses {
+		return errors.ErrIntegratorQuotaExceeded.Withf("max managed processes %d", maxProcesses)
 	}
-	if integrator.Counters.ManagedCensusSize+censusSize > limits.MaxManagedCensusSize {
-		return errors.ErrIntegratorQuotaExceeded.Withf("max managed census size %d", limits.MaxManagedCensusSize)
+	if integrator.Counters.ManagedCensusSize+censusSize > maxCensus {
+		return errors.ErrIntegratorQuotaExceeded.Withf("max managed census size %d", maxCensus)
 	}
 	return nil
 }

--- a/subscriptions/subscriptions.go
+++ b/subscriptions/subscriptions.go
@@ -3,6 +3,7 @@
 package subscriptions
 
 import (
+	stderrors "errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -131,7 +132,10 @@ func (p *Subscriptions) limitsOwner(org *db.Organization) (*db.Organization, *db
 	if managed(org) {
 		integrator, err := p.db.Organization(org.ManagedBy)
 		if err != nil {
-			return nil, nil, errors.ErrOrganizationNotFound.WithErr(err)
+			if stderrors.Is(err, db.ErrNotFound) {
+				return nil, nil, errors.ErrOrganizationNotFound.WithErr(err)
+			}
+			return nil, nil, errors.ErrGenericInternalServerError.WithErr(err)
 		}
 		owner = integrator
 	}
@@ -140,7 +144,10 @@ func (p *Subscriptions) limitsOwner(org *db.Organization) (*db.Organization, *db
 	}
 	plan, err := p.db.Plan(owner.Subscription.PlanID)
 	if err != nil {
-		return nil, nil, errors.ErrPlanNotFound.WithErr(err)
+		if stderrors.Is(err, db.ErrNotFound) {
+			return nil, nil, errors.ErrPlanNotFound.WithErr(err)
+		}
+		return nil, nil, errors.ErrGenericInternalServerError.WithErr(err)
 	}
 	return owner, plan, nil
 }
@@ -331,11 +338,11 @@ func (p *Subscriptions) OrgCanPublishGroupCensus(census *db.Census, groupID stri
 		}
 	}
 
-	remainingEmails := plan.Features.TwoFaEmail - sentEmails
+	remainingEmails := max(0, plan.Features.TwoFaEmail-sentEmails)
 	if census.TwoFaFields.Contains(db.OrgMemberTwoFaFieldEmail) && memberCount > remainingEmails {
 		return errors.ErrProcessCensusSizeExceedsEmailAllowance.Withf("remaining emails: %d", remainingEmails)
 	}
-	remainingSMS := plan.Features.TwoFaSms - sentSMS
+	remainingSMS := max(0, plan.Features.TwoFaSms-sentSMS)
 	if census.TwoFaFields.Contains(db.OrgMemberTwoFaFieldPhone) && memberCount > remainingSMS {
 		return errors.ErrProcessCensusSizeExceedsSMSAllowance.Withf("remaining sms: %d", remainingSMS)
 	}

--- a/subscriptions/subscriptions.go
+++ b/subscriptions/subscriptions.go
@@ -61,6 +61,9 @@ type DBInterface interface {
 	OrganizationWithParent(address common.Address) (*db.Organization, *db.Organization, error)
 	CountCensusParticipants(censusID string) (int64, error)
 	CountOrgMembers(orgAddress common.Address) (int64, error)
+	CountMembersManagedBy(integratorAddr common.Address) (int64, error)
+	SumSentEmailsManagedBy(integratorAddr common.Address) (int, error)
+	SumSentSMSManagedBy(integratorAddr common.Address) (int, error)
 	CountProcesses(orgAddress common.Address, draft db.DraftFilter) (int64, error)
 	OrganizationMemberGroup(groupID string, orgAddress common.Address) (*db.OrganizationMemberGroup, error)
 }
@@ -110,6 +113,38 @@ func hasElectionMetadataPermissions(process *models.NewProcessTx, plan *db.Plan)
 	return true, nil
 }
 
+// managed reports whether org is a managed organization (created and owned by an integrator).
+func managed(org *db.Organization) bool {
+	return org != nil && org.ManagedBy != (common.Address{})
+}
+
+// limitsOwner returns the organization whose subscription plan governs usage limits for
+// org, together with that plan. For a managed organization the owner is its integrator
+// (org.ManagedBy); otherwise it is org itself. It fails closed if a managed org's
+// integrator cannot be resolved or has no plan — there is no silent fallback to the
+// managed org's own (throwaway default) plan.
+func (p *Subscriptions) limitsOwner(org *db.Organization) (*db.Organization, *db.Plan, error) {
+	if org == nil {
+		return nil, nil, errors.ErrInvalidData.With("organization is nil")
+	}
+	owner := org
+	if managed(org) {
+		integrator, err := p.db.Organization(org.ManagedBy)
+		if err != nil {
+			return nil, nil, errors.ErrOrganizationNotFound.WithErr(err)
+		}
+		owner = integrator
+	}
+	if owner.Subscription.PlanID == "" {
+		return nil, nil, errors.ErrOrganizationHasNoSubscription
+	}
+	plan, err := p.db.Plan(owner.Subscription.PlanID)
+	if err != nil {
+		return nil, nil, errors.ErrPlanNotFound.WithErr(err)
+	}
+	return owner, plan, nil
+}
+
 // HasTxPermission checks if the organization has permission to perform the given transaction.
 func (p *Subscriptions) HasTxPermission(
 	tx *models.Tx,
@@ -121,14 +156,11 @@ func (p *Subscriptions) HasTxPermission(
 		return false, errors.ErrInvalidData.With("organization is nil")
 	}
 
-	// Check if the organization has a subscription
-	if org.Subscription.PlanID == "" {
-		return false, errors.ErrOrganizationHasNoSubscription
-	}
-
-	plan, err := p.db.Plan(org.Subscription.PlanID)
+	// Resolve the plan that governs this org's limits: the integrator's plan for a
+	// managed org, otherwise the org's own plan.
+	_, plan, err := p.limitsOwner(org)
 	if err != nil {
-		return false, errors.ErrPlanNotFound.WithErr(err)
+		return false, err
 	}
 
 	switch txType {
@@ -145,13 +177,19 @@ func (p *Subscriptions) HasTxPermission(
 			return false, errors.ErrUserHasNoAdminRole
 		}
 		newProcess := tx.GetNewProcess()
-		if newProcess.Process.MaxCensusSize > uint64(plan.Organization.MaxCensus) {
-			return false, errors.ErrProcessCensusSizeExceedsPlanLimit.Withf("plan max census: %d", plan.Organization.MaxCensus)
-		}
-		if org.Counters.Processes >= plan.Organization.MaxProcesses {
-			// allow processes with less than TestMaxCensusSize for user testing
-			if newProcess.Process.MaxCensusSize > uint64(db.TestMaxCensusSize) {
-				return false, errors.ErrMaxProcessesReached
+		// For managed orgs the census-size and process-count limits are enforced against
+		// the integrator's aggregate quota (ReserveManagedPublish) at publish time, so the
+		// per-org plan checks are skipped here. Capability/duration checks below still apply,
+		// using the integrator's plan.
+		if !managed(org) {
+			if newProcess.Process.MaxCensusSize > uint64(plan.Organization.MaxCensus) {
+				return false, errors.ErrProcessCensusSizeExceedsPlanLimit.Withf("plan max census: %d", plan.Organization.MaxCensus)
+			}
+			if org.Counters.Processes >= plan.Organization.MaxProcesses {
+				// allow processes with less than TestMaxCensusSize for user testing
+				if newProcess.Process.MaxCensusSize > uint64(db.TestMaxCensusSize) {
+					return false, errors.ErrMaxProcessesReached
+				}
 			}
 		}
 		return hasElectionMetadataPermissions(newProcess, plan)
@@ -205,13 +243,11 @@ func (p *Subscriptions) OrgHasPermission(orgAddress common.Address, permission D
 			return errors.ErrOrganizationNotFound.WithErr(err)
 		}
 
-		if org.Subscription.PlanID == "" {
-			return errors.ErrOrganizationHasNoSubscription.With("can't create draft process")
-		}
-
-		plan, err := p.db.Plan(org.Subscription.PlanID)
+		// MaxDrafts value comes from the integrator's plan for managed orgs; the draft
+		// count itself stays per-org.
+		_, plan, err := p.limitsOwner(org)
 		if err != nil {
-			return errors.ErrGenericInternalServerError.WithErr(err)
+			return err
 		}
 
 		count, err := p.db.CountProcesses(orgAddress, db.DraftOnly)
@@ -229,22 +265,24 @@ func (p *Subscriptions) OrgHasPermission(orgAddress common.Address, permission D
 }
 
 func (p *Subscriptions) OrgCanAddNMembers(orgAddress common.Address, memberNumber int) error {
-	// Check if the organization has a subscription
 	org, err := p.db.Organization(orgAddress)
 	if err != nil {
 		return errors.ErrOrganizationNotFound.WithErr(err)
 	}
 
-	if org.Subscription.PlanID == "" {
-		return errors.ErrOrganizationHasNoSubscription.With("can't create draft process")
-	}
-
-	plan, err := p.db.Plan(org.Subscription.PlanID)
+	owner, plan, err := p.limitsOwner(org)
 	if err != nil {
-		return errors.ErrGenericInternalServerError.WithErr(err)
+		return err
 	}
 
-	count, err := p.db.CountOrgMembers(orgAddress)
+	// For a managed org the member limit is a shared pool across all of the integrator's
+	// managed orgs; for a standalone org it is just the org's own members.
+	var count int64
+	if managed(org) {
+		count, err = p.db.CountMembersManagedBy(owner.Address)
+	} else {
+		count, err = p.db.CountOrgMembers(orgAddress)
+	}
 	if err != nil {
 		return errors.ErrGenericInternalServerError.WithErr(err)
 	}
@@ -261,13 +299,9 @@ func (p *Subscriptions) OrgCanPublishGroupCensus(census *db.Census, groupID stri
 		return errors.ErrOrganizationNotFound.WithErr(err)
 	}
 
-	if org.Subscription.PlanID == "" {
-		return errors.ErrOrganizationHasNoSubscription
-	}
-
-	plan, err := p.db.Plan(org.Subscription.PlanID)
+	owner, plan, err := p.limitsOwner(org)
 	if err != nil {
-		return errors.ErrPlanNotFound.WithErr(err)
+		return err
 	}
 
 	group, err := p.db.OrganizationMemberGroup(groupID, org.Address)
@@ -284,11 +318,24 @@ func (p *Subscriptions) OrgCanPublishGroupCensus(census *db.Census, groupID stri
 		memberCount = int(count)
 	}
 
-	remainingEmails := plan.Features.TwoFaEmail - org.Counters.SentEmails
+	// For a managed org the 2FA allowance is a shared pool: consumption is summed across
+	// all of the integrator's managed orgs. For a standalone org it is the org's own
+	// sent counters.
+	sentEmails, sentSMS := org.Counters.SentEmails, org.Counters.SentSMS
+	if managed(org) {
+		if sentEmails, err = p.db.SumSentEmailsManagedBy(owner.Address); err != nil {
+			return errors.ErrGenericInternalServerError.WithErr(err)
+		}
+		if sentSMS, err = p.db.SumSentSMSManagedBy(owner.Address); err != nil {
+			return errors.ErrGenericInternalServerError.WithErr(err)
+		}
+	}
+
+	remainingEmails := plan.Features.TwoFaEmail - sentEmails
 	if census.TwoFaFields.Contains(db.OrgMemberTwoFaFieldEmail) && memberCount > remainingEmails {
 		return errors.ErrProcessCensusSizeExceedsEmailAllowance.Withf("remaining emails: %d", remainingEmails)
 	}
-	remainingSMS := plan.Features.TwoFaSms - org.Counters.SentSMS
+	remainingSMS := plan.Features.TwoFaSms - sentSMS
 	if census.TwoFaFields.Contains(db.OrgMemberTwoFaFieldPhone) && memberCount > remainingSMS {
 		return errors.ErrProcessCensusSizeExceedsSMSAllowance.Withf("remaining sms: %d", remainingSMS)
 	}
@@ -297,19 +344,21 @@ func (p *Subscriptions) OrgCanPublishGroupCensus(census *db.Census, groupID stri
 }
 
 func (p *Subscriptions) OrgCanAddCensusParticipants(orgAddress common.Address, censusID string, participantsCount int) error {
-	// Check if the organization has a subscription
 	org, err := p.db.Organization(orgAddress)
 	if err != nil {
 		return errors.ErrOrganizationNotFound.WithErr(err)
 	}
 
-	if org.Subscription.PlanID == "" {
-		return errors.ErrOrganizationHasNoSubscription.With("can't create draft process")
+	// For a managed org, census size is governed by the integrator's aggregate
+	// ManagedCensusSize quota (ReserveManagedPublish) at publish time, so the per-org
+	// census-size limit is not enforced here.
+	if managed(org) {
+		return nil
 	}
 
-	plan, err := p.db.Plan(org.Subscription.PlanID)
+	_, plan, err := p.limitsOwner(org)
 	if err != nil {
-		return errors.ErrPlanNotFound.WithErr(err)
+		return err
 	}
 
 	count, err := p.db.CountCensusParticipants(censusID)

--- a/subscriptions/subscriptions_test.go
+++ b/subscriptions/subscriptions_test.go
@@ -17,6 +17,11 @@ var (
 	testAnotherOrgAddress = common.Address{0x10, 0x11, 0x12, 0x13, 0x14}
 )
 
+const (
+	integratorPlanID = "integrator-plan"
+	tinyPlanID       = "tiny-plan"
+)
+
 func TestHasTxPermission(t *testing.T) {
 	c := qt.New(t)
 	// Create a mock organization without a subscription plan
@@ -298,11 +303,210 @@ func TestCanPublishForManagedOrg(t *testing.T) {
 	c.Assert(subs.CanPublishForManagedOrg(integrator(0, 90), 11), qt.ErrorIs, errors.ErrIntegratorQuotaExceeded)
 }
 
+// TestManagedOrgLimitsUseIntegratorPlan asserts that a managed org's limits are governed
+// by its integrator's plan and aggregate quotas, never by its own (throwaway default) plan.
+// In every case the managed org's own plan is intentionally near-zero while the integrator's
+// plan is generous: if the managed org were bound by its own plan it would be rejected.
+func TestManagedOrgLimitsUseIntegratorPlan(t *testing.T) {
+	c := qt.New(t)
+
+	integratorAddr := common.Address{0xAA}
+	managedAddr := common.Address{0xBB}
+	standaloneAddr := common.Address{0xCC} // not managed, same tiny plan — the control
+
+	mockDB := &mockMongoStorage{
+		plans: map[string]*db.Plan{
+			// generous integrator plan
+			integratorPlanID: {
+				ID: integratorPlanID,
+				Organization: db.PlanLimits{
+					MaxProcesses: 100, MaxCensus: 1000, MaxDuration: 30, MaxDrafts: 10,
+				},
+				Features: db.Features{Anonymous: true, TwoFaEmail: 100, TwoFaSms: 100},
+			},
+			// near-zero throwaway plan the managed/standalone orgs are seeded with
+			tinyPlanID: {
+				ID: tinyPlanID,
+				Organization: db.PlanLimits{
+					MaxProcesses: 0, MaxCensus: 1, MaxDuration: 0, MaxDrafts: 0,
+				},
+				Features: db.Features{Anonymous: false, TwoFaEmail: 0, TwoFaSms: 0},
+			},
+		},
+		orgs: map[string]*db.Organization{
+			integratorAddr.String(): {
+				Address:      integratorAddr,
+				Subscription: db.OrganizationSubscription{PlanID: integratorPlanID, Active: true},
+			},
+			managedAddr.String(): {
+				Address:      managedAddr,
+				ManagedBy:    integratorAddr,
+				Subscription: db.OrganizationSubscription{PlanID: tinyPlanID, Active: true},
+			},
+			standaloneAddr.String(): {
+				Address:      standaloneAddr,
+				Subscription: db.OrganizationSubscription{PlanID: tinyPlanID, Active: true},
+			},
+		},
+		// shared-pool consumption across the integrator's managed orgs
+		membersManagedBy:    map[string]int64{integratorAddr.String(): 5},
+		sentEmailsManagedBy: map[string]int{integratorAddr.String(): 10},
+		sentSMSManagedBy:    map[string]int{integratorAddr.String(): 10},
+		orgMembers:          map[string]int64{standaloneAddr.String(): 5},
+		groups: map[string]*db.OrganizationMemberGroup{
+			"group-1": {MemberIDs: []string{"a", "b", "c"}},
+		},
+	}
+	subs := &Subscriptions{db: mockDB}
+
+	adminUser := &db.User{
+		Email: "admin@example.com",
+		Organizations: []db.OrganizationUser{
+			{Address: managedAddr, Role: db.AdminRole},
+			{Address: standaloneAddr, Role: db.AdminRole},
+		},
+	}
+
+	// a NEW_PROCESS tx requesting an anonymous election bigger than a test-sized one.
+	newProcessTx := func() *models.Tx {
+		return &models.Tx{
+			Payload: &models.Tx_NewProcess{
+				NewProcess: &models.NewProcessTx{
+					Txtype: models.TxType_NEW_PROCESS,
+					Process: &models.Process{
+						MaxCensusSize: uint64(db.TestMaxCensusSize) + 50,
+						Duration:      3600,
+						EnvelopeType:  &models.EnvelopeType{Anonymous: true},
+						VoteOptions:   &models.ProcessVoteOptions{},
+					},
+				},
+			},
+		}
+	}
+
+	managedOrg := mockDB.orgs[managedAddr.String()]
+	standaloneOrg := mockDB.orgs[standaloneAddr.String()]
+
+	// --- Capability flag (Anonymous) + dropped census/process checks (HasTxPermission) ---
+	// Managed org: anonymous allowed because the integrator's plan permits it, and the
+	// per-org census/process caps are skipped (integrator aggregate governs at publish).
+	ok, err := subs.HasTxPermission(newProcessTx(), models.TxType_NEW_PROCESS, managedOrg, adminUser)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ok, qt.IsTrue)
+	// Standalone org on the same tiny plan: rejected (its own plan forbids anonymous).
+	_, err = subs.HasTxPermission(newProcessTx(), models.TxType_NEW_PROCESS, standaloneOrg, adminUser)
+	c.Assert(err, qt.Not(qt.IsNil))
+
+	// --- MaxDrafts value cap (OrgHasPermission) ---
+	// Managed org: governed by integrator MaxDrafts (10) — allowed; standalone tiny plan
+	// (MaxDrafts 0) — rejected.
+	c.Assert(subs.OrgHasPermission(managedAddr, CreateDraft), qt.IsNil)
+	c.Assert(subs.OrgHasPermission(standaloneAddr, CreateDraft), qt.ErrorIs, errors.ErrMaxDraftsReached)
+
+	// --- Members shared pool (OrgCanAddNMembers) ---
+	// Managed org: integrator MaxCensus (1000) vs shared-pool count (5) — allowed.
+	c.Assert(subs.OrgCanAddNMembers(managedAddr, 3), qt.IsNil)
+	// Standalone tiny plan (MaxCensus 1) vs its own members (5) — rejected.
+	c.Assert(subs.OrgCanAddNMembers(standaloneAddr, 3), qt.ErrorIs, errors.ErrExceedsOrganizationMembersLimit)
+
+	// --- Census participants: dropped for managed, enforced for standalone ---
+	c.Assert(subs.OrgCanAddCensusParticipants(managedAddr, "census-x", 10_000), qt.IsNil)
+	c.Assert(subs.OrgCanAddCensusParticipants(standaloneAddr, "census-x", 10_000),
+		qt.ErrorIs, errors.ErrProcessCensusSizeExceedsPlanLimit)
+
+	// --- 2FA shared pool (OrgCanPublishGroupCensus) ---
+	emailCensus := func(orgAddr common.Address) *db.Census {
+		return &db.Census{OrgAddress: orgAddr, TwoFaFields: db.OrgMemberTwoFaFields{db.OrgMemberTwoFaFieldEmail}}
+	}
+	// Managed org: integrator TwoFaEmail (100) - shared sent (10) = 90 remaining >= 3 members — allowed.
+	c.Assert(subs.OrgCanPublishGroupCensus(emailCensus(managedAddr), "group-1"), qt.IsNil)
+	// Standalone tiny plan: TwoFaEmail 0 - 0 = 0 remaining < 3 members — rejected.
+	c.Assert(subs.OrgCanPublishGroupCensus(emailCensus(standaloneAddr), "group-1"),
+		qt.ErrorIs, errors.ErrProcessCensusSizeExceedsEmailAllowance)
+}
+
+// TestManagedOrgSharedPoolExceeded asserts the integrator's shared pool is enforced: when
+// combined consumption across the integrator's managed orgs reaches the integrator limit,
+// a managed org is rejected even though its own (throwaway) plan is irrelevant.
+func TestManagedOrgSharedPoolExceeded(t *testing.T) {
+	c := qt.New(t)
+
+	integratorAddr := common.Address{0xA1}
+	managedAddr := common.Address{0xB1}
+
+	mockDB := &mockMongoStorage{
+		plans: map[string]*db.Plan{
+			integratorPlanID: {
+				ID:           integratorPlanID,
+				Organization: db.PlanLimits{MaxCensus: 100},
+				Features:     db.Features{TwoFaSms: 50},
+			},
+			tinyPlanID: {ID: tinyPlanID, Organization: db.PlanLimits{MaxCensus: 1}},
+		},
+		orgs: map[string]*db.Organization{
+			integratorAddr.String(): {
+				Address:      integratorAddr,
+				Subscription: db.OrganizationSubscription{PlanID: integratorPlanID, Active: true},
+			},
+			managedAddr.String(): {
+				Address:      managedAddr,
+				ManagedBy:    integratorAddr,
+				Subscription: db.OrganizationSubscription{PlanID: tinyPlanID, Active: true},
+			},
+		},
+		// pool already near the integrator's limits
+		membersManagedBy: map[string]int64{integratorAddr.String(): 99},
+		sentSMSManagedBy: map[string]int{integratorAddr.String(): 50},
+		groups: map[string]*db.OrganizationMemberGroup{
+			"group-1": {MemberIDs: []string{"a"}},
+		},
+	}
+	subs := &Subscriptions{db: mockDB}
+
+	// members: pool at 99, integrator MaxCensus 100 → adding 2 exceeds.
+	c.Assert(subs.OrgCanAddNMembers(managedAddr, 2), qt.ErrorIs, errors.ErrExceedsOrganizationMembersLimit)
+	// 2FA SMS: pool at 50, integrator TwoFaSms 50 → 0 remaining, 1 member needed → rejected.
+	smsCensus := &db.Census{OrgAddress: managedAddr, TwoFaFields: db.OrgMemberTwoFaFields{db.OrgMemberTwoFaFieldPhone}}
+	c.Assert(subs.OrgCanPublishGroupCensus(smsCensus, "group-1"),
+		qt.ErrorIs, errors.ErrProcessCensusSizeExceedsSMSAllowance)
+}
+
+// TestManagedOrgMissingIntegratorFailsClosed asserts a managed org whose integrator cannot
+// be resolved is rejected rather than silently falling back to its own plan.
+func TestManagedOrgMissingIntegratorFailsClosed(t *testing.T) {
+	c := qt.New(t)
+
+	managedAddr := common.Address{0xD1}
+	mockDB := &mockMongoStorage{
+		plans: map[string]*db.Plan{tinyPlanID: {ID: tinyPlanID}},
+		orgs: map[string]*db.Organization{
+			managedAddr.String(): {
+				Address:      managedAddr,
+				ManagedBy:    common.Address{0xDE, 0xAD}, // integrator absent from the mock
+				Subscription: db.OrganizationSubscription{PlanID: tinyPlanID, Active: true},
+			},
+		},
+	}
+	subs := &Subscriptions{db: mockDB}
+
+	c.Assert(subs.OrgCanAddNMembers(managedAddr, 1), qt.ErrorIs, errors.ErrOrganizationNotFound)
+}
+
 // Mock implementation of the necessary db.MongoStorage methods for testing
 type mockMongoStorage struct {
 	plans map[string]*db.Plan
 	users map[string]*db.User
 	orgs  map[string]*db.Organization
+	// keyed by integrator address string; default 0 when absent
+	membersManagedBy    map[string]int64
+	sentEmailsManagedBy map[string]int
+	sentSMSManagedBy    map[string]int
+	// keyed by orgAddress string
+	orgMembers map[string]int64
+	// keyed by groupID
+	groups map[string]*db.OrganizationMemberGroup
+	// keyed by orgAddress string; draft process count
+	draftCounts map[string]int64
 }
 
 func (m *mockMongoStorage) Plan(id string) (*db.Plan, error) {
@@ -339,18 +543,34 @@ func (m *mockMongoStorage) OrganizationWithParent(address common.Address) (
 	return org, nil, nil
 }
 
-func (*mockMongoStorage) CountOrgMembers(_ common.Address) (int64, error) {
-	return 0, nil
+func (m *mockMongoStorage) CountOrgMembers(addr common.Address) (int64, error) {
+	return m.orgMembers[addr.String()], nil
+}
+
+func (m *mockMongoStorage) CountMembersManagedBy(integratorAddr common.Address) (int64, error) {
+	return m.membersManagedBy[integratorAddr.String()], nil
+}
+
+func (m *mockMongoStorage) SumSentEmailsManagedBy(integratorAddr common.Address) (int, error) {
+	return m.sentEmailsManagedBy[integratorAddr.String()], nil
+}
+
+func (m *mockMongoStorage) SumSentSMSManagedBy(integratorAddr common.Address) (int, error) {
+	return m.sentSMSManagedBy[integratorAddr.String()], nil
 }
 
 func (*mockMongoStorage) CountCensusParticipants(string) (int64, error) {
 	return 0, nil
 }
 
-func (*mockMongoStorage) CountProcesses(_ common.Address, _ db.DraftFilter) (int64, error) {
-	return 0, nil
+func (m *mockMongoStorage) CountProcesses(addr common.Address, _ db.DraftFilter) (int64, error) {
+	return m.draftCounts[addr.String()], nil
 }
 
-func (*mockMongoStorage) OrganizationMemberGroup(string, common.Address) (*db.OrganizationMemberGroup, error) {
-	return nil, fmt.Errorf("not implemented in mock")
+func (m *mockMongoStorage) OrganizationMemberGroup(groupID string, _ common.Address) (*db.OrganizationMemberGroup, error) {
+	group, ok := m.groups[groupID]
+	if !ok {
+		return nil, fmt.Errorf("group not found in mock")
+	}
+	return group, nil
 }

--- a/subscriptions/subscriptions_test.go
+++ b/subscriptions/subscriptions_test.go
@@ -409,9 +409,14 @@ func TestManagedOrgLimitsUseIntegratorPlan(t *testing.T) {
 	// Standalone tiny plan (MaxCensus 1) vs its own members (5) — rejected.
 	c.Assert(subs.OrgCanAddNMembers(standaloneAddr, 3), qt.ErrorIs, errors.ErrExceedsOrganizationMembersLimit)
 
-	// --- Census participants: dropped for managed, enforced for standalone ---
-	c.Assert(subs.OrgCanAddCensusParticipants(managedAddr, "census-x", 10_000), qt.IsNil)
-	c.Assert(subs.OrgCanAddCensusParticipants(standaloneAddr, "census-x", 10_000),
+	// --- Census participants: integrator-governed cap for managed, own plan for standalone ---
+	// Managed org: integrator MaxCensus (1000) — 500 allowed, 2000 rejected (its own tiny
+	// plan would have rejected 500, proving the integrator's plan governs).
+	c.Assert(subs.OrgCanAddCensusParticipants(managedAddr, "census-x", 500), qt.IsNil)
+	c.Assert(subs.OrgCanAddCensusParticipants(managedAddr, "census-x", 2000),
+		qt.ErrorIs, errors.ErrProcessCensusSizeExceedsPlanLimit)
+	// Standalone tiny plan (MaxCensus 1): even small adds are rejected.
+	c.Assert(subs.OrgCanAddCensusParticipants(standaloneAddr, "census-x", 10),
 		qt.ErrorIs, errors.ErrProcessCensusSizeExceedsPlanLimit)
 
 	// --- 2FA shared pool (OrgCanPublishGroupCensus) ---

--- a/subscriptions/subscriptions_test.go
+++ b/subscriptions/subscriptions_test.go
@@ -214,9 +214,7 @@ func TestEffectiveIntegratorLimits(t *testing.T) {
 	c := qt.New(t)
 	mockDB := &mockMongoStorage{
 		plans: map[string]*db.Plan{
-			"plan-1": {ID: "plan-1", IntegratorLimits: db.IntegratorLimits{
-				MaxManagedOrgs: 5, MaxManagedProcesses: 50, MaxManagedCensusSize: 500,
-			}},
+			"plan-1": {ID: "plan-1", IntegratorLimits: db.IntegratorLimits{MaxManagedOrgs: 5}},
 		},
 	}
 	subs := &Subscriptions{db: mockDB}
@@ -226,7 +224,7 @@ func TestEffectiveIntegratorLimits(t *testing.T) {
 	c.Assert(err, qt.ErrorIs, errors.ErrNotAnIntegrator)
 
 	// a per-org override takes precedence over the plan limits
-	override := &db.IntegratorLimits{MaxManagedOrgs: 2, MaxManagedProcesses: 20, MaxManagedCensusSize: 200}
+	override := &db.IntegratorLimits{MaxManagedOrgs: 2}
 	limits, err := subs.EffectiveIntegratorLimits(&db.Organization{
 		IntegratorLimits: override,
 		Subscription:     db.OrganizationSubscription{PlanID: "plan-1"},
@@ -280,12 +278,21 @@ func TestCanCreateManagedOrg(t *testing.T) {
 
 func TestCanPublishForManagedOrg(t *testing.T) {
 	c := qt.New(t)
-	subs := &Subscriptions{}
-	limits := &db.IntegratorLimits{MaxManagedOrgs: 5, MaxManagedProcesses: 5, MaxManagedCensusSize: 100}
+	mockDB := &mockMongoStorage{
+		plans: map[string]*db.Plan{
+			// aggregate caps come from the plan's top-level Organization limits
+			integratorPlanID: {
+				ID:               integratorPlanID,
+				Organization:     db.PlanLimits{MaxProcesses: 5, MaxCensus: 100},
+				IntegratorLimits: db.IntegratorLimits{MaxManagedOrgs: 5},
+			},
+		},
+	}
+	subs := &Subscriptions{db: mockDB}
 	integrator := func(processes, censusSize int) *db.Organization {
 		return &db.Organization{
-			IntegratorLimits: limits,
-			Counters:         db.OrganizationCounters{ManagedProcesses: processes, ManagedCensusSize: censusSize},
+			Subscription: db.OrganizationSubscription{PlanID: integratorPlanID, Active: true},
+			Counters:     db.OrganizationCounters{ManagedProcesses: processes, ManagedCensusSize: censusSize},
 		}
 	}
 


### PR DESCRIPTION
## Problem

Managed organizations are created with a throwaway **default plan**, and almost every usage-limit check in `subscriptions/subscriptions.go` resolved limits from that org's *own* `Subscription.PlanID`. So a managed org was bound by its default plan, and its integrator's plan was ignored for everything except the three aggregate quotas (`MaxManagedOrgs` / `MaxManagedProcesses` / `MaxManagedCensusSize`).

This changes enforcement so that for a managed org (`org.ManagedBy != zero`), **all** limits come from the integrator. The managed org's own plan becomes irrelevant.

## Approach

- **`limitsOwner(org)` helper** — resolves the integrator (via `org.ManagedBy`) for managed orgs, otherwise the org itself, together with that owner's plan. **Fails closed** if a managed org's integrator can't be resolved — no silent fallback to the throwaway plan.
- **Capability flags & value caps** (Anonymous, Weighted, Overwrite, MaxDuration, MaxDrafts) → take the integrator's plan value.
- **Per-org census-size / process-count checks** → dropped for managed orgs; already enforced against the integrator aggregate via `ReserveManagedPublish` at publish.
- **2FA SMS/email and members** → enforced as a **shared integrator pool**, summed live across the integrator's managed orgs (`CountMembersManagedBy`, `SumSentSMSManagedBy`, `SumSentEmailsManagedBy`). No new counter fields, no `csp.go` change, no migration.

## Notes / behavior changes

- The integrator's `MaxCensus` now caps the **sum** of members across all its managed orgs (a true shared pool) — stricter than per-org. Integrator plans should carry a suitably large `MaxCensus`.
- 2FA `SentSMS`/`SentEmails` remain lifetime meters (unchanged increments); deleting a managed org does not reclaim past sends.

## Tests

- `subscriptions/subscriptions_test.go` — decisive table test: a managed org with a near-zero own plan but a generous integrator plan is allowed by each of the five checks, while an identical **standalone** org on the same tiny plan is rejected; plus shared-pool-exceeded and fail-closed-on-missing-integrator cases.
- `db/managed_org_limits_test.go` — integration test (real Mongo) for the live aggregate readers: sums only the integrator's managed orgs, excludes unrelated orgs, reads zero for an integrator with none.

Verified: `go build ./...`, `go test ./subscriptions/... ./db/...`, and `golangci-lint run --new-from-rev=origin/main` (0 new issues).