### PR TITLE
feat(api): meter relayed votes and cap elections by vote allowance (MaxVotes)

### DIFF
--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -633,6 +633,9 @@ type SubscriptionPlanLimits struct {
 	// Maximum number of census allowed
 	MaxCensus int `json:"maxCensus"`
 
+	// Maximum number of votes that may be relayed; 0 means unlimited
+	MaxVotes int `json:"maxVotes"`
+
 	// Maximum duration of voting processes in days
 	MaxDuration int `json:"maxDaysDuration"`
 
@@ -763,6 +766,9 @@ type SubscriptionUsage struct {
 	// Number of emails sent
 	SentEmails int `json:"sentEmails"`
 
+	// Number of votes relayed
+	SentVotes int `json:"sentVotes"`
+
 	// Number of sub-organizations created
 	SubOrgs int `json:"subOrgs"`
 
@@ -781,6 +787,7 @@ func SubscriptionUsageFromDB(usage *db.OrganizationCounters) SubscriptionUsage {
 	return SubscriptionUsage{
 		SentSMS:    usage.SentSMS,
 		SentEmails: usage.SentEmails,
+		SentVotes:  usage.SentVotes,
 		SubOrgs:    usage.SubOrgs,
 		Users:      usage.Users,
 		Processes:  usage.Processes,

--- a/api/process_vote.go
+++ b/api/process_vote.go
@@ -103,6 +103,11 @@ func (a *API) relayVoteHandler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			return nil, err
 		}
+		// meter the relayed vote for billing/quota; best-effort, never fail the relay on a
+		// counter error. The quota itself is enforced at election publish, not here.
+		if err := a.db.IncrementOrganizationSentVotesCounter(process.OrgAddress); err != nil {
+			log.Errorw(err, "failed to increment org sent votes counter")
+		}
 		return &db.JobResult{VoteID: internal.HexBytes(voteID)}, nil
 	}}) {
 		// full queue: mark the job failed so it is not orphaned pending.

--- a/api/process_vote_test.go
+++ b/api/process_vote_test.go
@@ -272,4 +272,9 @@ func TestRelayVote(t *testing.T) {
 	votesAfter, err := vocdoniClient.ElectionVoteCount(processID.Bytes())
 	c.Assert(err, qt.IsNil)
 	c.Assert(votesAfter, qt.Equals, votesBefore+1, qt.Commentf("expected 1 more vote, got %d", votesAfter))
+
+	// a chain-accepted relay meters the owning organization's SentVotes counter
+	orgAfter, err := testDB.Organization(orgAddress)
+	c.Assert(err, qt.IsNil)
+	c.Assert(orgAfter.Counters.SentVotes, qt.Equals, 1)
 }

--- a/db/organizations.go
+++ b/db/organizations.go
@@ -418,6 +418,12 @@ func (ms *MongoStorage) IncrementOrganizationSentSMSCounter(address common.Addre
 	return ms.addToOrganizationCounter(address, "sentSMS", 1)
 }
 
+// IncrementOrganizationSentVotesCounter atomically increments the relayed-votes counter
+// for the organization with the given address.
+func (ms *MongoStorage) IncrementOrganizationSentVotesCounter(address common.Address) error {
+	return ms.addToOrganizationCounter(address, "sentVotes", 1)
+}
+
 // IncrementOrganizationManagedOrgsCounterWithLimit atomically increments the managed
 // organizations counter only if it stays within limit, re-reading the counter under
 // keysLock so two concurrent creates cannot both pass a stale check and exceed the cap
@@ -572,6 +578,12 @@ func (ms *MongoStorage) SumSentEmailsManagedBy(integratorAddr common.Address) (i
 // by integratorAddr (the integrator's shared 2FA-SMS pool consumption).
 func (ms *MongoStorage) SumSentSMSManagedBy(integratorAddr common.Address) (int, error) {
 	return ms.sumManagedCounter(integratorAddr, "sentSMS")
+}
+
+// SumSentVotesManagedBy returns the total votes relayed across all organizations managed
+// by integratorAddr (the integrator's shared vote pool consumption).
+func (ms *MongoStorage) SumSentVotesManagedBy(integratorAddr common.Address) (int, error) {
+	return ms.sumManagedCounter(integratorAddr, "sentVotes")
 }
 
 func (ms *MongoStorage) fetchOrganizationAndPlan(orgAddress common.Address) (*Organization, *Plan, error) {

--- a/db/types.go
+++ b/db/types.go
@@ -112,6 +112,9 @@ type PlanLimits struct {
 	SubOrgs      int `json:"subOrgs" bson:"subOrgs"`
 	MaxProcesses int `json:"maxProcesses" bson:"maxProcesses"`
 	MaxCensus    int `json:"maxCensus" bson:"maxCensus"`
+	// Max votes that may be relayed; 0 means unlimited. For managed orgs this is the
+	// integrator's shared pool, summed across all its managed orgs.
+	MaxVotes int `json:"maxVotes" bson:"maxVotes"`
 	// Max process duration in days
 	MaxDuration int  `json:"maxDaysDuration" bson:"maxDuration"`
 	CustomURL   bool `json:"customURL" bson:"customURL"`
@@ -186,6 +189,7 @@ type OrganizationSubscription struct {
 type OrganizationCounters struct {
 	SentSMS           int `json:"sentSMS" bson:"sentSMS"`
 	SentEmails        int `json:"sentEmails" bson:"sentEmails"`
+	SentVotes         int `json:"sentVotes" bson:"sentVotes"`
 	SubOrgs           int `json:"subOrgs" bson:"subOrgs"`
 	Users             int `json:"users" bson:"users"`
 	Processes         int `json:"processes" bson:"processes"`

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1313,6 +1313,9 @@ definitions:
       maxProcesses:
         description: Maximum number of voting processes allowed
         type: integer
+      maxVotes:
+        description: Maximum number of votes that may be relayed; 0 means unlimited
+        type: integer
       subOrgs:
         description: Maximum number of sub-organizations allowed
         type: integer
@@ -1330,6 +1333,9 @@ definitions:
         type: integer
       sentSMS:
         description: Number of SMS messages sent
+        type: integer
+      sentVotes:
+        description: Number of votes relayed
         type: integer
       subOrgs:
         description: Number of sub-organizations created
@@ -1762,6 +1768,11 @@ definitions:
         description: Max process duration in days
         type: integer
       maxProcesses:
+        type: integer
+      maxVotes:
+        description: |-
+          Max votes that may be relayed; 0 means unlimited. For managed orgs this is the
+          integrator's shared pool, summed across all its managed orgs.
         type: integer
       subOrgs:
         type: integer

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -92,6 +92,7 @@ var (
 	ErrProcessCensusSizeExceedsPlanLimit      = Error{Code: 40035, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("process census size exceeds plan limit")}
 	ErrProcessCensusSizeExceedsEmailAllowance = Error{Code: 40046, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("process census size exceeds email allowance")}
 	ErrProcessCensusSizeExceedsSMSAllowance   = Error{Code: 40047, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("process census size exceeds sms allowance")}
+	ErrProcessCensusSizeExceedsVoteAllowance  = Error{Code: 40162, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("process census size exceeds vote allowance")}
 	ErrMaxOrganizationsReached                = Error{Code: 40048, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("user has reached maximum number of organizations")}
 	ErrExceedsOrganizationMembersLimit        = Error{Code: 40145, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("operation would exceed organization members limit")}
 	ErrAutoGroupCannotBeDeleted               = Error{Code: 40150, HTTPstatus: http.StatusForbidden, Err: fmt.Errorf("the \"All members\" group is auto-generated and cannot be deleted")}

--- a/subscriptions/subscriptions.go
+++ b/subscriptions/subscriptions.go
@@ -65,6 +65,7 @@ type DBInterface interface {
 	CountMembersManagedBy(integratorAddr common.Address) (int64, error)
 	SumSentEmailsManagedBy(integratorAddr common.Address) (int, error)
 	SumSentSMSManagedBy(integratorAddr common.Address) (int, error)
+	SumSentVotesManagedBy(integratorAddr common.Address) (int, error)
 	CountProcesses(orgAddress common.Address, draft db.DraftFilter) (int64, error)
 	OrganizationMemberGroup(groupID string, orgAddress common.Address) (*db.OrganizationMemberGroup, error)
 }
@@ -349,6 +350,22 @@ func (p *Subscriptions) OrgCanPublishGroupCensus(census *db.Census, groupID stri
 		}
 		if remainingSMS := max(0, plan.Features.TwoFaSms-sentSMS); memberCount > remainingSMS {
 			return errors.ErrProcessCensusSizeExceedsSMSAllowance.Withf("remaining sms: %d", remainingSMS)
+		}
+	}
+
+	// Votes are metered for billing rather than blocked at cast time: an election may not be
+	// published when its census size could exceed the remaining vote quota. As with 2FA, a
+	// managed org draws on the integrator's shared pool (summed across its managed orgs); a
+	// standalone org uses its own counter. MaxVotes of 0 means unlimited.
+	if plan.Organization.MaxVotes > 0 {
+		sentVotes := org.Counters.SentVotes
+		if managed(org) {
+			if sentVotes, err = p.db.SumSentVotesManagedBy(owner.Address); err != nil {
+				return errors.ErrGenericInternalServerError.WithErr(err)
+			}
+		}
+		if remainingVotes := max(0, plan.Organization.MaxVotes-sentVotes); memberCount > remainingVotes {
+			return errors.ErrProcessCensusSizeExceedsVoteAllowance.Withf("remaining votes: %d", remainingVotes)
 		}
 	}
 

--- a/subscriptions/subscriptions_test.go
+++ b/subscriptions/subscriptions_test.go
@@ -327,7 +327,7 @@ func TestManagedOrgLimitsUseIntegratorPlan(t *testing.T) {
 			integratorPlanID: {
 				ID: integratorPlanID,
 				Organization: db.PlanLimits{
-					MaxProcesses: 100, MaxCensus: 1000, MaxDuration: 30, MaxDrafts: 10,
+					MaxProcesses: 100, MaxCensus: 1000, MaxDuration: 30, MaxDrafts: 10, MaxVotes: 100,
 				},
 				Features: db.Features{Anonymous: true, TwoFaEmail: 100, TwoFaSms: 100},
 			},
@@ -335,7 +335,7 @@ func TestManagedOrgLimitsUseIntegratorPlan(t *testing.T) {
 			tinyPlanID: {
 				ID: tinyPlanID,
 				Organization: db.PlanLimits{
-					MaxProcesses: 0, MaxCensus: 1, MaxDuration: 0, MaxDrafts: 0,
+					MaxProcesses: 0, MaxCensus: 1, MaxDuration: 0, MaxDrafts: 0, MaxVotes: 1,
 				},
 				Features: db.Features{Anonymous: false, TwoFaEmail: 0, TwoFaSms: 0},
 			},
@@ -359,6 +359,7 @@ func TestManagedOrgLimitsUseIntegratorPlan(t *testing.T) {
 		membersManagedBy:    map[string]int64{integratorAddr.String(): 5},
 		sentEmailsManagedBy: map[string]int{integratorAddr.String(): 10},
 		sentSMSManagedBy:    map[string]int{integratorAddr.String(): 10},
+		sentVotesManagedBy:  map[string]int{integratorAddr.String(): 10},
 		orgMembers:          map[string]int64{standaloneAddr.String(): 5},
 		groups: map[string]*db.OrganizationMemberGroup{
 			"group-1": {MemberIDs: []string{"a", "b", "c"}},
@@ -435,6 +436,17 @@ func TestManagedOrgLimitsUseIntegratorPlan(t *testing.T) {
 	// Standalone tiny plan: TwoFaEmail 0 - 0 = 0 remaining < 3 members — rejected.
 	c.Assert(subs.OrgCanPublishGroupCensus(emailCensus(standaloneAddr), "group-1"),
 		qt.ErrorIs, errors.ErrProcessCensusSizeExceedsEmailAllowance)
+
+	// --- Vote shared pool (OrgCanPublishGroupCensus) ---
+	// A census with no 2FA fields isolates the vote allowance from the email/sms checks.
+	plainCensus := func(orgAddr common.Address) *db.Census {
+		return &db.Census{OrgAddress: orgAddr}
+	}
+	// Managed org: integrator MaxVotes (100) - shared sent (10) = 90 remaining >= 3 members — allowed.
+	c.Assert(subs.OrgCanPublishGroupCensus(plainCensus(managedAddr), "group-1"), qt.IsNil)
+	// Standalone tiny plan: MaxVotes 1 - own sent (0) = 1 remaining < 3 members — rejected.
+	c.Assert(subs.OrgCanPublishGroupCensus(plainCensus(standaloneAddr), "group-1"),
+		qt.ErrorIs, errors.ErrProcessCensusSizeExceedsVoteAllowance)
 }
 
 // TestManagedOrgSharedPoolExceeded asserts the integrator's shared pool is enforced: when
@@ -450,7 +462,7 @@ func TestManagedOrgSharedPoolExceeded(t *testing.T) {
 		plans: map[string]*db.Plan{
 			integratorPlanID: {
 				ID:           integratorPlanID,
-				Organization: db.PlanLimits{MaxCensus: 100},
+				Organization: db.PlanLimits{MaxCensus: 100, MaxVotes: 50},
 				Features:     db.Features{TwoFaSms: 50},
 			},
 			tinyPlanID: {ID: tinyPlanID, Organization: db.PlanLimits{MaxCensus: 1}},
@@ -467,8 +479,9 @@ func TestManagedOrgSharedPoolExceeded(t *testing.T) {
 			},
 		},
 		// pool already near the integrator's limits
-		membersManagedBy: map[string]int64{integratorAddr.String(): 99},
-		sentSMSManagedBy: map[string]int{integratorAddr.String(): 50},
+		membersManagedBy:   map[string]int64{integratorAddr.String(): 99},
+		sentSMSManagedBy:   map[string]int{integratorAddr.String(): 50},
+		sentVotesManagedBy: map[string]int{integratorAddr.String(): 50},
 		groups: map[string]*db.OrganizationMemberGroup{
 			"group-1": {MemberIDs: []string{"a"}},
 		},
@@ -481,6 +494,10 @@ func TestManagedOrgSharedPoolExceeded(t *testing.T) {
 	smsCensus := &db.Census{OrgAddress: managedAddr, TwoFaFields: db.OrgMemberTwoFaFields{db.OrgMemberTwoFaFieldPhone}}
 	c.Assert(subs.OrgCanPublishGroupCensus(smsCensus, "group-1"),
 		qt.ErrorIs, errors.ErrProcessCensusSizeExceedsSMSAllowance)
+	// votes: pool at 50, integrator MaxVotes 50 → 0 remaining, 1 member needed → rejected.
+	voteCensus := &db.Census{OrgAddress: managedAddr}
+	c.Assert(subs.OrgCanPublishGroupCensus(voteCensus, "group-1"),
+		qt.ErrorIs, errors.ErrProcessCensusSizeExceedsVoteAllowance)
 }
 
 // TestManagedOrgMissingIntegratorFailsClosed asserts a managed org whose integrator cannot
@@ -513,6 +530,7 @@ type mockMongoStorage struct {
 	membersManagedBy    map[string]int64
 	sentEmailsManagedBy map[string]int
 	sentSMSManagedBy    map[string]int
+	sentVotesManagedBy  map[string]int
 	// keyed by orgAddress string
 	orgMembers map[string]int64
 	// keyed by groupID
@@ -569,6 +587,10 @@ func (m *mockMongoStorage) SumSentEmailsManagedBy(integratorAddr common.Address)
 
 func (m *mockMongoStorage) SumSentSMSManagedBy(integratorAddr common.Address) (int, error) {
 	return m.sentSMSManagedBy[integratorAddr.String()], nil
+}
+
+func (m *mockMongoStorage) SumSentVotesManagedBy(integratorAddr common.Address) (int, error) {
+	return m.sentVotesManagedBy[integratorAddr.String()], nil
 }
 
 func (*mockMongoStorage) CountCensusParticipants(string) (int64, error) {


### PR DESCRIPTION
## What

Meters relayed votes for billing and caps usage via a new plan limit `MaxVotes` — **without blocking voters**. Votes always relay; the integrator is billed for what's cast. Enforcement happens at **election publish**: a group census can't be published when its size could exceed the remaining vote allowance.

This mirrors the SMS/email census-size allowance gate and is **built on #557** — the allowance resolves through `limitsOwner`, so:
- a **managed org** draws on the **integrator's shared vote pool** (summed across all its managed orgs via `SumSentVotesManagedBy`);
- a **standalone org** uses its own counter.

`MaxVotes = 0` means **unlimited** (non-breaking: existing plans are unaffected).

## Changes

- **`db.OrganizationCounters.SentVotes`** + `IncrementOrganizationSentVotesCounter`, `SumSentVotesManagedBy` (shared-pool aggregate, mirrors `SumSentSMSManagedBy`).
- **`db.PlanLimits.MaxVotes`** + API surface (`SubscriptionUsage.SentVotes`, `SubscriptionPlanLimits.MaxVotes`).
- **`subscriptions.OrgCanPublishGroupCensus`** — vote-allowance block alongside the email/sms checks: deny when `memberCount > max(0, MaxVotes − sentVotes)`.
- **`POST /vote`** — increments `SentVotes` on a chain-accepted relay (best-effort, in the worker). No quota block at cast time.
- **`ErrProcessCensusSizeExceedsVoteAllowance`** — code `40162`, HTTP **400**, grouped with the email/sms allowance errors.

## Test

- `TestManagedOrgLimits` / `TestManagedOrgSharedPoolExceeded` extended with the vote pool: managed org draws the integrator allowance; standalone uses its own; pool-exhausted is rejected.
- `TestRelayVote` (Docker): votes relay and `SentVotes` increments.
- `golangci-lint --new-from-rev=origin/main`: 0 issues.

## Follow-up (not in this PR)

- Seed real `maxVotes` values into the default/Stripe plan definitions — required before any cap actually bites (0 = unlimited until then).