### PR TITLE
feat(orgs): add embedded name/logo/description fields

### DIFF
--- a/api/apicommon/multilingual_test.go
+++ b/api/apicommon/multilingual_test.go
@@ -56,33 +56,39 @@ func TestBuildOrgMeta(t *testing.T) {
 	desc := MultilingualText{"default": "We make things"}
 
 	// only name
-	m := BuildOrgMeta(&name, nil, nil, nil)
+	m := BuildOrgMeta(nil, &name, nil, nil, nil)
 	c.Assert(m["name"], qt.DeepEquals, MultilingualText{"default": "Acme"})
 	_, hasLogo := m["logo"]
 	c.Assert(hasLogo, qt.IsFalse)
 
 	// all three fields
-	m = BuildOrgMeta(&name, &logo, &desc, nil)
+	m = BuildOrgMeta(nil, &name, &logo, &desc, nil)
 	c.Assert(m["name"], qt.DeepEquals, MultilingualText{"default": "Acme"})
 	c.Assert(m["logo"], qt.DeepEquals, MultilingualText{"default": "https://acme.com/logo.png"})
 	c.Assert(m["description"], qt.DeepEquals, MultilingualText{"default": "We make things"})
 
 	// explicit meta wins over shorthand
 	explicit := map[string]any{"name": MultilingualText{"default": "Override"}, "extra": "val"}
-	m = BuildOrgMeta(&name, nil, nil, explicit)
+	m = BuildOrgMeta(nil, &name, nil, nil, explicit)
 	c.Assert(m["name"], qt.DeepEquals, MultilingualText{"default": "Override"})
 	c.Assert(m["extra"], qt.Equals, "val")
 
 	// only explicit meta, no shorthand
-	m = BuildOrgMeta(nil, nil, nil, map[string]any{"foo": "bar"})
+	m = BuildOrgMeta(nil, nil, nil, nil, map[string]any{"foo": "bar"})
 	c.Assert(m["foo"], qt.Equals, "bar")
 	_, hasName := m["name"]
 	c.Assert(hasName, qt.IsFalse)
 
 	// all nil → empty map (not nil)
-	m = BuildOrgMeta(nil, nil, nil, nil)
+	m = BuildOrgMeta(nil, nil, nil, nil, nil)
 	c.Assert(m, qt.IsNotNil)
 	c.Assert(m, qt.HasLen, 0)
+
+	// base keys are preserved and shorthands override them; explicit wins last
+	base := map[string]any{"name": MultilingualText{"default": "Old"}, "keep": "me"}
+	m = BuildOrgMeta(base, &name, nil, nil, nil)
+	c.Assert(m["name"], qt.DeepEquals, MultilingualText{"default": "Acme"})
+	c.Assert(m["keep"], qt.Equals, "me")
 }
 
 func TestMultilingualFromAny(t *testing.T) {

--- a/api/apicommon/multilingual_test.go
+++ b/api/apicommon/multilingual_test.go
@@ -1,0 +1,121 @@
+package apicommon
+
+import (
+	"encoding/json"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestMultilingualTextUnmarshal(t *testing.T) {
+	c := qt.New(t)
+
+	type wrapper struct {
+		V *MultilingualText `json:"v"`
+	}
+
+	unmarshal := func(s string) (*MultilingualText, error) {
+		var w wrapper
+		err := json.Unmarshal([]byte(`{"v":`+s+`}`), &w)
+		return w.V, err
+	}
+
+	// plain string → normalised to {"default": "..."}
+	got, err := unmarshal(`"hello"`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(*got, qt.DeepEquals, MultilingualText{"default": "hello"})
+
+	// object with default key → stored as-is
+	got, err = unmarshal(`{"default":"hi","es":"hola"}`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(*got, qt.DeepEquals, MultilingualText{"default": "hi", "es": "hola"})
+
+	// object without default key → error
+	_, err = unmarshal(`{"en":"hi"}`)
+	c.Assert(err, qt.IsNotNil)
+
+	// object with non-string value → error (rejected by map[string]string decode)
+	_, err = unmarshal(`{"default":"hi","count":3}`)
+	c.Assert(err, qt.IsNotNil)
+
+	// completely invalid JSON → error
+	_, err = unmarshal(`not-json`)
+	c.Assert(err, qt.IsNotNil)
+
+	// absent key → nil pointer
+	var w wrapper
+	c.Assert(json.Unmarshal([]byte(`{}`), &w), qt.IsNil)
+	c.Assert(w.V, qt.IsNil)
+}
+
+func TestBuildOrgMeta(t *testing.T) {
+	c := qt.New(t)
+
+	name := MultilingualText{"default": "Acme"}
+	logo := MultilingualText{"default": "https://acme.com/logo.png"}
+	desc := MultilingualText{"default": "We make things"}
+
+	// only name
+	m := BuildOrgMeta(&name, nil, nil, nil)
+	c.Assert(m["name"], qt.DeepEquals, MultilingualText{"default": "Acme"})
+	_, hasLogo := m["logo"]
+	c.Assert(hasLogo, qt.IsFalse)
+
+	// all three fields
+	m = BuildOrgMeta(&name, &logo, &desc, nil)
+	c.Assert(m["name"], qt.DeepEquals, MultilingualText{"default": "Acme"})
+	c.Assert(m["logo"], qt.DeepEquals, MultilingualText{"default": "https://acme.com/logo.png"})
+	c.Assert(m["description"], qt.DeepEquals, MultilingualText{"default": "We make things"})
+
+	// explicit meta wins over shorthand
+	explicit := map[string]any{"name": MultilingualText{"default": "Override"}, "extra": "val"}
+	m = BuildOrgMeta(&name, nil, nil, explicit)
+	c.Assert(m["name"], qt.DeepEquals, MultilingualText{"default": "Override"})
+	c.Assert(m["extra"], qt.Equals, "val")
+
+	// only explicit meta, no shorthand
+	m = BuildOrgMeta(nil, nil, nil, map[string]any{"foo": "bar"})
+	c.Assert(m["foo"], qt.Equals, "bar")
+	_, hasName := m["name"]
+	c.Assert(hasName, qt.IsFalse)
+
+	// all nil → empty map (not nil)
+	m = BuildOrgMeta(nil, nil, nil, nil)
+	c.Assert(m, qt.IsNotNil)
+	c.Assert(m, qt.HasLen, 0)
+}
+
+func TestMultilingualFromAny(t *testing.T) {
+	c := qt.New(t)
+
+	// MultilingualText (in-memory, set at creation time)
+	mt := MultilingualText{"default": "hello"}
+	got := multilingualFromAny(mt)
+	c.Assert(got, qt.IsNotNil)
+	c.Assert(*got, qt.DeepEquals, mt)
+
+	// map[string]string (named type)
+	ms := map[string]string{"default": "world"}
+	got = multilingualFromAny(ms)
+	c.Assert(got, qt.IsNotNil)
+	c.Assert(*got, qt.DeepEquals, MultilingualText{"default": "world"})
+
+	// map[string]any with string values (BSON-decoded form)
+	ma := map[string]any{"default": "bson", "es": "bson-es"}
+	got = multilingualFromAny(ma)
+	c.Assert(got, qt.IsNotNil)
+	c.Assert(*got, qt.DeepEquals, MultilingualText{"default": "bson", "es": "bson-es"})
+
+	// map[string]any with a non-string value → nil
+	bad := map[string]any{"default": 42}
+	got = multilingualFromAny(bad)
+	c.Assert(got, qt.IsNil)
+
+	// nil → nil
+	got = multilingualFromAny(nil)
+	c.Assert(got, qt.IsNil)
+
+	// unknown type → nil
+	got = multilingualFromAny(123)
+	c.Assert(got, qt.IsNil)
+}

--- a/api/apicommon/multilingual_test.go
+++ b/api/apicommon/multilingual_test.go
@@ -111,6 +111,11 @@ func TestMultilingualFromAny(t *testing.T) {
 	got = multilingualFromAny(bad)
 	c.Assert(got, qt.IsNil)
 
+	// plain string (legacy storage) → normalised to {"default": "..."}
+	got = multilingualFromAny("legacy name")
+	c.Assert(got, qt.IsNotNil)
+	c.Assert(*got, qt.DeepEquals, MultilingualText{"default": "legacy name"})
+
 	// nil → nil
 	got = multilingualFromAny(nil)
 	c.Assert(got, qt.IsNil)

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -49,11 +49,15 @@ func (m *MultilingualText) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// multilingualFromAny extracts a MultilingualText from a meta map value. It handles both
-// the in-memory form (MultilingualText / map[string]string, set at creation time) and the
-// BSON-decoded form (map[string]interface{}, returned after a MongoDB round-trip).
+// multilingualFromAny extracts a MultilingualText from a meta map value. It handles:
+//   - plain string (legacy storage): normalised to {"default": "<string>"}
+//   - MultilingualText / map[string]string (in-memory, set at creation time)
+//   - map[string]any (BSON-decoded form after a MongoDB round-trip)
 func multilingualFromAny(v any) *MultilingualText {
 	switch m := v.(type) {
+	case string:
+		r := MultilingualText{"default": m}
+		return &r
 	case MultilingualText:
 		return &m
 	case map[string]string:
@@ -71,6 +75,17 @@ func multilingualFromAny(v any) *MultilingualText {
 		return &r
 	}
 	return nil
+}
+
+// OrgDisplayName returns the "default" value of meta["name"] as a plain string, falling
+// back to fallback (typically the org's hex address) when the field is absent or empty.
+func OrgDisplayName(meta map[string]any, fallback string) string {
+	if mt := multilingualFromAny(meta["name"]); mt != nil {
+		if def := (*mt)["default"]; def != "" {
+			return def
+		}
+	}
+	return fallback
 }
 
 // BuildOrgMeta merges the convenience name/logo/description fields with an explicit meta
@@ -568,6 +583,13 @@ func OrganizationFromDB(dbOrg, parent *db.Organization) *OrganizationInfo {
 	meta := dbOrg.Meta
 	if meta == nil {
 		meta = make(map[string]any)
+	}
+	// Upgrade any plain-string values for the well-known keys to the object
+	// form so that meta.name and the top-level name field always agree.
+	for _, key := range []string{"name", "logo", "description"} {
+		if s, ok := meta[key].(string); ok {
+			meta[key] = MultilingualText{"default": s}
+		}
 	}
 	// Expose ManagedBy only when set, as a pointer, so regular orgs omit the field
 	// instead of serializing the zero address.

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -3,7 +3,9 @@ package apicommon
 //revive:disable:max-public-structs
 
 import (
+	"encoding/json"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -23,6 +25,71 @@ const (
 	// MaxItemsPerPage defines a ceiling for the `limit` param passed by the client
 	MaxItemsPerPage = 100
 )
+
+// MultilingualText is a locale-keyed string map. Clients may send either a plain string
+// (normalised to {"default": "<string>"}) or an object {"<lang>": "<text>", ...}.
+// When sending an object, a "default" key is required.
+type MultilingualText map[string]string
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (m *MultilingualText) UnmarshalJSON(data []byte) error {
+	var s string
+	if json.Unmarshal(data, &s) == nil {
+		*m = MultilingualText{"default": s}
+		return nil
+	}
+	var obj map[string]string
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return fmt.Errorf("must be a string or an object with string values")
+	}
+	if _, ok := obj["default"]; !ok {
+		return fmt.Errorf("multilingual object must have a \"default\" key")
+	}
+	*m = MultilingualText(obj)
+	return nil
+}
+
+// multilingualFromAny extracts a MultilingualText from a meta map value. It handles both
+// the in-memory form (MultilingualText / map[string]string, set at creation time) and the
+// BSON-decoded form (map[string]interface{}, returned after a MongoDB round-trip).
+func multilingualFromAny(v any) *MultilingualText {
+	switch m := v.(type) {
+	case MultilingualText:
+		return &m
+	case map[string]string:
+		r := MultilingualText(m)
+		return &r
+	case map[string]any:
+		r := make(MultilingualText, len(m))
+		for k, val := range m {
+			s, ok := val.(string)
+			if !ok {
+				return nil
+			}
+			r[k] = s
+		}
+		return &r
+	}
+	return nil
+}
+
+// BuildOrgMeta merges the convenience name/logo/description fields with an explicit meta
+// map. The explicit meta keys take precedence: if both name and meta["name"] are set,
+// meta["name"] wins.
+func BuildOrgMeta(name, logo, description *MultilingualText, explicit map[string]any) map[string]any {
+	meta := make(map[string]any)
+	if name != nil {
+		meta["name"] = *name
+	}
+	if logo != nil {
+		meta["logo"] = *logo
+	}
+	if description != nil {
+		meta["description"] = *description
+	}
+	maps.Copy(meta, explicit)
+	return meta
+}
 
 // Pagination contains all the values needed for the UI to easily organize the returned data
 type Pagination struct {
@@ -110,6 +177,18 @@ type OrganizationInfo struct {
 
 	// Arbitrary key value fields with metadata regarding the organization
 	Meta map[string]any `json:"meta"`
+
+	// Name is a shorthand for meta["name"]. On write accepts a plain string
+	// (stored as {"default": "<string>"}) or a locale map; on read it mirrors
+	// whatever is stored in meta["name"]. If both Name and meta["name"] are
+	// provided on a create request, meta["name"] takes precedence.
+	Name *MultilingualText `json:"name,omitempty"`
+
+	// Logo is a shorthand for meta["logo"]. Same encoding rules as Name.
+	Logo *MultilingualText `json:"logo,omitempty"`
+
+	// Description is a shorthand for meta["description"]. Same encoding rules as Name.
+	Description *MultilingualText `json:"description,omitempty"`
 
 	// Whether to subscribe the new organization to the free integrator plan at
 	// creation time (opt-in). Used by the integrator portal so a newly created org
@@ -510,6 +589,9 @@ func OrganizationFromDB(dbOrg, parent *db.Organization) *OrganizationInfo {
 		Active:         dbOrg.Active,
 		Communications: dbOrg.Communications,
 		Meta:           meta,
+		Name:           multilingualFromAny(meta["name"]),
+		Logo:           multilingualFromAny(meta["logo"]),
+		Description:    multilingualFromAny(meta["description"]),
 		Parent:         parentOrg,
 		ManagedBy:      managedBy,
 		Subscription:   &details,

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -578,13 +578,14 @@ func OrganizationFromDB(dbOrg, parent *db.Organization) *OrganizationInfo {
 	}
 	details := SubscriptionDetailsFromDB(&dbOrg.Subscription)
 	usage := SubscriptionUsageFromDB(&dbOrg.Counters)
-	// normalize a nil Meta to an empty map so responses are consistent: the DB
-	// read path already does this, but dbOrg may be built in-memory (e.g. at
-	// creation) where Meta is nil, which would otherwise emit "meta": null.
-	meta := dbOrg.Meta
-	if meta == nil {
-		meta = make(map[string]any)
-	}
+	// copy dbOrg.Meta into a fresh map: we normalize legacy string values below
+	// and must not mutate the db model in-place, since callers don't expect this
+	// read/convert helper to have side effects. A nil Meta is normalized to an
+	// empty map so responses are consistent: the DB read path already does this,
+	// but dbOrg may be built in-memory (e.g. at creation) where Meta is nil,
+	// which would otherwise emit "meta": null.
+	meta := make(map[string]any, len(dbOrg.Meta))
+	maps.Copy(meta, dbOrg.Meta)
 	// Upgrade any plain-string values for the well-known keys to the object
 	// form so that meta.name and the top-level name field always agree.
 	for _, key := range []string{"name", "logo", "description"} {

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -89,10 +89,11 @@ func OrgDisplayName(meta map[string]any, fallback string) string {
 }
 
 // BuildOrgMeta merges the convenience name/logo/description fields with an explicit meta
-// map. The explicit meta keys take precedence: if both name and meta["name"] are set,
-// meta["name"] wins.
-func BuildOrgMeta(name, logo, description *MultilingualText, explicit map[string]any) map[string]any {
-	meta := make(map[string]any)
+// map on top of base (nil starts from an empty map). Precedence, lowest to highest:
+// base keys → shorthand fields → explicit meta keys.
+func BuildOrgMeta(base map[string]any, name, logo, description *MultilingualText, explicit map[string]any) map[string]any {
+	meta := make(map[string]any, len(base))
+	maps.Copy(meta, base)
 	if name != nil {
 		meta["name"] = *name
 	}

--- a/api/organization_embedded_meta_test.go
+++ b/api/organization_embedded_meta_test.go
@@ -15,9 +15,10 @@ func TestOrganizationEmbeddedMeta(t *testing.T) {
 
 	t.Run("string name is normalised to default locale", func(t *testing.T) {
 		c := qt.New(t)
-		body := &apicommon.OrganizationInfo{
-			Type: string(db.CompanyType),
-			Name: &apicommon.MultilingualText{"default": "Acme Corp"},
+		// send a raw JSON string for name to exercise the plain-string input path
+		body := map[string]any{
+			"type": string(db.CompanyType),
+			"name": "Acme Corp",
 		}
 		resp, code := testRequest(t, http.MethodPost, token, body, organizationsEndpoint)
 		c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))

--- a/api/organization_embedded_meta_test.go
+++ b/api/organization_embedded_meta_test.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/api/apicommon"
+	"github.com/vocdoni/saas-backend/db"
+)
+
+func TestOrganizationEmbeddedMeta(t *testing.T) {
+	token := testCreateUser(t, "password123")
+
+	t.Run("string name is normalised to default locale", func(t *testing.T) {
+		c := qt.New(t)
+		body := &apicommon.OrganizationInfo{
+			Type: string(db.CompanyType),
+			Name: &apicommon.MultilingualText{"default": "Acme Corp"},
+		}
+		resp, code := testRequest(t, http.MethodPost, token, body, organizationsEndpoint)
+		c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+
+		var org apicommon.OrganizationInfo
+		c.Assert(json.Unmarshal(resp, &org), qt.IsNil)
+
+		c.Assert(org.Name, qt.IsNotNil)
+		c.Assert((*org.Name)["default"], qt.Equals, "Acme Corp")
+		// also present in meta
+		c.Assert(org.Meta["name"], qt.IsNotNil)
+	})
+
+	t.Run("multilingual object is stored as-is", func(t *testing.T) {
+		c := qt.New(t)
+		body := &apicommon.OrganizationInfo{
+			Type: string(db.CompanyType),
+			Name: &apicommon.MultilingualText{"default": "Acme", "es": "Acme ES"},
+		}
+		resp, code := testRequest(t, http.MethodPost, token, body, organizationsEndpoint)
+		c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+
+		var org apicommon.OrganizationInfo
+		c.Assert(json.Unmarshal(resp, &org), qt.IsNil)
+
+		c.Assert(org.Name, qt.IsNotNil)
+		c.Assert((*org.Name)["default"], qt.Equals, "Acme")
+		c.Assert((*org.Name)["es"], qt.Equals, "Acme ES")
+	})
+
+	t.Run("logo and description are stored and returned", func(t *testing.T) {
+		c := qt.New(t)
+		body := &apicommon.OrganizationInfo{
+			Type:        string(db.CompanyType),
+			Logo:        &apicommon.MultilingualText{"default": "https://acme.com/logo.png"},
+			Description: &apicommon.MultilingualText{"default": "We make things"},
+		}
+		resp, code := testRequest(t, http.MethodPost, token, body, organizationsEndpoint)
+		c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+
+		var org apicommon.OrganizationInfo
+		c.Assert(json.Unmarshal(resp, &org), qt.IsNil)
+
+		c.Assert(org.Logo, qt.IsNotNil)
+		c.Assert((*org.Logo)["default"], qt.Equals, "https://acme.com/logo.png")
+		c.Assert(org.Description, qt.IsNotNil)
+		c.Assert((*org.Description)["default"], qt.Equals, "We make things")
+	})
+
+	t.Run("explicit meta.name takes precedence over name field", func(t *testing.T) {
+		c := qt.New(t)
+		body := map[string]any{
+			"type": string(db.CompanyType),
+			"name": map[string]any{"default": "Shorthand Name"},
+			"meta": map[string]any{
+				"name": map[string]any{"default": "Meta Name"},
+			},
+		}
+		resp, code := testRequest(t, http.MethodPost, token, body, organizationsEndpoint)
+		c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+
+		var org apicommon.OrganizationInfo
+		c.Assert(json.Unmarshal(resp, &org), qt.IsNil)
+
+		c.Assert(org.Name, qt.IsNotNil)
+		c.Assert((*org.Name)["default"], qt.Equals, "Meta Name")
+	})
+
+	t.Run("object without default key is rejected", func(t *testing.T) {
+		c := qt.New(t)
+		body := map[string]any{
+			"type": string(db.CompanyType),
+			"name": map[string]any{"en": "No Default"},
+		}
+		_, code := testRequest(t, http.MethodPost, token, body, organizationsEndpoint)
+		c.Assert(code, qt.Equals, http.StatusBadRequest)
+	})
+}

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -162,7 +162,7 @@ func (a *API) createOrganizationHandler(w http.ResponseWriter, r *http.Request) 
 	// is identical to the legacy flow (DB row only; account created later by the SDK).
 	if orgInfo.ProvisionAccount {
 		infoURI := fmt.Sprintf("%s/organizations/%s", a.serverURL, dbOrg.Address.String())
-		if err := a.account.CreateOrgAccount(signer, dbOrg.Address.String(), infoURI); err != nil {
+		if err := a.account.CreateOrgAccount(signer, apicommon.OrgDisplayName(dbOrg.Meta, dbOrg.Address.String()), infoURI); err != nil {
 			if orgInfo.Parent != nil {
 				if err := a.db.DecrementOrganizationSubOrgsCounter(parentOrg); err != nil {
 					log.Errorf("decrement suborgs: %v", err)

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -145,7 +145,7 @@ func (a *API) createOrganizationHandler(w http.ResponseWriter, r *http.Request) 
 		Timezone:        orgInfo.Timezone,
 		Active:          true,
 		Communications:  orgInfo.Communications,
-		Meta:            apicommon.BuildOrgMeta(orgInfo.Name, orgInfo.Logo, orgInfo.Description, orgInfo.Meta),
+		Meta:            apicommon.BuildOrgMeta(nil, orgInfo.Name, orgInfo.Logo, orgInfo.Description, orgInfo.Meta),
 		TokensPurchased: 0,
 		TokensRemaining: 0,
 		Parent:          parentOrg,
@@ -284,6 +284,10 @@ func (a *API) updateOrganizationHandler(w http.ResponseWriter, r *http.Request) 
 	}
 	if newOrgInfo.Active != org.Active {
 		org.Active = newOrgInfo.Active
+		updateOrg = true
+	}
+	if newOrgInfo.Name != nil || newOrgInfo.Logo != nil || newOrgInfo.Description != nil || len(newOrgInfo.Meta) > 0 {
+		org.Meta = apicommon.BuildOrgMeta(org.Meta, newOrgInfo.Name, newOrgInfo.Logo, newOrgInfo.Description, newOrgInfo.Meta)
 		updateOrg = true
 	}
 	// update the organization if any field was changed

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -145,7 +145,7 @@ func (a *API) createOrganizationHandler(w http.ResponseWriter, r *http.Request) 
 		Timezone:        orgInfo.Timezone,
 		Active:          true,
 		Communications:  orgInfo.Communications,
-		Meta:            orgInfo.Meta,
+		Meta:            apicommon.BuildOrgMeta(orgInfo.Name, orgInfo.Logo, orgInfo.Description, orgInfo.Meta),
 		TokensPurchased: 0,
 		TokensRemaining: 0,
 		Parent:          parentOrg,

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -162,7 +162,8 @@ func (a *API) createOrganizationHandler(w http.ResponseWriter, r *http.Request) 
 	// is identical to the legacy flow (DB row only; account created later by the SDK).
 	if orgInfo.ProvisionAccount {
 		infoURI := fmt.Sprintf("%s/organizations/%s", a.serverURL, dbOrg.Address.String())
-		if err := a.account.CreateOrgAccount(signer, apicommon.OrgDisplayName(dbOrg.Meta, dbOrg.Address.String()), infoURI); err != nil {
+		displayName := apicommon.OrgDisplayName(dbOrg.Meta, dbOrg.Address.String())
+		if err := a.account.CreateOrgAccount(signer, displayName, infoURI); err != nil {
 			if orgInfo.Parent != nil {
 				if err := a.db.DecrementOrganizationSubOrgsCounter(parentOrg); err != nil {
 					log.Errorf("decrement suborgs: %v", err)

--- a/api/organizations_managed.go
+++ b/api/organizations_managed.go
@@ -189,7 +189,7 @@ func (a *API) createManagedOrganizationHandler(w http.ResponseWriter, r *http.Re
 	// row. CreateOrgAccount is idempotent and the address derives from the signer, so a
 	// failure here leaves nothing to clean up and the request can be retried safely.
 	infoURI := fmt.Sprintf("%s/organizations/%s", a.serverURL, dbOrg.Address.String())
-	if err := a.account.CreateOrgAccount(signer, dbOrg.Address.String(), infoURI); err != nil {
+	if err := a.account.CreateOrgAccount(signer, apicommon.OrgDisplayName(dbOrg.Meta, dbOrg.Address.String()), infoURI); err != nil {
 		a.releaseManagedOrgSlot(integratorAddr)
 		errors.ErrGenericInternalServerError.Withf("could not provision managed organization account: %v", err).Write(w)
 		return

--- a/api/organizations_managed.go
+++ b/api/organizations_managed.go
@@ -166,7 +166,7 @@ func (a *API) createManagedOrganizationHandler(w http.ResponseWriter, r *http.Re
 		Timezone:       req.Timezone,
 		Active:         true,
 		Communications: req.Communications,
-		Meta:           req.Meta,
+		Meta:           apicommon.BuildOrgMeta(req.Name, req.Logo, req.Description, req.Meta),
 		ManagedBy:      integratorAddr,
 		Subscription: db.OrganizationSubscription{
 			PlanID:    defaultPlan.ID,

--- a/api/organizations_managed.go
+++ b/api/organizations_managed.go
@@ -166,7 +166,7 @@ func (a *API) createManagedOrganizationHandler(w http.ResponseWriter, r *http.Re
 		Timezone:       req.Timezone,
 		Active:         true,
 		Communications: req.Communications,
-		Meta:           apicommon.BuildOrgMeta(req.Name, req.Logo, req.Description, req.Meta),
+		Meta:           apicommon.BuildOrgMeta(nil, req.Name, req.Logo, req.Description, req.Meta),
 		ManagedBy:      integratorAddr,
 		Subscription: db.OrganizationSubscription{
 			PlanID:    defaultPlan.ID,

--- a/api/process_bundles.go
+++ b/api/process_bundles.go
@@ -88,16 +88,6 @@ func (a *API) createProcessBundleHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	org, err := a.db.Organization(census.OrgAddress)
-	if err != nil {
-		if err == db.ErrNotFound {
-			errors.ErrInvalidCensusData.Withf("organization not found").Write(w)
-			return
-		}
-		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
-		return
-	}
-
 	// Get the user from the request context
 	user, ok := apicommon.UserFromContext(r.Context())
 	if !ok {
@@ -173,17 +163,6 @@ func (a *API) createProcessBundleHandler(w http.ResponseWriter, r *http.Request)
 		Processes:  processes,
 		OrgAddress: census.OrgAddress,
 		Census:     *census,
-	}
-
-	// get organization metadata from the vochain
-	if meta, err := a.client.AccountMetadata(census.OrgAddress.String()); err == nil {
-		org.Meta["name"], org.Meta["logo"] = db.ParseVochainOrganizationMeta(meta)
-	}
-	if err := a.db.SetOrganization(org); err != nil {
-		errors.ErrGenericInternalServerError.
-			Withf("tried to update update organization name and logo but failed: %v", err).
-			Write(w)
-		return
 	}
 
 	_, err = a.db.SetProcessBundle(bundle)

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -237,6 +237,11 @@ definitions:
       createdAt:
         description: Creation timestamp in RFC3339 format
         type: string
+      description:
+        allOf:
+        - $ref: '#/definitions/apicommon.MultilingualText'
+        description: Description is a shorthand for meta["description"]. Same encoding
+          rules as Name.
       integrator:
         description: |-
           Whether to subscribe the new organization to the free integrator plan at
@@ -244,6 +249,11 @@ definitions:
           becomes an integrator on the free tier with no checkout. Default false uses
           the regular default plan.
         type: boolean
+      logo:
+        allOf:
+        - $ref: '#/definitions/apicommon.MultilingualText'
+        description: Logo is a shorthand for meta["logo"]. Same encoding rules as
+          Name.
       managedBy:
         description: |-
           Integrator organization that manages this org, when it was created through
@@ -261,6 +271,14 @@ definitions:
         additionalProperties: {}
         description: Arbitrary key value fields with metadata regarding the organization
         type: object
+      name:
+        allOf:
+        - $ref: '#/definitions/apicommon.MultilingualText'
+        description: |-
+          Name is a shorthand for meta["name"]. On write accepts a plain string
+          (stored as {"default": "<string>"}) or a locale map; on read it mirrors
+          whatever is stored in meta["name"]. If both Name and meta["name"] are
+          provided on a create request, meta["name"] takes precedence.
       ownerEmail:
         description: OwnerEmail optionally assigns an existing user as the managed
           org's creator/admin.
@@ -333,6 +351,11 @@ definitions:
       createdAt:
         description: Creation timestamp in RFC3339 format
         type: string
+      description:
+        allOf:
+        - $ref: '#/definitions/apicommon.MultilingualText'
+        description: Description is a shorthand for meta["description"]. Same encoding
+          rules as Name.
       integrator:
         description: |-
           Whether to subscribe the new organization to the free integrator plan at
@@ -340,6 +363,11 @@ definitions:
           becomes an integrator on the free tier with no checkout. Default false uses
           the regular default plan.
         type: boolean
+      logo:
+        allOf:
+        - $ref: '#/definitions/apicommon.MultilingualText'
+        description: Logo is a shorthand for meta["logo"]. Same encoding rules as
+          Name.
       managedBy:
         description: |-
           Integrator organization that manages this org, when it was created through
@@ -357,6 +385,14 @@ definitions:
         additionalProperties: {}
         description: Arbitrary key value fields with metadata regarding the organization
         type: object
+      name:
+        allOf:
+        - $ref: '#/definitions/apicommon.MultilingualText'
+        description: |-
+          Name is a shorthand for meta["name"]. On write accepts a plain string
+          (stored as {"default": "<string>"}) or a locale map; on read it mirrors
+          whatever is stored in meta["name"]. If both Name and meta["name"] are
+          provided on a create request, meta["name"] takes precedence.
       parent:
         allOf:
         - $ref: '#/definitions/apicommon.OrganizationInfo'
@@ -651,6 +687,10 @@ definitions:
         format: hex
         type: string
     type: object
+  apicommon.MultilingualText:
+    additionalProperties:
+      type: string
+    type: object
   apicommon.OAuthLinkRequest:
     properties:
       address:
@@ -851,6 +891,11 @@ definitions:
       createdAt:
         description: Creation timestamp in RFC3339 format
         type: string
+      description:
+        allOf:
+        - $ref: '#/definitions/apicommon.MultilingualText'
+        description: Description is a shorthand for meta["description"]. Same encoding
+          rules as Name.
       integrator:
         description: |-
           Whether to subscribe the new organization to the free integrator plan at
@@ -858,6 +903,11 @@ definitions:
           becomes an integrator on the free tier with no checkout. Default false uses
           the regular default plan.
         type: boolean
+      logo:
+        allOf:
+        - $ref: '#/definitions/apicommon.MultilingualText'
+        description: Logo is a shorthand for meta["logo"]. Same encoding rules as
+          Name.
       managedBy:
         description: |-
           Integrator organization that manages this org, when it was created through
@@ -875,6 +925,14 @@ definitions:
         additionalProperties: {}
         description: Arbitrary key value fields with metadata regarding the organization
         type: object
+      name:
+        allOf:
+        - $ref: '#/definitions/apicommon.MultilingualText'
+        description: |-
+          Name is a shorthand for meta["name"]. On write accepts a plain string
+          (stored as {"default": "<string>"}) or a locale map; on read it mirrors
+          whatever is stored in meta["name"]. If both Name and meta["name"] are
+          provided on a create request, meta["name"] takes precedence.
       parent:
         allOf:
         - $ref: '#/definitions/apicommon.OrganizationInfo'


### PR DESCRIPTION
- Add MultilingualText type to apicommon: accepts a plain string (normalised
  to {"default": "<string>"}) or a locale map (requires "default" key).
- Add Name, Logo, Description *MultilingualText fields to OrganizationInfo so
  they are accepted on both creation endpoints and returned in every org response.
- BuildOrgMeta helper merges the shorthand fields into meta before applying the
  explicit meta map, so meta always wins on conflict.
- OrganizationFromDB now populates Name/Logo/Description from meta on read,
  handling both the in-memory form (MultilingualText) and the BSON-decoded form
  (map[string]any) after a MongoDB round-trip.
- Fix bug in createProcessBundleHandler: remove the block that fetched vochain
  account metadata and overwrote org.Meta["name"]/["logo"] with on-chain values
  (which were the hex address string), then persisted back to MongoDB. This was
  the cause of org names disappearing seconds after creation.

Breaking: organization names are always returned with the expected multilanguage object (i.e. `{"default": "name"}`)