### PR TITLE
fix(api): enforce integrator process quota on the /transactions path

### DIFF
--- a/api/integrator_test.go
+++ b/api/integrator_test.go
@@ -10,6 +10,8 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
+	"go.vocdoni.io/proto/build/go/models"
+	"google.golang.org/protobuf/proto"
 )
 
 // TestIntegratorManagedOrgs exercises the integrator layer: a non-integrator org is
@@ -195,4 +197,93 @@ func TestIntegratorManagedOrgs(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	_, code = testRequest(t, http.MethodPost, token, nil, "process", draftID2.Hex(), "publish")
 	c.Assert(code, qt.Equals, http.StatusBadRequest) // ErrIntegratorQuotaExceeded
+}
+
+// TestIntegratorProcessQuotaViaTransactions guards the regression where the remote-signer
+// /transactions path stopped enforcing the integrator's shared process quota for managed orgs.
+// A managed org creating elections through /transactions must consume, and be capped by, the
+// integrator's aggregate ManagedProcesses quota — exactly like /process/{id}/publish does.
+func TestIntegratorProcessQuotaViaTransactions(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	token := testCreateUser(t, "integratorpass123")
+	integratorAddr := testCreateOrganization(t, token)
+
+	// enable integrator (override) and subscribe it to a plan whose top-level MaxProcesses (1)
+	// is the shared process cap across all of its managed orgs.
+	integratorOrg, err := testDB.Organization(integratorAddr)
+	c.Assert(err, qt.IsNil)
+	integratorOrg.IntegratorLimits = &db.IntegratorLimits{MaxManagedOrgs: 1}
+	c.Assert(testDB.SetOrganization(integratorOrg), qt.IsNil)
+
+	integratorPlan := &db.Plan{
+		ID:           "prod_test_tx_quota",
+		Name:         "Integrator Tx Quota",
+		Organization: db.PlanLimits{MaxProcesses: 1, MaxCensus: 1000, MaxVotes: 5000, MaxDuration: 30},
+		Features:     db.Features{TwoFaSms: 50, TwoFaEmail: 100},
+	}
+	c.Assert(testDB.SetPlan(integratorPlan), qt.IsNil)
+	defer func() { _ = testDB.DelPlan(&db.Plan{ID: integratorPlan.ID}) }()
+	c.Assert(testDB.SetOrganizationSubscription(integratorAddr, &db.OrganizationSubscription{
+		PlanID:          integratorPlan.ID,
+		StartDate:       time.Now(),
+		RenewalDate:     time.Now().Add(24 * time.Hour),
+		LastPaymentDate: time.Now(),
+		Active:          true,
+	}), qt.IsNil)
+
+	// create a managed org: its on-chain account is provisioned eagerly and the calling user
+	// becomes its admin, so it can fund and sign NEW_PROCESS txs through /transactions.
+	managed := requestAndParse[apicommon.OrganizationInfo](
+		t, http.MethodPost, token,
+		&apicommon.CreateManagedOrganizationRequest{
+			OrganizationInfo: apicommon.OrganizationInfo{Type: string(db.CompanyType), Website: "https://managed.example"},
+		},
+		"integrator", "organizations",
+	)
+	c.Assert(managed.Address, qt.Not(qt.Equals), common.Address{})
+
+	// newProcessTx builds a marshalled NEW_PROCESS tx for the managed org with the given census
+	// size. No overwrite/anonymous/weighted features are requested so the plan's feature gates
+	// in HasTxPermission pass.
+	newProcessTx := func(maxCensusSize uint64) []byte {
+		tx := &models.Tx{Payload: &models.Tx_NewProcess{NewProcess: &models.NewProcessTx{
+			Txtype: models.TxType_NEW_PROCESS,
+			Process: &models.Process{
+				EntityId:      managed.Address.Bytes(),
+				MaxCensusSize: maxCensusSize,
+				Duration:      86400,
+				EnvelopeType:  &models.EnvelopeType{},
+				VoteOptions:   &models.ProcessVoteOptions{MaxCount: 1, MaxValue: 1},
+			},
+		}}}
+		b, err := proto.Marshal(tx)
+		c.Assert(err, qt.IsNil)
+		return b
+	}
+	postTx := func(payload []byte) int {
+		_, code := testRequest(t, http.MethodPost, token,
+			&apicommon.TransactionData{Address: managed.Address, TxPayload: payload}, "transactions")
+		return code
+	}
+	managedProcesses := func() int {
+		org, err := testDB.Organization(integratorAddr)
+		c.Assert(err, qt.IsNil)
+		return org.Counters.ManagedProcesses
+	}
+
+	// first non-test-sized process is signed and consumes one slot of the integrator pool.
+	c.Assert(postTx(newProcessTx(100)), qt.Equals, http.StatusOK)
+	c.Assert(managedProcesses(), qt.Equals, 1)
+
+	// the second is capped by the integrator's aggregate quota (plan MaxProcesses == 1).
+	// Before the fix this path enforced nothing and returned 200, leaving the counter at 0.
+	c.Assert(postTx(newProcessTx(100)), qt.Equals, http.StatusBadRequest) // ErrIntegratorQuotaExceeded
+	c.Assert(managedProcesses(), qt.Equals, 1)                            // reservation never taken / rolled back
+
+	// a test-sized election (<= TestMaxCensusSize) is exempt: allowed even with the pool full,
+	// and it does not consume the integrator quota.
+	c.Assert(postTx(newProcessTx(uint64(db.TestMaxCensusSize))), qt.Equals, http.StatusOK)
+	c.Assert(managedProcesses(), qt.Equals, 1)
 }

