### PR TITLE
fix(api): allow integrator API keys to delete process drafts (voting:write)

### DIFF
--- a/api/apikeys.go
+++ b/api/apikeys.go
@@ -71,6 +71,7 @@ var apiKeyAllowlist = map[string]string{
 
 	// voting: processes, censuses, bundles (for managed organizations)
 	"POST " + processCreateEndpoint:                ScopeVotingWrite,
+	"DELETE " + processEndpoint:                    ScopeVotingWrite,
 	"POST " + processPublishEndpoint:               ScopeVotingWrite,
 	"PUT " + processStatusEndpoint:                 ScopeVotingWrite,
 	"GET " + organizationListProcessDraftsEndpoint: ScopeVotingWrite,

--- a/api/apikeys_api_test.go
+++ b/api/apikeys_api_test.go
@@ -5,11 +5,13 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 // TestAPIKeysAPI exercises the API-key lifecycle and the auth/scope/allowlist enforcement:
@@ -120,6 +122,80 @@ func TestIntegratorAPIKeyPathless(t *testing.T) {
 	info := requestAndParse[apicommon.IntegratorInfoResponse](t, http.MethodGet, apiKey, nil, "integrator")
 	c.Assert(info.Enabled, qt.IsTrue)
 	c.Assert(info.Usage.ManagedOrgs, qt.Equals, 1)
+}
+
+// TestIntegratorAPIKeyDeletesProcessDraft verifies that a scoped API key (voting:write) can delete
+// a draft process of a managed organization, mirroring the create/publish/status write ops which are
+// all voting:write. Without DELETE /process/{processId} in the allowlist the call is rejected with 403
+// (ErrAPIKeyNotAllowed), which leaves quota-blocked drafts permanently stuck for key-only integrators.
+func TestIntegratorAPIKeyDeletesProcessDraft(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "deletedraftpass123")
+	orgAddr := testCreateOrganization(t, token)
+
+	// make the org an integrator (override)
+	org, err := testDB.Organization(orgAddr)
+	c.Assert(err, qt.IsNil)
+	org.IntegratorLimits = &db.IntegratorLimits{MaxManagedOrgs: 2, MaxManagedProcesses: 5, MaxManagedCensusSize: 100}
+	c.Assert(testDB.SetOrganization(org), qt.IsNil)
+
+	// mint a key with the scopes needed to create a managed org and act on its processes
+	createBody := &apicommon.CreateAPIKeyRequest{
+		Label:  "voting",
+		Scopes: []string{ScopeManagedWrite, ScopeVotingWrite},
+	}
+	data, code := testRequest(t, http.MethodPost, token, createBody, "organizations", orgAddr.String(), "apikeys")
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("resp: %s", data))
+	var created apicommon.CreateAPIKeyResponse
+	c.Assert(json.Unmarshal(data, &created), qt.IsNil)
+	apiKey := created.Secret
+
+	// create a managed org with the key; the key owner becomes its admin (org.Creator)
+	mbody := &apicommon.CreateManagedOrganizationRequest{
+		OrganizationInfo: apicommon.OrganizationInfo{Type: string(db.CompanyType), Website: "https://md.example"},
+	}
+	managed := requestAndParse[apicommon.OrganizationInfo](t, http.MethodPost, apiKey, mbody, "integrator", "organizations")
+	c.Assert(managed.Address, qt.Not(qt.Equals), common.Address{})
+
+	// seed a draft under the managed org directly (draft creation has its own quota that is
+	// orthogonal to delete authorization, which is what this test exercises). The key owner is
+	// admin of the managed org via org.Creator, exactly as for the publish/status handlers.
+	draftID, err := testDB.SetProcess(&db.Process{
+		OrgAddress: managed.Address,
+		ElectionParams: &db.ElectionParams{
+			Title:         db.MultiLangString{"default": "Draft to delete"},
+			EndDate:       time.Now().Add(2 * time.Hour),
+			MaxCensusSize: 10,
+			Questions: []db.Question{{
+				Title: db.MultiLangString{"default": "Approve?"},
+				Choices: []db.Choice{
+					{Title: db.MultiLangString{"default": "No"}, Value: 0},
+					{Title: db.MultiLangString{"default": "Yes"}, Value: 1},
+				},
+			}},
+			VoteType:     db.VoteType{MaxCount: 1, MaxValue: 1},
+			ElectionType: db.ElectionType{Autostart: true, Interruptible: true},
+		},
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(draftID.IsZero(), qt.IsFalse)
+
+	// the key (voting:write) can delete the managed org's draft
+	_, code = testRequest(t, http.MethodDelete, apiKey, nil, "process", draftID.Hex())
+	c.Assert(code, qt.Equals, http.StatusOK)
+
+	// the draft is gone
+	_, err = testDB.Process(draftID)
+	c.Assert(err, qt.Equals, db.ErrNotFound)
+
+	// a key without voting:write cannot delete (insufficient scope → 403)
+	noScopeBody := &apicommon.CreateAPIKeyRequest{Label: "noscope", Scopes: []string{ScopeManagedRead}}
+	data, code = testRequest(t, http.MethodPost, token, noScopeBody, "organizations", orgAddr.String(), "apikeys")
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("resp: %s", data))
+	var noScope apicommon.CreateAPIKeyResponse
+	c.Assert(json.Unmarshal(data, &noScope), qt.IsNil)
+	_, code = testRequest(t, http.MethodDelete, noScope.Secret, nil, "process", primitive.NewObjectID().Hex())
+	c.Assert(code, qt.Equals, http.StatusForbidden)
 }
 
 // TestAPIKeysRequireIntegrator verifies that API keys can only be created by integrator

