### PR TITLE
feat(api): expose election encryption keys on GET /process/{id}

### DIFF
--- a/account/process.go
+++ b/account/process.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/internal"
 	"go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/proto/build/go/models"
 )
@@ -225,4 +226,21 @@ func (a *Account) Election(processID []byte) (*api.Election, error) {
 		return nil, fmt.Errorf("could not fetch election %x: %w", processID, err)
 	}
 	return election, nil
+}
+
+// ElectionEncryptionKeys fetches the encryption public keys of the on-chain election with
+// the given id. Only encrypted (secretUntilTheEnd) elections publish keys, and only after
+// the keykeepers have done so, so the returned slice may be empty for a freshly created
+// election. The node also returns private keys once the election ends; those are never
+// needed for voting and are deliberately ignored here.
+func (a *Account) ElectionEncryptionKeys(processID []byte) ([]db.EncryptionKey, error) {
+	ek, err := a.client.ElectionKeys(processID)
+	if err != nil {
+		return nil, fmt.Errorf("could not fetch election keys %x: %w", processID, err)
+	}
+	keys := make([]db.EncryptionKey, 0, len(ek.PublicKeys))
+	for _, k := range ek.PublicKeys {
+		keys = append(keys, db.EncryptionKey{Index: k.Index, Key: internal.HexBytes(k.Key)})
+	}
+	return keys, nil
 }

--- a/api/process.go
+++ b/api/process.go
@@ -235,6 +235,9 @@ func (a *API) updateProcessHandler(w http.ResponseWriter, r *http.Request) {
 //
 //	@Summary		Get process information
 //	@Description	Retrieve voting process information by ID. Returns process details including census and metadata.
+//	@Description	For encrypted (secretUntilTheEnd) elections the response additionally carries the election's
+//	@Description	encryption public keys in `encryptionKeys` (one per keykeeper) once they are published on chain;
+//	@Description	the field is absent for non-encrypted elections and before the keys are published.
 //	@Tags			process
 //	@Accept			json
 //	@Produce		json
@@ -273,10 +276,51 @@ func (a *API) processInfoHandler(w http.ResponseWriter, r *http.Request) {
 		process.Metadata = md
 	}
 
+	// for encrypted (secretUntilTheEnd) elections, expose the encryption public keys the
+	// voter needs to encrypt their ballot. Gated and cached so the common (non-encrypted)
+	// read path never touches the chain.
+	process.EncryptionKeys = a.resolveProcessEncryptionKeys(process)
+
 	apicommon.HTTPWriteJSON(w, &apicommon.ProcessInfo{
 		Process: process,
 		ChainID: a.account.ChainID(),
 	})
+}
+
+// resolveProcessEncryptionKeys returns the encryption public keys for an encrypted
+// election, fetching them from the Vochain only when needed and caching them on the
+// process once published. It is a no-op (returns nil, no chain call) for non-encrypted
+// elections, unpublished drafts, and processes whose keys are already cached are served
+// from the cache. The result is cached only when non-empty: between an election's creation
+// and the keykeepers publishing its keys the node returns an empty set, and a later read
+// must still pick them up.
+func (a *API) resolveProcessEncryptionKeys(p *db.Process) []db.EncryptionKey {
+	// gate: only encrypted elections have encryption keys. Reading the stored election type
+	// keeps every other process on a chain-free path.
+	if p.ElectionParams == nil || !p.ElectionParams.ElectionType.SecretUntilTheEnd {
+		return nil
+	}
+	// nothing on chain yet (draft) — no keys to fetch
+	if p.Address.Equals(nil) {
+		return nil
+	}
+	// immutable once published: serve the cached keys without a chain round-trip
+	if len(p.EncryptionKeys) > 0 {
+		return p.EncryptionKeys
+	}
+	keys, err := a.account.ElectionEncryptionKeys(p.Address.Bytes())
+	if err != nil {
+		log.Warnw("encryption keys: election keys fetch failed", "process", p.Address.String(), "error", err)
+		return nil
+	}
+	// not published yet — do not cache an empty set so a later read still resolves them
+	if len(keys) == 0 {
+		return nil
+	}
+	if err := a.db.SetProcessEncryptionKeys(p.ID, keys); err != nil {
+		log.Warnw("encryption keys: could not persist keys", "process", p.Address.String(), "error", err)
+	}
+	return keys
 }
 
 // metadataObjectUserID is the object-storage owner recorded for server-generated