--- a/api/process.go
+++ b/api/process.go
@@ -549,6 +549,42 @@ func (a *API) deleteProcessHandler(w http.ResponseWriter, r *http.Request) {
 	apicommon.HTTPWriteOK(w)
 }
 
+// reserveManagedProcessSlot reserves one process slot against the integrator's shared
+// ManagedProcesses quota when org is a managed organization publishing a non-test-sized
+// election. It returns the integrator address and reserved=true when a slot was taken — the
+// caller MUST roll it back with AddOrganizationManagedProcesses(integratorAddr, -1) if the
+// publish/sign later fails. For a standalone org or a test-sized election it is a no-op
+// (reserved=false, nil error).
+//
+// HasTxPermission skips the per-org process-count check for managed orgs precisely because
+// this integrator-level reservation enforces it instead; every NEW_PROCESS entry point (draft
+// publish and the remote-signer /transactions path) must call this so the two cannot drift.
+func (a *API) reserveManagedProcessSlot(org *db.Organization, maxCensusSize uint64) (common.Address, bool, error) {
+	if org.ManagedBy == (common.Address{}) || maxCensusSize <= uint64(db.TestMaxCensusSize) {
+		return common.Address{}, false, nil
+	}
+	integrator, err := a.db.Organization(org.ManagedBy)
+	if err != nil {
+		// a managed org whose integrator no longer exists is a not-found condition, not a
+		// server fault — map it like subscriptions.limitsOwner does rather than 500.
+		if err == db.ErrNotFound {
+			return common.Address{}, false, errors.ErrOrganizationNotFound.WithErr(err)
+		}
+		return common.Address{}, false, errors.ErrGenericInternalServerError.Withf("could not get integrator organization: %v", err)
+	}
+	maxProcesses, err := a.subscriptions.ManagedPublishLimits(integrator)
+	if err != nil {
+		return common.Address{}, false, err
+	}
+	if err := a.db.ReserveManagedPublish(integrator.Address, maxProcesses); err != nil {
+		if err == db.ErrManagedQuotaReached {
+			return common.Address{}, false, errors.ErrIntegratorQuotaExceeded
+		}
+		return common.Address{}, false, errors.ErrGenericInternalServerError.WithErr(err)
+	}
+	return integrator.Address, true, nil
+}
+
 // publishProcessHandler godoc
 //
 //	@Summary		Publish a draft process as an on-chain election