--- a/api/process.go
+++ b/api/process.go
@@ -481,7 +481,10 @@ func (a *API) organizationListProcessDraftsHandler(w http.ResponseWriter, r *htt
 // deleteProcessHandler godoc
 //
 //	@Summary		Delete a voting process
-//	@Description	Delete a voting process. Requires Manager/Admin role.
+//	@Description	Delete a voting process. Requires Manager/Admin role of the organization that
+//	@Description	owns the process.
+//	@Description
+//	@Description	Also callable with a scoped API key (scope: `voting:write`).
 //	@Tags			process
 //	@Accept			json
 //	@Produce		json

--- a/api/process.go
+++ b/api/process.go
@@ -480,9 +480,10 @@ func (a *API) organizationListProcessDraftsHandler(w http.ResponseWriter, r *htt
 
 // deleteProcessHandler godoc
 //
-//	@Summary		Delete a voting process
-//	@Description	Delete a voting process. Requires Manager/Admin role of the organization that
-//	@Description	owns the process.
+//	@Summary		Delete a draft voting process
+//	@Description	Delete a draft voting process. Only unpublished drafts can be deleted; a process
+//	@Description	already published on-chain cannot be removed. Requires Manager/Admin role of the
+//	@Description	organization that owns the process.
 //	@Description
 //	@Description	Also callable with a scoped API key (scope: `voting:write`).
 //	@Tags			process
@@ -494,6 +495,7 @@ func (a *API) organizationListProcessDraftsHandler(w http.ResponseWriter, r *htt
 //	@Failure		400			{object}	errors.Error	"Invalid process ID"
 //	@Failure		401			{object}	errors.Error	"Unauthorized"
 //	@Failure		404			{object}	errors.Error	"Process not found"
+//	@Failure		409			{object}	errors.Error	"Process already published and not in draft mode"
 //	@Failure		500			{object}	errors.Error	"Internal server error"
 //	@Router			/process/{processId} [delete]
 func (a *API) deleteProcessHandler(w http.ResponseWriter, r *http.Request) {
@@ -522,6 +524,13 @@ func (a *API) deleteProcessHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+
+	// only draft processes can be deleted; a published process has a non-nil
+	// on-chain address and lives on the Vochain, where it cannot be removed.
+	if !existingProcess.Address.Equals(nil) {
+		errors.ErrDuplicateConflict.Withf("process already published and not in draft mode").Write(w)
 		return
 	}
 

--- a/api/process_test.go
+++ b/api/process_test.go
@@ -117,15 +117,40 @@ func TestProcess(t *testing.T) {
 	c.Assert(retrievedProcess.Metadata["title"], qt.Equals, "Test Process")
 	c.Assert(retrievedProcess.Metadata["description"], qt.Equals, "This is a test process")
 
-	// Test 1.8: Test delete process
-	resp, code = testRequest(t, http.MethodDelete, adminToken, nil, "process", pid)
+	// Test 1.8: Test delete process. Only drafts (nil on-chain address) are deletable, so seed a
+	// draft directly (draft creation has its own quota, orthogonal to delete) rather than the
+	// published process above.
+	draftPID, err := testDB.SetProcess(&db.Process{
+		OrgAddress: orgAddress,
+		Metadata:   map[string]any{"title": "Draft Process", "description": "This is a draft process"},
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(draftPID.IsZero(), qt.IsFalse)
+
+	resp, code = testRequest(t, http.MethodDelete, adminToken, nil, "process", draftPID.Hex())
 	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
-	t.Log("Successfully deleted the process")
+	t.Log("Successfully deleted the draft process")
 
 	// Verify the process no longer exists
-	_, code = testRequest(t, http.MethodGet, adminToken, nil, "process", pid)
+	_, code = testRequest(t, http.MethodGet, adminToken, nil, "process", draftPID.Hex())
 	c.Assert(code, qt.Equals, http.StatusNotFound)
 	t.Log("Verified the process no longer exists after deletion")
+
+	// Test 1.9: a published process (non-nil on-chain address) cannot be deleted; only drafts can.
+	publishedID, err := testDB.SetProcess(&db.Process{
+		OrgAddress: orgAddress,
+		Address:    internal.HexBytes(util.RandomBytes(32)),
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(publishedID.IsZero(), qt.IsFalse)
+
+	resp, code = testRequest(t, http.MethodDelete, adminToken, nil, "process", publishedID.Hex())
+	c.Assert(code, qt.Equals, http.StatusConflict, qt.Commentf("response: %s", resp))
+
+	// the published process is still there
+	_, err = testDB.Process(publishedID)
+	c.Assert(err, qt.IsNil)
+	t.Log("Verified a published process cannot be deleted")
 }
 
 // TestDraftProcess tests the draft process functionality

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4419,7 +4419,11 @@ paths:
     delete:
       consumes:
       - application/json
-      description: Delete a voting process. Requires Manager/Admin role.
+      description: |-
+        Delete a voting process. Requires Manager/Admin role of the organization that
+        owns the process.
+
+        Also callable with a scoped API key (scope: `voting:write`).
       parameters:
       - description: Process ID
         in: path

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4420,8 +4420,9 @@ paths:
       consumes:
       - application/json
       description: |-
-        Delete a voting process. Requires Manager/Admin role of the organization that
-        owns the process.
+        Delete a draft voting process. Only unpublished drafts can be deleted; a process
+        already published on-chain cannot be removed. Requires Manager/Admin role of the
+        organization that owns the process.
 
         Also callable with a scoped API key (scope: `voting:write`).
       parameters:
@@ -4449,13 +4450,17 @@ paths:
           description: Process not found
           schema:
             $ref: '#/definitions/errors.Error'
+        "409":
+          description: Process already published and not in draft mode
+          schema:
+            $ref: '#/definitions/errors.Error'
         "500":
           description: Internal server error
           schema:
             $ref: '#/definitions/errors.Error'
       security:
       - BearerAuth: []
-      summary: Delete a voting process
+      summary: Delete a draft voting process
       tags:
       - process
     get:


### PR DESCRIPTION
## The bug

`DELETE /process/{processId}` (delete a voting-process draft) rejects integrator **API keys** with:

```
HTTP 403 {"error":"API keys are not permitted for this endpoint","code":40157}
```

Reproduced live: an integrator using a scoped API key can **create** (`POST /process`), **publish** (`POST /process/{id}/publish`), and **set status** (`PUT /process/{id}/status`) of processes — all `voting:write` scope — but **cannot DELETE a draft**. Because there is also a 2-draft-per-org cap (`40031 max drafts reached`), an integrator that can't publish (e.g. quota-blocked) ends up with drafts stuck permanently, with no key-only way to remove them.

## Root cause

The API-key auth middleware (`authenticateAPIKey` in `api/middlewares.go`) is deny-by-default: it authorizes each request against `apiKeyAllowlist` in `api/apikeys.go`, a map of `"<METHOD> <route>" -> Scope`. Any endpoint **not** present is rejected with `ErrAPIKeyNotAllowed` (code 40157).

The map included `POST /process`, `POST /process/{id}/publish`, and `PUT /process/{id}/status` (all `voting:write`), but was **missing** `DELETE /process/{processId}` — even though delete is the same class of process write op on the same route constant (`processEndpoint`).

## The fix

Add one allowlist entry:

```go
"DELETE " + processEndpoint: ScopeVotingWrite,
```

mirroring the other process write ops. No handler change is needed:

- `deleteProcessHandler` already authorizes via `user.HasRoleFor(org, Manager/Admin)` — identical to the publish/status handlers.
- An integrator API key resolves to its **creating user**, who is admin of the managed org (set as `org.Creator` → `AdminRole` in `SetOrganization`), so the role check passes exactly as it does for publish/status.

Also updated the delete handler's swagger annotation to note API-key support (mirroring publish/status), regenerated `docs/swagger.yaml`, and added a focused integration test asserting an integrator key **can** delete a managed org's draft (and that a key lacking `voting:write` is rejected).

## Tests

- `go test ./api/ -run 'TestIntegratorAPIKeyDeletesProcessDraft|TestAPIKeysAPI|TestIntegratorAPIKeyPathless|TestAPIKeysRequireIntegrator'` → all pass.
- Verified the new test catches the regression: with the allowlist entry removed it fails with the exact 403/40157 from the bug report; with the fix it passes.
- `gofmt` clean; `golangci-lint` reports no new issues in the changed files.