### PR TITLE
feat(integrator): expose pooled votes/SMS/email usage and caps on /integrator

### DIFF
--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -534,12 +534,11 @@ type DeleteManagedOrganizationResponse struct {
 // IntegratorUsage holds an integrator's current managed-resource usage counters. SentVotes/
 // SentSMS/SentEmails are the shared-pool totals summed across the integrator's managed orgs.
 type IntegratorUsage struct {
-	ManagedOrgs       int `json:"managedOrgs"`
-	ManagedProcesses  int `json:"managedProcesses"`
-	ManagedCensusSize int `json:"managedCensusSize"`
-	SentVotes         int `json:"sentVotes"`
-	SentSMS           int `json:"sentSMS"`
-	SentEmails        int `json:"sentEmails"`
+	ManagedOrgs      int `json:"managedOrgs"`
+	ManagedProcesses int `json:"managedProcesses"`
+	SentVotes        int `json:"sentVotes"`
+	SentSMS          int `json:"sentSMS"`
+	SentEmails       int `json:"sentEmails"`
 }
 
 // IntegratorLimits holds an integrator's effective caps for the dashboard. MaxManagedOrgs is
@@ -547,12 +546,11 @@ type IntegratorUsage struct {
 // pools shared across its managed orgs. 0 means unlimited (or unknown, when an override-enabled
 // integrator has no subscription plan).
 type IntegratorLimits struct {
-	MaxManagedOrgs       int `json:"maxManagedOrgs"`
-	MaxManagedProcesses  int `json:"maxManagedProcesses"`
-	MaxManagedCensusSize int `json:"maxManagedCensusSize"`
-	MaxVotes             int `json:"maxVotes"`
-	MaxSMS               int `json:"maxSMS"`
-	MaxEmails            int `json:"maxEmails"`
+	MaxManagedOrgs      int `json:"maxManagedOrgs"`
+	MaxManagedProcesses int `json:"maxManagedProcesses"`
+	MaxVotes            int `json:"maxVotes"`
+	MaxSMS              int `json:"maxSMS"`
+	MaxEmails           int `json:"maxEmails"`
 }
 
 // IntegratorInfoResponse is returned by GET /organizations/{address}/integrator.

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -531,19 +531,36 @@ type DeleteManagedOrganizationResponse struct {
 	Address string `json:"address"`
 }
 
-// IntegratorUsage holds an integrator's current managed-resource usage counters.
+// IntegratorUsage holds an integrator's current managed-resource usage counters. SentVotes/
+// SentSMS/SentEmails are the shared-pool totals summed across the integrator's managed orgs.
 type IntegratorUsage struct {
 	ManagedOrgs       int `json:"managedOrgs"`
 	ManagedProcesses  int `json:"managedProcesses"`
 	ManagedCensusSize int `json:"managedCensusSize"`
+	SentVotes         int `json:"sentVotes"`
+	SentSMS           int `json:"sentSMS"`
+	SentEmails        int `json:"sentEmails"`
+}
+
+// IntegratorLimits holds an integrator's effective caps for the dashboard. MaxManagedOrgs is
+// the effective integrator limit; the rest are the integrator's subscription-plan caps for the
+// pools shared across its managed orgs. 0 means unlimited (or unknown, when an override-enabled
+// integrator has no subscription plan).
+type IntegratorLimits struct {
+	MaxManagedOrgs       int `json:"maxManagedOrgs"`
+	MaxManagedProcesses  int `json:"maxManagedProcesses"`
+	MaxManagedCensusSize int `json:"maxManagedCensusSize"`
+	MaxVotes             int `json:"maxVotes"`
+	MaxSMS               int `json:"maxSMS"`
+	MaxEmails            int `json:"maxEmails"`
 }
 
 // IntegratorInfoResponse is returned by GET /organizations/{address}/integrator.
 // Limits is only present when Enabled is true.
 type IntegratorInfoResponse struct {
-	Enabled bool                 `json:"enabled"`
-	Limits  *db.IntegratorLimits `json:"limits,omitempty"`
-	Usage   IntegratorUsage      `json:"usage"`
+	Enabled bool              `json:"enabled"`
+	Limits  *IntegratorLimits `json:"limits,omitempty"`
+	Usage   IntegratorUsage   `json:"usage"`
 }
 
 // OrganizationSubscriptionInfo provides detailed information about an organization's subscription.

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -547,9 +547,10 @@ type IntegratorUsage struct {
 //
 // Zero is not uniformly "unlimited". Only MaxVotes treats 0 as unlimited (vote enforcement is
 // skipped when the plan's MaxVotes is 0). MaxManagedProcesses, MaxSMS and MaxEmails are hard
-// caps where 0 means no allowance. Separately, every field is left at 0 when an override-enabled
-// integrator has no subscription plan to source caps from — an "unknown" the dashboard should
-// treat distinctly from a real 0 cap.
+// caps where 0 means no allowance. Separately, the plan-sourced fields (everything except
+// MaxManagedOrgs, which always comes from the effective integrator limit) are left at 0 when an
+// override-enabled integrator has no subscription plan to source caps from — an "unknown" the
+// dashboard should treat distinctly from a real 0 cap.
 type IntegratorLimits struct {
 	MaxManagedOrgs      int `json:"maxManagedOrgs"`
 	MaxManagedProcesses int `json:"maxManagedProcesses"`

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -543,8 +543,13 @@ type IntegratorUsage struct {
 
 // IntegratorLimits holds an integrator's effective caps for the dashboard. MaxManagedOrgs is
 // the effective integrator limit; the rest are the integrator's subscription-plan caps for the
-// pools shared across its managed orgs. 0 means unlimited (or unknown, when an override-enabled
-// integrator has no subscription plan).
+// pools shared across its managed orgs.
+//
+// Zero is not uniformly "unlimited". Only MaxVotes treats 0 as unlimited (vote enforcement is
+// skipped when the plan's MaxVotes is 0). MaxManagedProcesses, MaxSMS and MaxEmails are hard
+// caps where 0 means no allowance. Separately, every field is left at 0 when an override-enabled
+// integrator has no subscription plan to source caps from — an "unknown" the dashboard should
+// treat distinctly from a real 0 cap.
 type IntegratorLimits struct {
 	MaxManagedOrgs      int `json:"maxManagedOrgs"`
 	MaxManagedProcesses int `json:"maxManagedProcesses"`

--- a/api/integrator_test.go
+++ b/api/integrator_test.go
@@ -96,7 +96,6 @@ func TestIntegratorManagedOrgs(t *testing.T) {
 	c.Assert(info.Enabled, qt.IsTrue)
 	c.Assert(info.Limits.MaxManagedOrgs, qt.Equals, 2)
 	c.Assert(info.Limits.MaxManagedProcesses, qt.Equals, 1)
-	c.Assert(info.Limits.MaxManagedCensusSize, qt.Equals, 1000)
 	c.Assert(info.Limits.MaxVotes, qt.Equals, 5000)
 	c.Assert(info.Limits.MaxSMS, qt.Equals, 50)
 	c.Assert(info.Limits.MaxEmails, qt.Equals, 100)

--- a/api/integrator_test.go
+++ b/api/integrator_test.go
@@ -122,6 +122,30 @@ func TestIntegratorManagedOrgs(t *testing.T) {
 		Active:          true,
 	}), qt.IsNil)
 
+	// a managed org may not publish a process whose declared census size exceeds the
+	// integrator plan's MaxCensus (1000): the per-process bound applies to managed orgs even
+	// though the aggregate process-count quota is what governs how many they may publish.
+	overCapDraft, err := testDB.SetProcess(&db.Process{
+		OrgAddress: firstManaged,
+		ElectionParams: &db.ElectionParams{
+			Title:         db.MultiLangString{"default": "Over-cap managed election"},
+			EndDate:       time.Now().Add(2 * time.Hour),
+			MaxCensusSize: 2000,
+			Questions: []db.Question{{
+				Title: db.MultiLangString{"default": "Q1"},
+				Choices: []db.Choice{
+					{Title: db.MultiLangString{"default": "Yes"}, Value: 0},
+					{Title: db.MultiLangString{"default": "No"}, Value: 1},
+				},
+			}},
+			VoteType:     db.VoteType{MaxCount: 1, MaxValue: 1},
+			ElectionType: db.ElectionType{Autostart: true, Interruptible: true},
+		},
+	})
+	c.Assert(err, qt.IsNil)
+	_, code = testRequest(t, http.MethodPost, token, nil, "process", overCapDraft.Hex(), "publish")
+	c.Assert(code, qt.Equals, http.StatusUnauthorized) // ErrProcessCensusSizeExceedsPlanLimit, wrapped
+
 	// seed + publish a draft (MaxCensusSize 100, within the 1000 integrator cap)
 	draftID, err := testDB.SetProcess(&db.Process{
 		OrgAddress: firstManaged,

--- a/api/integrator_test.go
+++ b/api/integrator_test.go
@@ -41,7 +41,8 @@ func TestIntegratorManagedOrgs(t *testing.T) {
 	integratorPlan := &db.Plan{
 		ID:           "prod_test_integrator_caps",
 		Name:         "Integrator Caps",
-		Organization: db.PlanLimits{MaxProcesses: 1, MaxCensus: 1000, MaxDuration: 30},
+		Organization: db.PlanLimits{MaxProcesses: 1, MaxCensus: 1000, MaxVotes: 5000, MaxDuration: 30},
+		Features:     db.Features{TwoFaSms: 50, TwoFaEmail: 100},
 	}
 	c.Assert(testDB.SetPlan(integratorPlan), qt.IsNil)
 	defer func() { _ = testDB.DelPlan(&db.Plan{ID: integratorPlan.ID}) }()
@@ -78,13 +79,31 @@ func TestIntegratorManagedOrgs(t *testing.T) {
 		"integrator", "organizations")
 	c.Assert(code, qt.Equals, http.StatusBadRequest) // ErrMaxManagedOrgsReached
 
-	// integrator info reflects usage + limits
+	// seed shared-pool usage on a managed org: 3 votes, 2 SMS, 1 email
+	for i := 0; i < 3; i++ {
+		c.Assert(testDB.IncrementOrganizationSentVotesCounter(firstManaged), qt.IsNil)
+	}
+	for i := 0; i < 2; i++ {
+		c.Assert(testDB.IncrementOrganizationSentSMSCounter(firstManaged), qt.IsNil)
+	}
+	c.Assert(testDB.IncrementOrganizationSentEmailsCounter(firstManaged), qt.IsNil)
+
+	// integrator info reflects usage + limits, including the plan's pooled caps and the
+	// vote/SMS/email usage aggregated across the integrator's managed orgs
 	info := requestAndParse[apicommon.IntegratorInfoResponse](
 		t, http.MethodGet, token, nil, "integrator",
 	)
 	c.Assert(info.Enabled, qt.IsTrue)
 	c.Assert(info.Limits.MaxManagedOrgs, qt.Equals, 2)
+	c.Assert(info.Limits.MaxManagedProcesses, qt.Equals, 1)
+	c.Assert(info.Limits.MaxManagedCensusSize, qt.Equals, 1000)
+	c.Assert(info.Limits.MaxVotes, qt.Equals, 5000)
+	c.Assert(info.Limits.MaxSMS, qt.Equals, 50)
+	c.Assert(info.Limits.MaxEmails, qt.Equals, 100)
 	c.Assert(info.Usage.ManagedOrgs, qt.Equals, 2)
+	c.Assert(info.Usage.SentVotes, qt.Equals, 3)
+	c.Assert(info.Usage.SentSMS, qt.Equals, 2)
+	c.Assert(info.Usage.SentEmails, qt.Equals, 1)
 
 	// managed list returns the two orgs
 	list := requestAndParse[apicommon.ListManagedOrganizations](

--- a/api/integrator_test.go
+++ b/api/integrator_test.go
@@ -145,11 +145,10 @@ func TestIntegratorManagedOrgs(t *testing.T) {
 	c.Assert(pubJob.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("error: %s", pubJob.Error))
 	c.Assert(len(pubJob.Result.Address) > 0, qt.IsTrue)
 
-	// the integrator's aggregate counters were bumped
+	// the integrator's aggregate process counter was bumped
 	integratorOrg, err = testDB.Organization(integratorAddr)
 	c.Assert(err, qt.IsNil)
 	c.Assert(integratorOrg.Counters.ManagedProcesses, qt.Equals, 1)
-	c.Assert(integratorOrg.Counters.ManagedCensusSize, qt.Equals, 100)
 
 	// a second publish is blocked by the aggregate quota (plan MaxProcesses == 1)
 	draftID2, err := testDB.SetProcess(&db.Process{

--- a/api/organizations_managed.go
+++ b/api/organizations_managed.go
@@ -442,18 +442,16 @@ func (a *API) deleteManagedOrganizationHandler(w http.ResponseWriter, r *http.Re
 	}
 
 	// capture usage to roll back the integrator counters after deletion. The integrator's
-	// ManagedProcesses and ManagedCensusSize counters are bumped on publish only for non-test-sized
-	// elections (ElectionParams.MaxCensusSize > db.TestMaxCensusSize), by 1 and by MaxCensusSize
-	// respectively (see api/process.go). The rollback delta must mirror that rule exactly, so both
-	// are derived from the published non-test-sized processes' ElectionParams rather than from the
-	// census documents (whose Size is the current participant count and can under-decrement).
-	var nonTestPublishedCount, managedCensusSize int64
+	// ManagedProcesses counter is bumped on publish only for non-test-sized elections
+	// (ElectionParams.MaxCensusSize > db.TestMaxCensusSize), by 1 (see api/process.go). The
+	// rollback delta must mirror that rule exactly, so it is derived from the published
+	// non-test-sized processes' ElectionParams rather than from the census documents.
+	var nonTestPublishedCount int64
 	for _, p := range published {
 		if p.ElectionParams == nil || p.ElectionParams.MaxCensusSize <= uint64(db.TestMaxCensusSize) {
 			continue
 		}
 		nonTestPublishedCount++
-		managedCensusSize += int64(p.ElectionParams.MaxCensusSize)
 	}
 
 	// cascade: each step is best-effort. Failures are logged but do not abort the teardown, so a
@@ -526,9 +524,8 @@ func (a *API) deleteManagedOrganizationHandler(w http.ResponseWriter, r *http.Re
 	}
 
 	// roll back the integrator's aggregate usage counters (best-effort). ManagedOrgs always -1;
-	// processes/census only by the deltas captured above (published non-test-sized elections and
-	// their summed MaxCensusSize), mirroring the publish-time bump rule so the counters never go
-	// negative.
+	// processes only by the delta captured above (published non-test-sized elections), mirroring
+	// the publish-time bump rule so the counter never goes negative.
 	if err := a.db.DecrementOrganizationManagedOrgsCounter(integratorAddr); err != nil {
 		log.Warnw("could not decrement managed orgs counter",
 			"integrator", integratorAddr.Hex(), "error", err)
@@ -539,15 +536,9 @@ func (a *API) deleteManagedOrganizationHandler(w http.ResponseWriter, r *http.Re
 				"integrator", integratorAddr.Hex(), "delta", -nonTestPublishedCount, "error", err)
 		}
 	}
-	if managedCensusSize > 0 {
-		if err := a.db.AddOrganizationManagedCensusSize(integratorAddr, -managedCensusSize); err != nil {
-			log.Warnw("could not decrement managed census size counter",
-				"integrator", integratorAddr.Hex(), "delta", -managedCensusSize, "error", err)
-		}
-	}
 
 	log.Infow("deleted managed organization",
 		"integrator", integratorAddr.Hex(), "org", managedAddr.Hex(),
-		"processes", nonTestPublishedCount, "censusSize", managedCensusSize)
+		"processes", nonTestPublishedCount)
 	apicommon.HTTPWriteJSON(w, &apicommon.DeleteManagedOrganizationResponse{Address: managedAddr.Hex()})
 }

--- a/api/organizations_managed.go
+++ b/api/organizations_managed.go
@@ -323,7 +323,31 @@ func (a *API) integratorInfoHandler(w http.ResponseWriter, r *http.Request) {
 			errors.ErrGenericInternalServerError.WithErr(err).Write(w)
 			return
 		}
-		resp.Limits = &limits
+		apiLimits := apicommon.IntegratorLimits{MaxManagedOrgs: limits.MaxManagedOrgs}
+
+		// The process/census/votes/SMS/email caps are the integrator plan's pooled limits.
+		// An override-enabled integrator may have no subscription plan; leave those caps at 0
+		// (unlimited/unknown) rather than failing the dashboard.
+		if org.Subscription.PlanID != "" {
+			if plan, err := a.db.Plan(org.Subscription.PlanID); err == nil && plan != nil {
+				apiLimits.MaxManagedProcesses = plan.Organization.MaxProcesses
+				apiLimits.MaxManagedCensusSize = plan.Organization.MaxCensus
+				apiLimits.MaxVotes = plan.Organization.MaxVotes
+				apiLimits.MaxSMS = plan.Features.TwoFaSms
+				apiLimits.MaxEmails = plan.Features.TwoFaEmail
+			}
+		}
+		resp.Limits = &apiLimits
+
+		// Shared-pool usage summed across the integrator's managed orgs, in one aggregation.
+		counters, err := a.db.SumManagedCounters(integratorAddr)
+		if err != nil {
+			errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+			return
+		}
+		resp.Usage.SentVotes = counters.SentVotes
+		resp.Usage.SentSMS = counters.SentSMS
+		resp.Usage.SentEmails = counters.SentEmails
 	}
 	apicommon.HTTPWriteJSON(w, resp)
 }

--- a/api/organizations_managed.go
+++ b/api/organizations_managed.go
@@ -324,16 +324,20 @@ func (a *API) integratorInfoHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		apiLimits := apicommon.IntegratorLimits{MaxManagedOrgs: limits.MaxManagedOrgs}
 
-		// The process/votes/SMS/email caps are the integrator plan's pooled limits.
-		// An override-enabled integrator may have no subscription plan; leave those caps at 0
-		// (unlimited/unknown) rather than failing the dashboard.
+		// The process/votes/SMS/email caps are the integrator plan's pooled limits. An
+		// override-enabled integrator may have no subscription plan; leave those caps at 0
+		// (unlimited/unknown) in that case rather than failing the dashboard. A real lookup
+		// failure on a plan that is supposed to exist is surfaced rather than masked as 0.
 		if org.Subscription.PlanID != "" {
-			if plan, err := a.db.Plan(org.Subscription.PlanID); err == nil && plan != nil {
-				apiLimits.MaxManagedProcesses = plan.Organization.MaxProcesses
-				apiLimits.MaxVotes = plan.Organization.MaxVotes
-				apiLimits.MaxSMS = plan.Features.TwoFaSms
-				apiLimits.MaxEmails = plan.Features.TwoFaEmail
+			plan, err := a.db.Plan(org.Subscription.PlanID)
+			if err != nil {
+				errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+				return
 			}
+			apiLimits.MaxManagedProcesses = plan.Organization.MaxProcesses
+			apiLimits.MaxVotes = plan.Organization.MaxVotes
+			apiLimits.MaxSMS = plan.Features.TwoFaSms
+			apiLimits.MaxEmails = plan.Features.TwoFaEmail
 		}
 		resp.Limits = &apiLimits
 

--- a/api/organizations_managed.go
+++ b/api/organizations_managed.go
@@ -312,9 +312,8 @@ func (a *API) integratorInfoHandler(w http.ResponseWriter, r *http.Request) {
 	resp := &apicommon.IntegratorInfoResponse{
 		Enabled: a.subscriptions.IsIntegrator(org),
 		Usage: apicommon.IntegratorUsage{
-			ManagedOrgs:       org.Counters.ManagedOrgs,
-			ManagedProcesses:  org.Counters.ManagedProcesses,
-			ManagedCensusSize: org.Counters.ManagedCensusSize,
+			ManagedOrgs:      org.Counters.ManagedOrgs,
+			ManagedProcesses: org.Counters.ManagedProcesses,
 		},
 	}
 	if resp.Enabled {
@@ -325,13 +324,12 @@ func (a *API) integratorInfoHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		apiLimits := apicommon.IntegratorLimits{MaxManagedOrgs: limits.MaxManagedOrgs}
 
-		// The process/census/votes/SMS/email caps are the integrator plan's pooled limits.
+		// The process/votes/SMS/email caps are the integrator plan's pooled limits.
 		// An override-enabled integrator may have no subscription plan; leave those caps at 0
 		// (unlimited/unknown) rather than failing the dashboard.
 		if org.Subscription.PlanID != "" {
 			if plan, err := a.db.Plan(org.Subscription.PlanID); err == nil && plan != nil {
 				apiLimits.MaxManagedProcesses = plan.Organization.MaxProcesses
-				apiLimits.MaxManagedCensusSize = plan.Organization.MaxCensus
 				apiLimits.MaxVotes = plan.Organization.MaxVotes
 				apiLimits.MaxSMS = plan.Features.TwoFaSms
 				apiLimits.MaxEmails = plan.Features.TwoFaEmail

--- a/api/process.go
+++ b/api/process.go
@@ -559,7 +559,7 @@ func (a *API) deleteProcessHandler(w http.ResponseWriter, r *http.Request) {
 //	@Description	/jobs/{jobId} for the resulting on-chain id. Requires Admin role. Idempotent: if
 //	@Description	the draft is already published its on-chain id is returned with 200 without sending
 //	@Description	a new transaction. Publishing under a managed organization additionally enforces the
-//	@Description	integrator's per-org and aggregate election/census quotas.
+//	@Description	integrator's aggregate election (process-count) quota.
 //	@Description
 //	@Description	Also callable with a scoped API key (scope: `voting:write`).
 //	@Tags			process
@@ -669,10 +669,10 @@ func (a *API) publishProcessHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// if this org is managed by an integrator, atomically reserve the integrator's
-	// aggregate process/census quota BEFORE building the on-chain tx, so concurrent
-	// publishes cannot each pass a stale check and exceed the cap. The reservation is
-	// rolled back (deferred) unless the publish commits. Test-sized elections are exempt
-	// from the integrator quota, mirroring the per-org Processes counter exemption below.
+	// aggregate process quota BEFORE building the on-chain tx, so concurrent publishes
+	// cannot each pass a stale check and exceed the cap. The reservation is rolled back
+	// (deferred) unless the publish commits. Test-sized elections are exempt from the
+	// integrator quota, mirroring the per-org Processes counter exemption below.
 	managedReserved := false
 	var integratorAddr common.Address
 	nonTestSized := draft.ElectionParams.MaxCensusSize > uint64(db.TestMaxCensusSize)

--- a/api/process.go
+++ b/api/process.go
@@ -682,7 +682,7 @@ func (a *API) publishProcessHandler(w http.ResponseWriter, r *http.Request) {
 			errors.ErrGenericInternalServerError.Withf("could not get integrator organization: %v", err).Write(w)
 			return
 		}
-		maxProcesses, maxCensus, err := a.subscriptions.ManagedPublishLimits(integrator)
+		maxProcesses, err := a.subscriptions.ManagedPublishLimits(integrator)
 		if err != nil {
 			if apiErr, ok := err.(errors.Error); ok {
 				apiErr.Write(w)
@@ -691,8 +691,7 @@ func (a *API) publishProcessHandler(w http.ResponseWriter, r *http.Request) {
 			errors.ErrGenericInternalServerError.WithErr(err).Write(w)
 			return
 		}
-		if err := a.db.ReserveManagedPublish(integrator.Address,
-			maxProcesses, maxCensus, int(draft.ElectionParams.MaxCensusSize)); err != nil {
+		if err := a.db.ReserveManagedPublish(integrator.Address, maxProcesses); err != nil {
 			if err == db.ErrManagedQuotaReached {
 				errors.ErrIntegratorQuotaExceeded.Write(w)
 				return
@@ -711,10 +710,6 @@ func (a *API) publishProcessHandler(w http.ResponseWriter, r *http.Request) {
 			}
 			if e := a.db.AddOrganizationManagedProcesses(integratorAddr, -1); e != nil {
 				log.Warnw("could not roll back managed processes counter", "error", e)
-			}
-			if e := a.db.AddOrganizationManagedCensusSize(integratorAddr,
-				-int64(draft.ElectionParams.MaxCensusSize)); e != nil {
-				log.Warnw("could not roll back managed census counter", "error", e)
 			}
 		}()
 	}
@@ -818,7 +813,6 @@ func (a *API) publishProcessHandler(w http.ResponseWriter, r *http.Request) {
 	// is rolled back. The idempotency guard keys off draft.Address, so a retry after
 	// failure cannot create a duplicate election.
 	reserved := managedReserved
-	censusSize := int64(draft.ElectionParams.MaxCensusSize)
 	if !a.enqueueTx(txTask{jobID: jobID, run: func() (*db.JobResult, error) {
 		defer orgLock.Unlock()
 		data, err := a.account.SubmitSignedTx(stx)
@@ -829,9 +823,6 @@ func (a *API) publishProcessHandler(w http.ResponseWriter, r *http.Request) {
 			if reserved {
 				if e := a.db.AddOrganizationManagedProcesses(integratorAddr, -1); e != nil {
 					log.Warnw("could not roll back managed processes counter", "error", e)
-				}
-				if e := a.db.AddOrganizationManagedCensusSize(integratorAddr, -censusSize); e != nil {
-					log.Warnw("could not roll back managed census counter", "error", e)
 				}
 			}
 			return nil, err

--- a/db/organizations.go
+++ b/db/organizations.go
@@ -448,13 +448,12 @@ func (ms *MongoStorage) DecrementOrganizationManagedOrgsCounter(address common.A
 	return ms.addToOrganizationCounter(address, "managedOrgs", -1)
 }
 
-// ReserveManagedPublish atomically reserves one managed process and censusDelta managed
-// census slots for the integrator, re-reading both counters under keysLock so concurrent
-// publishes cannot each pass a stale check and exceed the integrator's aggregate quota.
-// Returns ErrManagedQuotaReached if either limit would be exceeded. Roll back with
-// AddOrganizationManagedProcesses(-1) / AddOrganizationManagedCensusSize(-censusDelta) if
-// the publish later fails.
-func (ms *MongoStorage) ReserveManagedPublish(address common.Address, processLimit, censusLimit, censusDelta int) error {
+// ReserveManagedPublish atomically reserves one managed process slot for the integrator,
+// re-reading the counter under keysLock so concurrent publishes cannot each pass a stale
+// check and exceed the integrator's aggregate process quota. Returns ErrManagedQuotaReached
+// if the limit would be exceeded. Roll back with AddOrganizationManagedProcesses(-1) if the
+// publish later fails.
+func (ms *MongoStorage) ReserveManagedPublish(address common.Address, processLimit int) error {
 	ms.keysLock.Lock()
 	defer ms.keysLock.Unlock()
 
@@ -465,23 +464,12 @@ func (ms *MongoStorage) ReserveManagedPublish(address common.Address, processLim
 	if org.Counters.ManagedProcesses >= processLimit {
 		return ErrManagedQuotaReached
 	}
-	if org.Counters.ManagedCensusSize+censusDelta > censusLimit {
-		return ErrManagedQuotaReached
-	}
-	if err := ms.addToOrganizationCounter(address, "managedProcesses", 1); err != nil {
-		return err
-	}
-	return ms.addToOrganizationCounter(address, "managedCensusSize", int64(censusDelta))
+	return ms.addToOrganizationCounter(address, "managedProcesses", 1)
 }
 
 // AddOrganizationManagedProcesses atomically adds delta to the managed processes counter.
 func (ms *MongoStorage) AddOrganizationManagedProcesses(address common.Address, delta int64) error {
 	return ms.addToOrganizationCounter(address, "managedProcesses", delta)
-}
-
-// AddOrganizationManagedCensusSize atomically adds delta to the managed census size counter.
-func (ms *MongoStorage) AddOrganizationManagedCensusSize(address common.Address, delta int64) error {
-	return ms.addToOrganizationCounter(address, "managedCensusSize", delta)
 }
 
 // ListManagedOrganizations returns a paginated list of organizations managed by

--- a/db/organizations.go
+++ b/db/organizations.go
@@ -586,6 +586,55 @@ func (ms *MongoStorage) SumSentVotesManagedBy(integratorAddr common.Address) (in
 	return ms.sumManagedCounter(integratorAddr, "sentVotes")
 }
 
+// ManagedCounters is an integrator's shared-pool usage summed across all of its managed
+// organizations: votes relayed and 2FA SMS/emails sent. bson tags match the $group output
+// of SumManagedCounters.
+type ManagedCounters struct {
+	SentVotes  int `bson:"sentVotes"`
+	SentSMS    int `bson:"sentSMS"`
+	SentEmails int `bson:"sentEmails"`
+}
+
+// SumManagedCounters returns the vote/SMS/email totals across all organizations managed by
+// integratorAddr in a single aggregation, so the frequently-hit /integrator dashboard reads
+// the whole shared-pool usage in one round trip instead of three separate sumManagedCounter
+// calls.
+//
+// ponytail: one $match+$group over the managedBy set the other integrator paths already scan.
+// If /integrator ever gets hot, denormalise these onto the integrator's own Counters at
+// increment time and drop the aggregation.
+func (ms *MongoStorage) SumManagedCounters(integratorAddr common.Address) (ManagedCounters, error) {
+	if integratorAddr.Cmp(common.Address{}) == 0 {
+		return ManagedCounters{}, ErrInvalidData
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	pipeline := mongo.Pipeline{
+		{{Key: "$match", Value: bson.M{"managedBy": integratorAddr}}},
+		{{Key: "$group", Value: bson.M{
+			"_id":        nil,
+			"sentVotes":  bson.M{"$sum": "$counters.sentVotes"},
+			"sentSMS":    bson.M{"$sum": "$counters.sentSMS"},
+			"sentEmails": bson.M{"$sum": "$counters.sentEmails"},
+		}}},
+	}
+	cursor, err := ms.organizations.Aggregate(ctx, pipeline)
+	if err != nil {
+		return ManagedCounters{}, fmt.Errorf("could not aggregate managed counters: %w", err)
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	var results []ManagedCounters
+	if err := cursor.All(ctx, &results); err != nil {
+		return ManagedCounters{}, fmt.Errorf("could not decode managed counters: %w", err)
+	}
+	if len(results) == 0 {
+		return ManagedCounters{}, nil
+	}
+	return results[0], nil
+}
+
 func (ms *MongoStorage) fetchOrganizationAndPlan(orgAddress common.Address) (*Organization, *Plan, error) {
 	org, err := ms.Organization(orgAddress)
 	if err != nil {

--- a/db/types.go
+++ b/db/types.go
@@ -185,15 +185,14 @@ type OrganizationSubscription struct {
 }
 
 type OrganizationCounters struct {
-	SentSMS           int `json:"sentSMS" bson:"sentSMS"`
-	SentEmails        int `json:"sentEmails" bson:"sentEmails"`
-	SentVotes         int `json:"sentVotes" bson:"sentVotes"`
-	SubOrgs           int `json:"subOrgs" bson:"subOrgs"`
-	Users             int `json:"users" bson:"users"`
-	Processes         int `json:"processes" bson:"processes"`
-	ManagedOrgs       int `json:"managedOrgs" bson:"managedOrgs"`
-	ManagedProcesses  int `json:"managedProcesses" bson:"managedProcesses"`
-	ManagedCensusSize int `json:"managedCensusSize" bson:"managedCensusSize"`
+	SentSMS          int `json:"sentSMS" bson:"sentSMS"`
+	SentEmails       int `json:"sentEmails" bson:"sentEmails"`
+	SentVotes        int `json:"sentVotes" bson:"sentVotes"`
+	SubOrgs          int `json:"subOrgs" bson:"subOrgs"`
+	Users            int `json:"users" bson:"users"`
+	Processes        int `json:"processes" bson:"processes"`
+	ManagedOrgs      int `json:"managedOrgs" bson:"managedOrgs"`
+	ManagedProcesses int `json:"managedProcesses" bson:"managedProcesses"`
 }
 
 type OrganizationInvite struct {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4680,7 +4680,7 @@ paths:
         /jobs/{jobId} for the resulting on-chain id. Requires Admin role. Idempotent: if
         the draft is already published its on-chain id is returned with 200 without sending
         a new transaction. Publishing under a managed organization additionally enforces the
-        integrator's per-org and aggregate election/census quotas.
+        integrator's aggregate election (process-count) quota.
 
         Also callable with a scoped API key (scope: `voting:write`).
       parameters:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -461,17 +461,34 @@ definitions:
       enabled:
         type: boolean
       limits:
-        $ref: '#/definitions/db.IntegratorLimits'
+        $ref: '#/definitions/apicommon.IntegratorLimits'
       usage:
         $ref: '#/definitions/apicommon.IntegratorUsage'
     type: object
+  apicommon.IntegratorLimits:
+    properties:
+      maxEmails:
+        type: integer
+      maxManagedOrgs:
+        type: integer
+      maxManagedProcesses:
+        type: integer
+      maxSMS:
+        type: integer
+      maxVotes:
+        type: integer
+    type: object
   apicommon.IntegratorUsage:
     properties:
-      managedCensusSize:
-        type: integer
       managedOrgs:
         type: integer
       managedProcesses:
+        type: integer
+      sentEmails:
+        type: integer
+      sentSMS:
+        type: integer
+      sentVotes:
         type: integer
     type: object
   apicommon.JobInfo:

--- a/migrations/0016_organizations_managed_by_index.go
+++ b/migrations/0016_organizations_managed_by_index.go
@@ -1,0 +1,48 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func init() {
+	AddMigration(16, "organizations_managed_by_index", upOrganizationsManagedByIndex, downOrganizationsManagedByIndex)
+}
+
+// managedByIndexName is the default name Mongo assigns to a single-field ascending index on
+// managedBy; kept explicit so the down migration can drop it deterministically.
+const managedByIndexName = "managedBy_1"
+
+// upOrganizationsManagedByIndex indexes organizations.managedBy. Every integrator path filters
+// organizations by managedBy (listing managed orgs, summing their shared-pool counters), and
+// /integrator is polled frequently from the dashboard, so without this index those queries are
+// collection scans. The index is partial — only documents that actually carry managedBy (the
+// managed orgs) are indexed — because the field is omitempty and absent on standalone orgs.
+func upOrganizationsManagedByIndex(ctx context.Context, database *mongo.Database) error {
+	coll := database.Collection("organizations")
+	model := mongo.IndexModel{
+		Keys: bson.D{{Key: "managedBy", Value: 1}},
+		// Only index documents that carry managedBy. An equality match on a concrete integrator
+		// address implies managedBy exists, so the planner can still serve those queries from
+		// this partial index while standalone orgs stay out of it.
+		Options: options.Index().SetPartialFilterExpression(bson.M{"managedBy": bson.M{"$exists": true}}),
+	}
+	if _, err := coll.Indexes().CreateOne(ctx, model); err != nil {
+		return fmt.Errorf("failed to create managedBy index on organizations: %w", err)
+	}
+	return nil
+}
+
+// downOrganizationsManagedByIndex drops the managedBy index. Dropping an index is non-destructive
+// to the documents, so unlike data-bearing collections this rollback is safe to perform.
+func downOrganizationsManagedByIndex(ctx context.Context, database *mongo.Database) error {
+	coll := database.Collection("organizations")
+	if _, err := coll.Indexes().DropOne(ctx, managedByIndexName); err != nil {
+		return fmt.Errorf("failed to drop managedBy index on organizations: %w", err)
+	}
+	return nil
+}

--- a/subscriptions/subscriptions.go
+++ b/subscriptions/subscriptions.go
@@ -185,14 +185,15 @@ func (p *Subscriptions) HasTxPermission(
 			return false, errors.ErrUserHasNoAdminRole
 		}
 		newProcess := tx.GetNewProcess()
-		// For managed orgs the process-count limit is enforced against the integrator's
-		// aggregate quota (ReserveManagedPublish) at publish time, and census size is
-		// metered through the shared vote pool, so the per-org plan checks are skipped here.
-		// Capability/duration checks below still apply, using the integrator's plan.
+		// A single process's declared census size is bounded by the governing plan's MaxCensus
+		// for every org — the integrator's plan for a managed org, otherwise the org's own.
+		if newProcess.Process.MaxCensusSize > uint64(plan.Organization.MaxCensus) {
+			return false, errors.ErrProcessCensusSizeExceedsPlanLimit.Withf("plan max census: %d", plan.Organization.MaxCensus)
+		}
+		// The process-*count* limit, however, is enforced for managed orgs against the
+		// integrator's aggregate quota (ReserveManagedPublish) at publish time, so the per-org
+		// count check is skipped for them. Capability/duration checks below apply to all.
 		if !managed(org) {
-			if newProcess.Process.MaxCensusSize > uint64(plan.Organization.MaxCensus) {
-				return false, errors.ErrProcessCensusSizeExceedsPlanLimit.Withf("plan max census: %d", plan.Organization.MaxCensus)
-			}
 			if org.Counters.Processes >= plan.Organization.MaxProcesses {
 				// allow processes with less than TestMaxCensusSize for user testing
 				if newProcess.Process.MaxCensusSize > uint64(db.TestMaxCensusSize) {

--- a/subscriptions/subscriptions.go
+++ b/subscriptions/subscriptions.go
@@ -185,10 +185,10 @@ func (p *Subscriptions) HasTxPermission(
 			return false, errors.ErrUserHasNoAdminRole
 		}
 		newProcess := tx.GetNewProcess()
-		// For managed orgs the census-size and process-count limits are enforced against
-		// the integrator's aggregate quota (ReserveManagedPublish) at publish time, so the
-		// per-org plan checks are skipped here. Capability/duration checks below still apply,
-		// using the integrator's plan.
+		// For managed orgs the process-count limit is enforced against the integrator's
+		// aggregate quota (ReserveManagedPublish) at publish time, and census size is
+		// metered through the shared vote pool, so the per-org plan checks are skipped here.
+		// Capability/duration checks below still apply, using the integrator's plan.
 		if !managed(org) {
 			if newProcess.Process.MaxCensusSize > uint64(plan.Organization.MaxCensus) {
 				return false, errors.ErrProcessCensusSizeExceedsPlanLimit.Withf("plan max census: %d", plan.Organization.MaxCensus)
@@ -379,9 +379,7 @@ func (p *Subscriptions) OrgCanAddCensusParticipants(orgAddress common.Address, c
 	}
 
 	// Per-census size is bounded by the governing plan's MaxCensus: the integrator's plan
-	// for a managed org, otherwise the org's own. This keeps the participant-add path
-	// bounded (the integrator-wide ManagedCensusSize total is additionally reserved at
-	// publish) rather than relying on the publish-time check alone.
+	// for a managed org, otherwise the org's own.
 	_, plan, err := p.limitsOwner(org)
 	if err != nil {
 		return err
@@ -458,38 +456,35 @@ func (p *Subscriptions) CanCreateManagedOrg(integrator *db.Organization) error {
 	return nil
 }
 
-// ManagedPublishLimits returns the integrator's aggregate caps for publishing under its
-// managed organizations: the integrator plan's top-level process and census-size limits.
-// These bound the ManagedProcesses / ManagedCensusSize counters across all managed orgs.
-func (p *Subscriptions) ManagedPublishLimits(integrator *db.Organization) (maxProcesses, maxCensus int, err error) {
+// ManagedPublishLimits returns the integrator's aggregate cap for publishing under its
+// managed organizations: the integrator plan's top-level process limit, which bounds the
+// ManagedProcesses counter across all managed orgs.
+func (p *Subscriptions) ManagedPublishLimits(integrator *db.Organization) (maxProcesses int, err error) {
 	if !p.IsIntegrator(integrator) {
-		return 0, 0, errors.ErrNotAnIntegrator
+		return 0, errors.ErrNotAnIntegrator
 	}
 	if integrator.Subscription.PlanID == "" {
-		return 0, 0, errors.ErrPlanNotFound.With("integrator has no subscription plan")
+		return 0, errors.ErrPlanNotFound.With("integrator has no subscription plan")
 	}
 	plan, err := p.db.Plan(integrator.Subscription.PlanID)
 	if err != nil {
 		if stderrors.Is(err, db.ErrNotFound) {
-			return 0, 0, errors.ErrPlanNotFound.WithErr(err)
+			return 0, errors.ErrPlanNotFound.WithErr(err)
 		}
-		return 0, 0, errors.ErrGenericInternalServerError.WithErr(err)
+		return 0, errors.ErrGenericInternalServerError.WithErr(err)
 	}
-	return plan.Organization.MaxProcesses, plan.Organization.MaxCensus, nil
+	return plan.Organization.MaxProcesses, nil
 }
 
-// CanPublishForManagedOrg checks the integrator's aggregate process/census quota
-// before publishing an election (with the given census size) under a managed org.
-func (p *Subscriptions) CanPublishForManagedOrg(integrator *db.Organization, censusSize int) error {
-	maxProcesses, maxCensus, err := p.ManagedPublishLimits(integrator)
+// CanPublishForManagedOrg checks the integrator's aggregate process quota before publishing
+// an election under a managed org.
+func (p *Subscriptions) CanPublishForManagedOrg(integrator *db.Organization) error {
+	maxProcesses, err := p.ManagedPublishLimits(integrator)
 	if err != nil {
 		return err
 	}
 	if integrator.Counters.ManagedProcesses >= maxProcesses {
 		return errors.ErrIntegratorQuotaExceeded.Withf("max managed processes %d", maxProcesses)
-	}
-	if integrator.Counters.ManagedCensusSize+censusSize > maxCensus {
-		return errors.ErrIntegratorQuotaExceeded.Withf("max managed census size %d", maxCensus)
 	}
 	return nil
 }

--- a/subscriptions/subscriptions.go
+++ b/subscriptions/subscriptions.go
@@ -179,12 +179,15 @@ func (p *Subscriptions) HasTxPermission(
 			return false, errors.ErrUserHasNoAdminRole
 		}
 	// check CREATE PROCESS
-	case models.TxType_NEW_PROCESS, models.TxType_SET_PROCESS_CENSUS:
+	case models.TxType_NEW_PROCESS:
 		// check if the user has the admin role for the organization
 		if !user.HasRoleFor(org.Address, db.AdminRole) {
 			return false, errors.ErrUserHasNoAdminRole
 		}
 		newProcess := tx.GetNewProcess()
+		if newProcess == nil || newProcess.Process == nil {
+			return false, errors.ErrInvalidData.With("missing new-process payload")
+		}
 		// A single process's declared census size is bounded by the governing plan's MaxCensus
 		// for every org — the integrator's plan for a managed org, otherwise the org's own.
 		if newProcess.Process.MaxCensusSize > uint64(plan.Organization.MaxCensus) {
@@ -202,6 +205,23 @@ func (p *Subscriptions) HasTxPermission(
 			}
 		}
 		return hasElectionMetadataPermissions(newProcess, plan)
+
+	// check UPDATE PROCESS CENSUS
+	case models.TxType_SET_PROCESS_CENSUS:
+		// check if the user has the admin role for the organization
+		if !user.HasRoleFor(org.Address, db.AdminRole) {
+			return false, errors.ErrUserHasNoAdminRole
+		}
+		// A census update carries a SetProcess payload (not NewProcess), so it must be read with
+		// GetSetProcess. Its new census size, when set, is bounded by the governing plan's
+		// MaxCensus exactly like a new process — the integrator's plan for a managed org.
+		setProcess := tx.GetSetProcess()
+		if setProcess == nil {
+			return false, errors.ErrInvalidData.With("missing set-process payload")
+		}
+		if setProcess.GetCensusSize() > uint64(plan.Organization.MaxCensus) {
+			return false, errors.ErrProcessCensusSizeExceedsPlanLimit.Withf("plan max census: %d", plan.Organization.MaxCensus)
+		}
 
 	case models.TxType_SET_PROCESS_STATUS,
 		models.TxType_CREATE_ACCOUNT:

--- a/subscriptions/subscriptions_test.go
+++ b/subscriptions/subscriptions_test.go
@@ -392,15 +392,38 @@ func TestManagedOrgLimitsUseIntegratorPlan(t *testing.T) {
 	managedOrg := mockDB.orgs[managedAddr.String()]
 	standaloneOrg := mockDB.orgs[standaloneAddr.String()]
 
-	// --- Capability flag (Anonymous) + dropped census/process checks (HasTxPermission) ---
-	// Managed org: anonymous allowed because the integrator's plan permits it, and the
-	// per-org census/process caps are skipped (integrator aggregate governs at publish).
+	// --- Per-process census cap + capability flags (HasTxPermission) ---
+	// Managed org: the census fits the integrator's generous plan (MaxCensus 1000), anonymous is
+	// allowed by that plan, and only the per-org *process-count* cap is skipped (the integrator
+	// aggregate governs that at publish).
 	ok, err := subs.HasTxPermission(newProcessTx(), models.TxType_NEW_PROCESS, managedOrg, adminUser)
 	c.Assert(err, qt.IsNil)
 	c.Assert(ok, qt.IsTrue)
-	// Standalone org on the same tiny plan: rejected (its own plan forbids anonymous).
+	// Standalone org on the tiny plan: rejected — its MaxCensus (1) is exceeded.
 	_, err = subs.HasTxPermission(newProcessTx(), models.TxType_NEW_PROCESS, standaloneOrg, adminUser)
 	c.Assert(err, qt.Not(qt.IsNil))
+
+	// A SET_PROCESS_CENSUS tx carries a SetProcess payload; the census update is bounded by the
+	// governing plan's MaxCensus and must be read with GetSetProcess (reading it as a NewProcess
+	// would nil-panic).
+	setProcessCensusTx := func(censusSize uint64) *models.Tx {
+		return &models.Tx{
+			Payload: &models.Tx_SetProcess{
+				SetProcess: &models.SetProcessTx{
+					Txtype:     models.TxType_SET_PROCESS_CENSUS,
+					ProcessId:  []byte{0x01},
+					CensusSize: &censusSize,
+				},
+			},
+		}
+	}
+	// Managed org: a census update within the integrator plan's MaxCensus (1000) is allowed.
+	ok, err = subs.HasTxPermission(setProcessCensusTx(500), models.TxType_SET_PROCESS_CENSUS, managedOrg, adminUser)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ok, qt.IsTrue)
+	// Managed org: a census update beyond the integrator plan's MaxCensus is rejected.
+	_, err = subs.HasTxPermission(setProcessCensusTx(2000), models.TxType_SET_PROCESS_CENSUS, managedOrg, adminUser)
+	c.Assert(err, qt.ErrorIs, errors.ErrProcessCensusSizeExceedsPlanLimit)
 
 	// --- MaxDrafts value cap (OrgHasPermission) ---
 	// Managed org: governed by integrator MaxDrafts (10) — allowed; standalone tiny plan

--- a/subscriptions/subscriptions_test.go
+++ b/subscriptions/subscriptions_test.go
@@ -280,34 +280,31 @@ func TestCanPublishForManagedOrg(t *testing.T) {
 	c := qt.New(t)
 	mockDB := &mockMongoStorage{
 		plans: map[string]*db.Plan{
-			// aggregate caps come from the plan's top-level Organization limits
+			// the aggregate process cap comes from the plan's top-level Organization limit
 			integratorPlanID: {
 				ID:               integratorPlanID,
-				Organization:     db.PlanLimits{MaxProcesses: 5, MaxCensus: 100},
+				Organization:     db.PlanLimits{MaxProcesses: 5},
 				IntegratorLimits: db.IntegratorLimits{MaxManagedOrgs: 5},
 			},
 		},
 	}
 	subs := &Subscriptions{db: mockDB}
-	integrator := func(processes, censusSize int) *db.Organization {
+	integrator := func(processes int) *db.Organization {
 		return &db.Organization{
 			Subscription: db.OrganizationSubscription{PlanID: integratorPlanID, Active: true},
-			Counters:     db.OrganizationCounters{ManagedProcesses: processes, ManagedCensusSize: censusSize},
+			Counters:     db.OrganizationCounters{ManagedProcesses: processes},
 		}
 	}
 
 	// a non-integrator org (no override, no plan) is refused
-	err := subs.CanPublishForManagedOrg(&db.Organization{}, 10)
+	err := subs.CanPublishForManagedOrg(&db.Organization{})
 	c.Assert(err, qt.ErrorIs, errors.ErrNotAnIntegrator)
 
-	// within quota (census exactly at the limit) is allowed
-	c.Assert(subs.CanPublishForManagedOrg(integrator(4, 50), 50), qt.IsNil)
+	// within the process quota is allowed
+	c.Assert(subs.CanPublishForManagedOrg(integrator(4)), qt.IsNil)
 
 	// process count at the limit is rejected
-	c.Assert(subs.CanPublishForManagedOrg(integrator(5, 0), 1), qt.ErrorIs, errors.ErrIntegratorQuotaExceeded)
-
-	// census size that would exceed the limit is rejected
-	c.Assert(subs.CanPublishForManagedOrg(integrator(0, 90), 11), qt.ErrorIs, errors.ErrIntegratorQuotaExceeded)
+	c.Assert(subs.CanPublishForManagedOrg(integrator(5)), qt.ErrorIs, errors.ErrIntegratorQuotaExceeded)
 }
 
 // TestManagedOrgLimitsUseIntegratorPlan asserts that a managed org's limits are governed


### PR DESCRIPTION
**Limits** (new `apicommon.IntegratorLimits`, replacing the bare `db.IntegratorLimits` in the response) gains `maxManagedProcesses`, `maxVotes`, `maxSMS`, `maxEmails`, sourced from the integrator's subscription plan.

Zero is **not** uniformly "unlimited": only `maxVotes` treats `0` as unlimited; `maxManagedProcesses`/`maxSMS`/`maxEmails` are hard caps where `0` means no allowance. Separately, the plan-sourced fields (everything except `maxManagedOrgs`) are left at `0` as "unknown" when an override-enabled integrator has no subscription plan — clients should treat that distinctly from a real `0` cap.

### Contract change (breaking)
This PR also **removes** the census-size pool from the `/integrator` surface:
- `IntegratorUsage.managedCensusSize` and `IntegratorLimits.maxManagedCensusSize` are gone from the response.
- The underlying integrator-aggregate `ManagedCensusSize` counter and its publish-time reservation/gate are removed entirely.

Rationale: the census-size pool is superseded by the votes pool (`maxVotes`/`sentVotes`), which is the limit the platform actually meters managed-org consumption on. The per-plan `Organization.MaxCensus` is **kept** — it still bounds per-process declared census size (for managed and standalone orgs alike), per-census participant adds, and standalone member limits.

Frontend should drop the census-size card and rely on the Votes/SMS/Emails cards.

## Why
The endpoint previously exposed only managed orgs/processes/census usage and `maxManagedOrgs`; the dashboard had no data for votes, SMS or email consumption, and the process limit was never actually sent. The census-size aggregate was redundant double-accounting alongside the votes pool, so it is retired here.

## Performance
`/integrator` is polled freely from the UI, so the three per-metric sums are collapsed into a single `$match`+`$group` aggregation (`db.SumManagedCounters`) — one round trip instead of three, over the same `managedBy` set the other integrator paths already scan. A `ponytail:` note documents the denormalize-onto-the-integrator's-own-counters upgrade path if it ever gets hot.

## How verified
- `go build ./...`, `go vet ./api/... ./db/... ./subscriptions/...`
- `go test ./api/ -run TestIntegratorManagedOrgs` — extended to seed plan caps, bump a managed org's counters, assert the new usage/limit fields, and assert a managed publish over the integrator plan's `MaxCensus` is rejected (per-process census bound still applies to managed orgs) — passes
- `go test ./subscriptions/ -run 'TestCanPublishForManagedOrg|TestHasTxPermission'` — pass

Pairs with the frontend PR adding the Votes/SMS/Emails cards to the integrator dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)