--- a/api/process_encryption_keys_test.go
+++ b/api/process_encryption_keys_test.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/api/apicommon"
+	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/internal"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.vocdoni.io/proto/build/go/models"
+)
+
+// TestProcessEncryptionKeys exercises the encryptionKeys field of GET /process/{id}:
+//   - an encrypted (secretUntilTheEnd) election exposes the election's on-chain encryption
+//     public keys, and they are cached on the stored process once resolved;
+//   - a non-encrypted election leaves the field absent (and the handler stays chain-free).
+func TestProcessEncryptionKeys(t *testing.T) {
+	c := qt.New(t)
+
+	// create a user and organization
+	token := testCreateUser(t, "superpassword123")
+	vocdoniClient := testNewVocdoniClient(t)
+	orgAddress := testCreateOrganization(t, token)
+
+	// subscribe the organization to a plan
+	plans, err := testDB.Plans()
+	c.Assert(err, qt.IsNil)
+	c.Assert(len(plans) > 1, qt.IsTrue)
+	c.Assert(testDB.SetOrganizationSubscription(orgAddress, &db.OrganizationSubscription{
+		PlanID:          plans[1].ID,
+		StartDate:       time.Now(),
+		RenewalDate:     time.Now().Add(time.Hour * 24),
+		LastPaymentDate: time.Now(),
+		Active:          true,
+	}), qt.IsNil)
+
+	// create the organization account on-chain
+	orgName := fmt.Sprintf("encorg-%d", internal.RandomInt(1000))
+	orgInfoURI := fmt.Sprintf("https://example.com/%d", internal.RandomInt(1000))
+	nonce := uint32(0)
+	accountTx := &models.Tx{Payload: &models.Tx_SetAccount{SetAccount: &models.SetAccountTx{
+		Nonce:   &nonce,
+		Txtype:  models.TxType_CREATE_ACCOUNT,
+		Account: orgAddress.Bytes(),
+		Name:    &orgName,
+		InfoURI: &orgInfoURI,
+	}}}
+	signRemoteSignerAndSendVocdoniTx(t, accountTx, token, vocdoniClient, orgAddress)
+
+	cspPubKey, err := testCSP.PubKey()
+	c.Assert(err, qt.IsNil)
+
+	// newProcess publishes an on-chain election (encrypted or not) and stores the matching
+	// SaaS process record, returning its Mongo ObjectID and on-chain id.
+	newProcess := func(encrypted bool) (string, internal.HexBytes) {
+		processNonce := fetchVocdoniAccountNonce(t, vocdoniClient, orgAddress)
+		processTx := &models.Tx{Payload: &models.Tx_NewProcess{NewProcess: &models.NewProcessTx{
+			Txtype: models.TxType_NEW_PROCESS,
+			Nonce:  processNonce,
+			Process: &models.Process{
+				EntityId:      orgAddress.Bytes(),
+				Duration:      120,
+				Status:        models.ProcessStatus_READY,
+				CensusOrigin:  models.CensusOrigin_OFF_CHAIN_CA,
+				CensusRoot:    cspPubKey,
+				MaxCensusSize: 10,
+				EnvelopeType:  &models.EnvelopeType{EncryptedVotes: encrypted},
+				VoteOptions:   &models.ProcessVoteOptions{MaxCount: 1, MaxValue: 5},
+				Mode:          &models.ProcessMode{AutoStart: true, Interruptible: true},
+			},
+		}}}
+		addr := internal.HexBytes(signRemoteSignerAndSendVocdoniTx(t, processTx, token, vocdoniClient, orgAddress))
+		objID, err := testDB.SetProcess(&db.Process{
+			OrgAddress: orgAddress,
+			Address:    addr,
+			ElectionParams: &db.ElectionParams{
+				Title:         db.MultiLangString{"default": "Encryption keys election"},
+				EndDate:       time.Now().Add(2 * time.Hour),
+				MaxCensusSize: 100,
+				VoteType:      db.VoteType{MaxCount: 1, MaxValue: 1},
+				ElectionType: db.ElectionType{
+					Autostart:         true,
+					Interruptible:     true,
+					SecretUntilTheEnd: encrypted,
+				},
+			},
+		})
+		c.Assert(err, qt.IsNil)
+		return objID.Hex(), addr
+	}
+
+	// --- encrypted election: keys must be exposed and cached ---
+	encObjID, encAddr := newProcess(true)
+
+	// wait until the keykeepers publish the election encryption keys on chain
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	nodeKeys, err := vocdoniClient.WaitUntilElectionKeys(ctx, encAddr.Bytes())
+	cancel()
+	c.Assert(err, qt.IsNil)
+	c.Assert(nodeKeys.PublicKeys, qt.Not(qt.HasLen), 0)
+
+	info := requestAndParse[apicommon.ProcessInfo](t, http.MethodGet, token, nil, "process", encObjID)
+	c.Assert(info.EncryptionKeys, qt.HasLen, len(nodeKeys.PublicKeys))
+	for i, k := range nodeKeys.PublicKeys {
+		c.Assert(info.EncryptionKeys[i].Index, qt.Equals, k.Index)
+		c.Assert(info.EncryptionKeys[i].Key.String(), qt.Equals, k.Key.String())
+	}
+
+	// the keys are immutable once published, so they are cached on the stored process
+	encParsedID, err := primitive.ObjectIDFromHex(encObjID)
+	c.Assert(err, qt.IsNil)
+	stored, err := testDB.Process(encParsedID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stored.EncryptionKeys, qt.HasLen, len(nodeKeys.PublicKeys))
+
+	// --- non-encrypted election: no keys, no chain lookup ---
+	plainObjID, _ := newProcess(false)
+	plain := requestAndParse[apicommon.ProcessInfo](t, http.MethodGet, token, nil, "process", plainObjID)
+	c.Assert(plain.EncryptionKeys, qt.HasLen, 0)
+}