@@ -673,34 +709,17 @@ func (a *API) publishProcessHandler(w http.ResponseWriter, r *http.Request) {
 	// cannot each pass a stale check and exceed the cap. The reservation is rolled back
 	// (deferred) unless the publish commits. Test-sized elections are exempt from the
 	// integrator quota, mirroring the per-org Processes counter exemption below.
-	managedReserved := false
-	var integratorAddr common.Address
 	nonTestSized := draft.ElectionParams.MaxCensusSize > uint64(db.TestMaxCensusSize)
-	if org.ManagedBy != (common.Address{}) && nonTestSized {
-		integrator, err := a.db.Organization(org.ManagedBy)
-		if err != nil {
-			errors.ErrGenericInternalServerError.Withf("could not get integrator organization: %v", err).Write(w)
+	integratorAddr, managedReserved, err := a.reserveManagedProcessSlot(org, draft.ElectionParams.MaxCensusSize)
+	if err != nil {
+		if apiErr, ok := err.(errors.Error); ok {
+			apiErr.Write(w)
 			return
 		}
-		maxProcesses, err := a.subscriptions.ManagedPublishLimits(integrator)
-		if err != nil {
-			if apiErr, ok := err.(errors.Error); ok {
-				apiErr.Write(w)
-				return
-			}
-			errors.ErrGenericInternalServerError.WithErr(err).Write(w)
-			return
-		}
-		if err := a.db.ReserveManagedPublish(integrator.Address, maxProcesses); err != nil {
-			if err == db.ErrManagedQuotaReached {
-				errors.ErrIntegratorQuotaExceeded.Write(w)
-				return
-			}
-			errors.ErrGenericInternalServerError.WithErr(err).Write(w)
-			return
-		}
-		managedReserved = true
-		integratorAddr = integrator.Address
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+	if managedReserved {
 		// roll back the reservation if the publish is not handed to a worker (any
 		// synchronous failure below, or a full queue). Once enqueued the worker owns
 		// the reservation outcome and clears managedReserved.

--- a/api/transaction.go
+++ b/api/transaction.go
@@ -8,6 +8,7 @@ import (
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
+	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/proto/build/go/models"
 	"google.golang.org/protobuf/proto"
 )
@@ -101,8 +102,33 @@ func (a *API) signTxHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// if isNewProcess and everything went well so far update the organization process counter
+	managedReserved := false
 	if *txType == models.TxType_NEW_PROCESS {
 		newProcess := tx.GetNewProcess()
+		// For a managed org the process-count limit is enforced against the integrator's
+		// shared ManagedProcesses quota (HasTxPermission skips the per-org check for managed
+		// orgs), exactly like the /process/{id}/publish path. Reserve before signing and roll
+		// the reservation back if signing fails below. Test-sized elections are exempt.
+		integratorAddr, reserved, rerr := a.reserveManagedProcessSlot(org, newProcess.Process.MaxCensusSize)
+		if rerr != nil {
+			if apiErr, ok := rerr.(errors.Error); ok {
+				apiErr.Write(w)
+				return
+			}
+			errors.ErrGenericInternalServerError.WithErr(rerr).Write(w)
+			return
+		}
+		managedReserved = reserved
+		if reserved {
+			defer func() {
+				if !managedReserved {
+					return
+				}
+				if e := a.db.AddOrganizationManagedProcesses(integratorAddr, -1); e != nil {
+					log.Warnw("could not roll back managed processes counter", "error", e)
+				}
+			}()
+		}
 		// do not count processes with less than TestMaxCensusSize for user testing
 		if newProcess.Process.MaxCensusSize > uint64(db.TestMaxCensusSize) {
 			if err := a.db.IncrementOrganizationProcessesCounter(org.Address); err != nil {
@@ -118,6 +144,9 @@ func (a *API) signTxHandler(w http.ResponseWriter, r *http.Request) {
 		errors.ErrGenericInternalServerError.Withf("could not sign transaction: %v", err).Write(w)
 		return
 	}
+	// signed successfully; the client owns submission from here, so keep the reservation
+	// (the per-org Processes counter above is likewise not rolled back on this path).
+	managedReserved = false
 
 	// return the signed tx payload
 	apicommon.HTTPWriteJSON(w, &apicommon.TransactionData{


### PR DESCRIPTION
## Problem

A managed organization can create unlimited on-chain elections through the
`/transactions` remote-signer endpoint, completely bypassing its integrator's
aggregate process quota — and the `/integrator` dashboard under-reports
`ManagedProcesses` as a result.

### Root cause — regression in #557

#557 (`fix(subscriptions): govern managed-org limits by the integrator's plan`)
added an `if !managed(org)` skip around the process-count check in
`HasTxPermission`, with a comment stating the count is *"enforced for managed
orgs against the integrator's aggregate quota (ReserveManagedPublish) at publish
time."*

That reservation, however, was only ever wired into `publishProcessHandler`
(`POST /process/{id}/publish`). The older `signTxHandler` (`POST /transactions`)
— the path the Vocdoni SDK remote-signer flow uses — also signs `NEW_PROCESS`
txs, calls `HasTxPermission` (now skipping managed orgs), and **never** called
`ReserveManagedPublish`. So #557 deleted the only check that path had for
managed orgs and pointed it at a mechanism it doesn't invoke.

Before #557, `/transactions` capped managed-org process creation via the per-org
`Processes` counter check in `HasTxPermission`; that's the behavior that broke.

## Fix

- Extract the reserve-against-the-integrator-pool logic out of
  `publishProcessHandler` into a shared `reserveManagedProcessSlot` helper.
- Call it from **both** `NEW_PROCESS` entry points (`/publish` and
  `/transactions`) so they can't drift apart again — which is exactly how this
  regression happened (logic inlined in one handler).
- `signTxHandler` reserves before signing and rolls the reservation back if
  signing fails, mirroring the publish path. Test-sized elections
  (`MaxCensusSize <= TestMaxCensusSize`) stay exempt.

No behavior change for `/publish` (pure refactor) or for standalone orgs.

## Tests

Adds `TestIntegratorProcessQuotaViaTransactions`, which drives `/transactions`
for a managed org and asserts:
1. the first non-test process increments the integrator's `ManagedProcesses` to 1;
2. the second is rejected with `ErrIntegratorQuotaExceeded` (the assertion that
   fails on `main`);
3. a test-sized election is still allowed with the pool full and does not consume
   the quota.

Passes against the live Mongo + Voconed test stack; existing
`TestIntegratorManagedOrgs` and `TestSignTxHandler` still green.