### PR TITLE
fix: two HIGH-severity auth vulnerabilities (JWT expiry, OTP brute-force)

### DIFF
--- a/api/helpers.go
+++ b/api/helpers.go
@@ -56,11 +56,15 @@ func (a *API) buildLoginResponse(id string) (*apicommon.LoginResponse, error) {
 	if err := j.Set("userId", id); err != nil {
 		return nil, err
 	}
-	if err := j.Set(jwt.ExpirationKey, time.Now().Add(jwtExpiration).UnixNano()); err != nil {
+	// pass a time.Time so jwx encodes a proper NumericDate (seconds). An int64 here would be
+	// read as Unix *seconds*, so a nanosecond value would push expiry ~55 billion years out
+	// and jwt.Validate would never reject the token on expiry.
+	expiry := time.Now().Add(jwtExpiration)
+	if err := j.Set(jwt.ExpirationKey, expiry); err != nil {
 		return nil, err
 	}
 	lr := apicommon.LoginResponse{}
-	lr.Expirity = time.Now().Add(jwtExpiration)
+	lr.Expirity = expiry
 	jmap, err := j.AsMap(context.Background())
 	if err != nil {
 		return nil, err

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestBuildLoginResponseExpiry guards the JWT expiry regression: the exp claim must be encoded
+// as seconds (a sane ~15-day expiry), not nanoseconds. jwx v2 reads an int64 exp as seconds, so
+// a nanosecond value would push expiration ~55 billion years out and jwt.Validate would never
+// reject an expired token.
+func TestBuildLoginResponseExpiry(t *testing.T) {
+	c := qt.New(t)
+
+	res, err := testAPI.buildLoginResponse("expiry@test.com")
+	c.Assert(err, qt.IsNil)
+
+	token, err := testAPI.auth.Decode(res.Token)
+	c.Assert(err, qt.IsNil)
+
+	exp := token.Expiration()
+	now := time.Now()
+	// expiry is in the future and close to now+jwtExpiration — not decades/eons away
+	c.Assert(exp.After(now), qt.IsTrue)
+	c.Assert(exp.Before(now.Add(jwtExpiration+time.Hour)), qt.IsTrue,
+		qt.Commentf("exp %s is too far out — likely encoded as nanoseconds", exp))
+	// the response-level expiry mirrors the token claim
+	c.Assert(res.Expirity.Before(now.Add(jwtExpiration+time.Hour)), qt.IsTrue)
+}

--- a/api/users.go
+++ b/api/users.go
@@ -163,6 +163,18 @@ func (a *API) verifyUserAccountHandler(w http.ResponseWriter, r *http.Request) {
 		errors.ErrVerificationCodeExpired.Write(w)
 		return
 	}
+	// bound brute-force: atomically spend one verification attempt, failing closed once the
+	// per-code cap is reached. Done before comparing the code so an exhausted code is locked
+	// regardless of the submitted value (no per-guess unlimited retries).
+	recorded, err := a.db.VerificationCodeCheckAndAddAttempt(user, db.CodeTypeVerifyAccount, apicommon.VerificationCodeMaxAttempts)
+	if err != nil {
+		errors.ErrUnauthorized.Write(w)
+		return
+	}
+	if !recorded {
+		errors.ErrVerificationMaxAttempts.Write(w)
+		return
+	}
 	// check the verification code is correct
 	code, err := internal.OpenToken(userVerification.SealedCode, verification.Email, a.secret)
 	if err != nil {
@@ -696,6 +708,19 @@ func (a *API) resetUserPasswordHandler(w http.ResponseWriter, r *http.Request) {
 	// check the verification code is not expired
 	if userVerification.Expiration.Before(time.Now()) {
 		errors.ErrVerificationCodeExpired.Write(w)
+		return
+	}
+
+	// bound brute-force: atomically spend one attempt, failing closed once the per-code cap is
+	// reached. Done before comparing the code so an exhausted reset code is locked regardless of
+	// the submitted value, closing the online guessing vector against the short OTP.
+	recorded, err := a.db.VerificationCodeCheckAndAddAttempt(user, db.CodeTypePasswordReset, apicommon.VerificationCodeMaxAttempts)
+	if err != nil {
+		errors.ErrUnauthorized.Write(w)
+		return
+	}
+	if !recorded {
+		errors.ErrVerificationMaxAttempts.Write(w)
 		return
 	}
 

--- a/api/users.go
+++ b/api/users.go
@@ -168,6 +168,9 @@ func (a *API) verifyUserAccountHandler(w http.ResponseWriter, r *http.Request) {
 	// regardless of the submitted value (no per-guess unlimited retries).
 	recorded, err := a.db.VerificationCodeCheckAndAddAttempt(user, db.CodeTypeVerifyAccount, apicommon.VerificationCodeMaxAttempts)
 	if err != nil {
+		if err != db.ErrNotFound {
+			log.Warnw("could not record verification attempt", "error", err)
+		}
 		errors.ErrUnauthorized.Write(w)
 		return
 	}
@@ -716,6 +719,9 @@ func (a *API) resetUserPasswordHandler(w http.ResponseWriter, r *http.Request) {
 	// the submitted value, closing the online guessing vector against the short OTP.
 	recorded, err := a.db.VerificationCodeCheckAndAddAttempt(user, db.CodeTypePasswordReset, apicommon.VerificationCodeMaxAttempts)
 	if err != nil {
+		if err != db.ErrNotFound {
+			log.Warnw("could not record password reset attempt", "error", err)
+		}
 		errors.ErrUnauthorized.Write(w)
 		return
 	}

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -286,6 +286,61 @@ func TestResetPasswordWrongCodeRejected(t *testing.T) {
 	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
 }
 
+// TestResetPasswordBruteForceLockout verifies the password-reset code is locked after a bounded
+// number of wrong guesses, so the short OTP cannot be brute-forced online: repeated wrong codes
+// are rejected and, once the per-code attempt cap is reached, even the CORRECT code is refused
+// and the account password is left unchanged.
+func TestResetPasswordBruteForceLockout(t *testing.T) {
+	c := qt.New(t)
+
+	mail := fmt.Sprintf("%d-lockout@test.com", internal.RandomInt(100000))
+	userInfo := &apicommon.UserInfo{Email: mail, Password: testPass, FirstName: testFirstName, LastName: testLastName}
+	resp, code := testRequest(t, http.MethodPost, "", userInfo, usersEndpoint)
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+
+	// verify the user
+	mailBody := waitForEmail(t, mail)
+	verifyMailCode := verificationCodeRgx.FindStringSubmatch(mailBody)
+	c.Assert(len(verifyMailCode) > 1, qt.IsTrue)
+	resp, code = testRequest(t, http.MethodPost, "",
+		&apicommon.UserVerification{Email: mail, Code: verifyMailCode[1]}, verifyUserEndpoint)
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+
+	// request a password reset code
+	resp, code = testRequest(t, http.MethodPost, "", &apicommon.UserInfo{Email: mail}, usersRecoveryPasswordEndpoint)
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+	mailBody = waitForEmail(t, mail)
+	passResetMailCode := passwordResetRgx.FindStringSubmatch(mailBody)
+	c.Assert(len(passResetMailCode) > 1, qt.IsTrue)
+	validCode := passResetMailCode[1]
+
+	// exhaust the guess budget with wrong codes. The stored counter starts at 1, so
+	// VerificationCodeMaxAttempts-1 wrong guesses are compared-and-rejected (401) before lockout.
+	for i := 0; i < apicommon.VerificationCodeMaxAttempts-1; i++ {
+		resp, code = testRequest(t, http.MethodPost, "", &apicommon.UserPasswordReset{
+			Email: mail, Code: validCode + "x", NewPassword: "attackerpassword",
+		}, usersResetPasswordEndpoint)
+		c.Assert(code, qt.Equals, http.StatusUnauthorized, qt.Commentf("guess %d response: %s", i, resp))
+	}
+
+	// the code is now locked: a further wrong guess is refused with max-attempts (400), not 401
+	resp, code = testRequest(t, http.MethodPost, "", &apicommon.UserPasswordReset{
+		Email: mail, Code: validCode + "x", NewPassword: "attackerpassword",
+	}, usersResetPasswordEndpoint)
+	c.Assert(code, qt.Equals, http.StatusBadRequest, qt.Commentf("response: %s", resp))
+
+	// even the CORRECT code is rejected once locked out
+	resp, code = testRequest(t, http.MethodPost, "", &apicommon.UserPasswordReset{
+		Email: mail, Code: validCode, NewPassword: "attackerpassword",
+	}, usersResetPasswordEndpoint)
+	c.Assert(code, qt.Equals, http.StatusBadRequest, qt.Commentf("response: %s", resp))
+
+	// the original password still works: the attacker never reset it
+	resp, code = testRequest(t, http.MethodPost, "",
+		&apicommon.UserInfo{Email: mail, Password: testPass}, authLoginEndpoint)
+	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
+}
+
 func TestUserWithOrganization(t *testing.T) {
 	c := qt.New(t)
 

--- a/db/verifications.go
+++ b/db/verifications.go
@@ -73,6 +73,39 @@ func (ms *MongoStorage) SetVerificationCode(user *User, sealedCode []byte, t Cod
 	return err
 }
 
+// VerificationCodeCheckAndAddAttempt atomically records one verification attempt for the
+// user's code of the given type, but only while the stored attempt count is still below
+// maxAttempts. It returns recorded=true when the attempt was counted and recorded=false when
+// the cap had already been reached (no increment performed) — a single conditional update, so
+// concurrent submissions cannot push the counter past the cap. It is the fail-closed guard on
+// the code-guessing path (mirrors IncrementCSPAuthAttempts). It returns ErrNotFound when no
+// such code exists.
+func (ms *MongoStorage) VerificationCodeCheckAndAddAttempt(user *User, t CodeType, maxAttempts int) (bool, error) {
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	// conditional increment: only bump attempts while still below the cap
+	res, err := ms.verifications.UpdateOne(ctx,
+		bson.M{"_id": user.ID, "type": t, "attempts": bson.M{"$lt": maxAttempts}},
+		bson.M{"$inc": bson.M{"attempts": 1}})
+	if err != nil {
+		return false, err
+	}
+	if res.MatchedCount == 1 {
+		return true, nil
+	}
+	// no document matched: either no code exists or the cap is already reached. Distinguish the
+	// two so the caller can return the right error.
+	if err := ms.verifications.FindOne(ctx, bson.M{"_id": user.ID, "type": t}).Err(); err != nil {
+		if err == mongo.ErrNoDocuments {
+			return false, ErrNotFound
+		}
+		return false, err
+	}
+	return false, nil
+}
+
 // VerificationCodeIncrementAttempts method increments the number of attempts
 // for the verification code of the user provided. If an error occurs, it
 // returns the error.

--- a/db/verifications_test.go
+++ b/db/verifications_test.go
@@ -95,4 +95,49 @@ func TestVerifications(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 		c.Assert(code.Attempts, qt.Equals, 2)
 	})
+
+	t.Run("TestVerificationCodeCheckAndAddAttempt", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		const maxAttempts = 3
+		userID, err := testDB.SetUser(&User{
+			Email:     testUserEmail + "4",
+			Password:  testUserPass,
+			FirstName: testUserFirstName,
+			LastName:  testUserLastName,
+		})
+		c.Assert(err, qt.IsNil)
+		user := &User{ID: userID}
+
+		// no code yet: the guard reports ErrNotFound rather than a spurious lockout
+		recorded, err := testDB.VerificationCodeCheckAndAddAttempt(user, CodeTypePasswordReset, maxAttempts)
+		c.Assert(err, qt.Equals, ErrNotFound)
+		c.Assert(recorded, qt.IsFalse)
+
+		sealedCode, err := internal.SealToken("testCode", testUserEmail, "mock-app-secret")
+		c.Assert(err, qt.IsNil)
+		// SetVerificationCode seeds Attempts at 1, so only maxAttempts-1 attempts are recordable
+		c.Assert(testDB.SetVerificationCode(user, sealedCode, CodeTypePasswordReset, time.Now()), qt.IsNil)
+
+		// record attempts until the cap is hit; each recorded call bumps the stored counter
+		for want := 2; want <= maxAttempts; want++ {
+			recorded, err = testDB.VerificationCodeCheckAndAddAttempt(user, CodeTypePasswordReset, maxAttempts)
+			c.Assert(err, qt.IsNil)
+			c.Assert(recorded, qt.IsTrue)
+			code, err := testDB.UserVerificationCode(user, CodeTypePasswordReset)
+			c.Assert(err, qt.IsNil)
+			c.Assert(code.Attempts, qt.Equals, want)
+		}
+
+		// cap reached: further attempts fail closed and do not increment past the cap
+		recorded, err = testDB.VerificationCodeCheckAndAddAttempt(user, CodeTypePasswordReset, maxAttempts)
+		c.Assert(err, qt.IsNil)
+		c.Assert(recorded, qt.IsFalse)
+		code, err := testDB.UserVerificationCode(user, CodeTypePasswordReset)
+		c.Assert(err, qt.IsNil)
+		c.Assert(code.Attempts, qt.Equals, maxAttempts)
+
+		// a different code type for the same user is tracked independently (not locked)
+		_, err = testDB.VerificationCodeCheckAndAddAttempt(user, CodeTypeVerifyAccount, maxAttempts)
+		c.Assert(err, qt.Equals, ErrNotFound)
+	})
 }

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -51,7 +51,7 @@ var (
 	ErrNoOrganizationProvided  = Error{Code: 40011, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("organization address is required")}
 	ErrInvalidOrganizationData = Error{Code: 40013, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid organization information provided")}
 	ErrUserAlreadyVerified     = Error{Code: 40015, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("user account is already verified")}
-	ErrVerificationMaxAttempts = Error{Code: 40017, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("verification resend max attempts reached")}
+	ErrVerificationMaxAttempts = Error{Code: 40017, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("verification max attempts reached")}
 	ErrStorageInvalidObject    = Error{Code: 40024, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("invalid storage object or parameters")}
 	ErrNotSupported            = Error{Code: 40025, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("feature not supported")}
 	ErrUserNoVoted             = Error{Code: 40036, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("user has not voted yet"), LogLevel: "info"}


### PR DESCRIPTION
Fixes the two HIGH-severity auth findings from #574. One fix per commit.

## 1. JWT `exp` set in nanoseconds → tokens never expire (`fix(auth)`)
`buildLoginResponse` set the `exp` claim to `time.Now().Add(jwtExpiration).UnixNano()`. jwx v2 interprets an `int64` `exp` as Unix **seconds**, so a nanosecond value (~1.75e18) placed expiration ~55 billion years out and `jwt.Validate` never rejected a token on expiry — defeating the intended 15-day lifetime and leaving leaked/stolen tokens valid essentially forever (there is no jti/blacklist revocation).

**Fix:** pass a `time.Time`, which jwx encodes as a proper `NumericDate` (seconds), and reuse the same value for `LoginResponse.Expirity`.

> Note: existing tokens minted with the bad `exp` remain valid until manually invalidated (rotate the JWT secret if you want to force re-login).

## 2. Verification-code / password-reset OTP brute-force (`fix(users)`)
`resetUserPasswordHandler` and `verifyUserAccountHandler` compared the submitted code with **no attempt counter and no per-account rate limiting** (only the global `Throttle(100)` concurrency cap). With a 3-byte / 6-hex code (~16.7M values) valid for the full 15-min window, an attacker could trigger a reset for a victim email and brute-force the code online → account takeover.

**Fix:** new `VerificationCodeCheckAndAddAttempt` — a single atomic conditional `$inc` that only bumps the attempt counter while it is below `VerificationCodeMaxAttempts`, mirroring the fail-closed `IncrementCSPAuthAttempts` guard. Both handlers now spend one attempt **before** comparing the code, so an exhausted code is locked regardless of the submitted value and concurrent submissions can't race past the cap. Reuses the existing `Attempts` field / `ErrVerificationMaxAttempts`.

Defense-in-depth follow-up (not in this PR): raise `VerificationCodeLength` for more entropy. The attempt cap alone already reduces the brute-force space to ≤2 guesses per issued code.

## Testing
⚠️ **I could not build, lint, or run the test suite** — the Go toolchain is not available in the environment where these changes were authored. Changes were verified by manual review only (type-correctness for jwx v2, line-length under the 130-char `lll` limit, `a.db` is the concrete `*db.MongoStorage`). **Please rely on CI** and a maintainer's local `make test` / `make lint` before merging. Regression tests for both paths (an expired-then-rejected token; a code locked after N wrong guesses) are worth adding — happy to follow up.

Closes #574 (partial — the two HIGH items; the MEDIUM/LOW findings remain tracked there).

---
*Generated with [Claude Code](https://claude.com/claude-code)*