--- a/db/process.go
+++ b/db/process.go
@@ -134,6 +134,28 @@ func (ms *MongoStorage) SetProcessMetadataURL(processID primitive.ObjectID, meta
 	return nil
 }
 
+// SetProcessEncryptionKeys sets only the encryptionKeys field of the process identified
+// by processID, leaving every other field untouched (same targeted-update rationale as
+// SetProcessMetadataURL). The encryption public keys are immutable once published by the
+// keykeepers, so this is written once and only with a non-empty set.
+func (ms *MongoStorage) SetProcessEncryptionKeys(processID primitive.ObjectID, keys []EncryptionKey) error {
+	if processID == primitive.NilObjectID {
+		return ErrInvalidData
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	filter := bson.M{"_id": processID}
+	res, err := ms.processes.UpdateOne(ctx, filter, bson.M{"$set": bson.M{"encryptionKeys": keys}})
+	if err != nil {
+		return fmt.Errorf("failed to set process encryption keys: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // DeleteProcess removes a process
 func (ms *MongoStorage) DelProcess(processID primitive.ObjectID) error {
 	if processID == primitive.NilObjectID {

--- a/db/types.go
+++ b/db/types.go
@@ -480,6 +480,15 @@ type ElectionType struct {
 	Anonymous         bool `json:"anonymous" bson:"anonymous"`
 }
 
+// EncryptionKey is a single election encryption public key for an encrypted
+// (secretUntilTheEnd) election, identified by its keykeeper Index. Key holds the
+// hex-encoded public key voters use to encrypt their ballots. Only public keys are
+// ever represented here; the private keys revealed when the election ends are not.
+type EncryptionKey struct {
+	Index int               `json:"index" bson:"index"`
+	Key   internal.HexBytes `json:"key" bson:"key" swaggertype:"string" format:"hex" example:"deadbeef"`
+}
+
 // ElectionTypeMetadata is the metadata "type" block describing how results are displayed.
 type ElectionTypeMetadata struct {
 	Name       string `json:"name" bson:"name"`
@@ -523,6 +532,11 @@ type Process struct {
 	ElectionParams *ElectionParams `json:"electionParams,omitempty" bson:"electionParams,omitempty"`
 	Status         string          `json:"status,omitempty" bson:"status,omitempty"`
 	PublishedAt    time.Time       `json:"publishedAt,omitempty" bson:"publishedAt,omitempty"`
+	// EncryptionKeys holds the on-chain encryption public keys of an encrypted
+	// (secretUntilTheEnd) election. They are resolved lazily on read and cached here once
+	// the keykeepers have published them (immutable thereafter). Unset/omitted for
+	// non-encrypted elections and for encrypted ones whose keys are not yet published.
+	EncryptionKeys []EncryptionKey `json:"encryptionKeys,omitempty" bson:"encryptionKeys,omitempty"`
 }
 
 // ProcessesBundle represents a group of voting processes that share a common census.

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1054,6 +1054,15 @@ definitions:
         type: string
       electionParams:
         $ref: '#/definitions/db.ElectionParams'
+      encryptionKeys:
+        description: |-
+          EncryptionKeys holds the on-chain encryption public keys of an encrypted
+          (secretUntilTheEnd) election. They are resolved lazily on read and cached here once
+          the keykeepers have published them (immutable thereafter). Unset/omitted for
+          non-encrypted elections and for encrypted ones whose keys are not yet published.
+        items:
+          $ref: '#/definitions/db.EncryptionKey'
+        type: array
       id:
         type: string
       metadata:
@@ -1608,6 +1617,15 @@ definitions:
         type: string
       properties: {}
     type: object
+  db.EncryptionKey:
+    properties:
+      index:
+        type: integer
+      key:
+        example: deadbeef
+        format: hex
+        type: string
+    type: object
   db.Features:
     properties:
       2FAemail:
@@ -1764,6 +1782,15 @@ definitions:
         $ref: '#/definitions/db.Census'
       electionParams:
         $ref: '#/definitions/db.ElectionParams'
+      encryptionKeys:
+        description: |-
+          EncryptionKeys holds the on-chain encryption public keys of an encrypted
+          (secretUntilTheEnd) election. They are resolved lazily on read and cached here once
+          the keykeepers have published them (immutable thereafter). Unset/omitted for
+          non-encrypted elections and for encrypted ones whose keys are not yet published.
+        items:
+          $ref: '#/definitions/db.EncryptionKey'
+        type: array
       id:
         type: string
       metadata:
@@ -4430,8 +4457,11 @@ paths:
     get:
       consumes:
       - application/json
-      description: Retrieve voting process information by ID. Returns process details
-        including census and metadata.
+      description: |-
+        Retrieve voting process information by ID. Returns process details including census and metadata.
+        For encrypted (secretUntilTheEnd) elections the response additionally carries the election's
+        encryption public keys in `encryptionKeys` (one per keykeeper) once they are published on chain;
+        the field is absent for non-encrypted elections and before the keys are published.
       parameters:
       - description: Process ID
         in: path


### PR DESCRIPTION
Add an encryptionKeys field to the process response carrying the election's on-chain encryption public keys, so clients (e.g. the integrators-sdk) can encrypt ballots for secretUntilTheEnd elections without ever calling a Vochain node directly.

The lookup is gated on electionType.secretUntilTheEnd so the common (non-encrypted) read path stays chain-free, and the keys are cached on the stored process once published by the keykeepers. Only public keys are exposed; the private keys revealed at election end are never returned.