### PR TITLE
fix(processes): serialize org address as internal.HexBytes (bare hex)

### DIFF
--- a/api/apicommon/voting_processes.go
+++ b/api/apicommon/voting_processes.go
@@ -41,7 +41,7 @@ type VotingProcessQuestionRequest struct {
 // CreateVotingProcessRequest is the body of POST /processes (also used by PUT to update a
 // draft). Common params are shared by every question.
 type CreateVotingProcessRequest struct {
-	OrgAddress  internal.HexBytes              `json:"orgAddress" swaggertype:"string" format:"hex" example:"deadbeef"`
+	OrgAddress  internal.HexBytes              `json:"orgAddress" swaggertype:"string" format:"hex" example:"a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"` //nolint:lll
 	Census      CensusSpec                     `json:"census"`
 	Title       db.MultiLangString             `json:"title"`
 	Description db.MultiLangString             `json:"description,omitempty"`
@@ -61,7 +61,7 @@ type CreateVotingProcessResponse struct {
 // and list endpoints. Questions are fully hydrated (including the synced status).
 type VotingProcessResponse struct {
 	ID          string                     `json:"id"`
-	OrgAddress  internal.HexBytes          `json:"orgAddress" swaggertype:"string" format:"hex" example:"deadbeef"`
+	OrgAddress  internal.HexBytes          `json:"orgAddress" swaggertype:"string" format:"hex" example:"a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"` //nolint:lll
 	Published   bool                       `json:"published"`
 	Census      CensusSpec                 `json:"census"`
 	Title       db.MultiLangString         `json:"title"`

--- a/api/apicommon/voting_processes.go
+++ b/api/apicommon/voting_processes.go
@@ -3,7 +3,6 @@ package apicommon
 //revive:disable:max-public-structs
 
 import (
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -42,7 +41,7 @@ type VotingProcessQuestionRequest struct {
 // CreateVotingProcessRequest is the body of POST /processes (also used by PUT to update a
 // draft). Common params are shared by every question.
 type CreateVotingProcessRequest struct {
-	OrgAddress  common.Address                 `json:"orgAddress"`
+	OrgAddress  internal.HexBytes              `json:"orgAddress" swaggertype:"string" format:"hex" example:"deadbeef"`
 	Census      CensusSpec                     `json:"census"`
 	Title       db.MultiLangString             `json:"title"`
 	Description db.MultiLangString             `json:"description,omitempty"`
@@ -62,7 +61,7 @@ type CreateVotingProcessResponse struct {
 // and list endpoints. Questions are fully hydrated (including the synced status).
 type VotingProcessResponse struct {
 	ID          string                     `json:"id"`
-	OrgAddress  common.Address             `json:"orgAddress"`
+	OrgAddress  internal.HexBytes          `json:"orgAddress" swaggertype:"string" format:"hex" example:"deadbeef"`
 	Published   bool                       `json:"published"`
 	Census      CensusSpec                 `json:"census"`
 	Title       db.MultiLangString         `json:"title"`
@@ -167,7 +166,7 @@ func VotingProcessResponseFromDB(
 ) *VotingProcessResponse {
 	resp := &VotingProcessResponse{
 		ID:          vp.ID.Hex(),
-		OrgAddress:  vp.OrgAddress,
+		OrgAddress:  vp.OrgAddress.Bytes(),
 		Published:   vp.Published,
 		Title:       vp.Title,
 		Description: vp.Description,

--- a/api/processes.go
+++ b/api/processes.go
@@ -61,11 +61,14 @@ func (a *API) createVotingProcessHandler(w http.ResponseWriter, r *http.Request)
 		errors.ErrUnauthorized.Write(w)
 		return
 	}
-	if req.OrgAddress == (common.Address{}) {
-		errors.ErrMalformedBody.Withf("missing org address").Write(w)
+	// orgAddress is internal.HexBytes over the API (bare-hex JSON, like upstreamId); unlike
+	// common.Address it doesn't enforce a 20-byte length on decode, so validate it here.
+	if len(req.OrgAddress) != common.AddressLength {
+		errors.ErrMalformedBody.Withf("missing or invalid org address").Write(w)
 		return
 	}
-	if !user.HasRoleFor(req.OrgAddress, db.ManagerRole) && !user.HasRoleFor(req.OrgAddress, db.AdminRole) {
+	orgAddr := common.BytesToAddress(req.OrgAddress)
+	if !user.HasRoleFor(orgAddr, db.ManagerRole) && !user.HasRoleFor(orgAddr, db.AdminRole) {
 		errors.ErrUnauthorized.Withf("user is not admin or manager of the organization").Write(w)
 		return
 	}
@@ -73,7 +76,7 @@ func (a *API) createVotingProcessHandler(w http.ResponseWriter, r *http.Request)
 		errors.ErrMalformedBody.Withf("questions must be between 1 and %d", maxQuestionsPerProcess).Write(w)
 		return
 	}
-	if err := a.subscriptions.OrgCanCreateVotingProcessDraft(req.OrgAddress); err != nil {
+	if err := a.subscriptions.OrgCanCreateVotingProcessDraft(orgAddr); err != nil {
 		writeSubscriptionError(w, err)
 		return
 	}
@@ -82,14 +85,14 @@ func (a *API) createVotingProcessHandler(w http.ResponseWriter, r *http.Request)
 		errors.ErrMalformedBody.WithErr(err).Write(w)
 		return
 	}
-	census, err := a.resolveOrCreateDefaultCensus(req.Census, req.OrgAddress)
+	census, err := a.resolveOrCreateDefaultCensus(req.Census, orgAddr)
 	if err != nil {
 		writeSubscriptionError(w, err)
 		return
 	}
 	// validate + build the questions (incl. eligibility against the census) before any process
 	// write, so a bad request rolls the census back and never creates a half-written draft.
-	built, err := a.buildQuestions(req.OrgAddress, req.Questions, census)
+	built, err := a.buildQuestions(orgAddr, req.Questions, census)
 	if err != nil {
 		_ = a.db.DelCensus(census.ID.Hex())
 		writeSubscriptionError(w, err)
@@ -97,7 +100,7 @@ func (a *API) createVotingProcessHandler(w http.ResponseWriter, r *http.Request)
 	}
 
 	vp := &db.VotingProcess{
-		OrgAddress:  req.OrgAddress,
+		OrgAddress:  orgAddr,
 		Published:   false,
 		Title:       req.Title,
 		Description: req.Description,

--- a/api/processes.go
+++ b/api/processes.go
@@ -62,12 +62,13 @@ func (a *API) createVotingProcessHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	// orgAddress is internal.HexBytes over the API (bare-hex JSON, like upstreamId); unlike
-	// common.Address it doesn't enforce a 20-byte length on decode, so validate it here.
-	if len(req.OrgAddress) != common.AddressLength {
+	// common.Address it doesn't enforce a 20-byte length on decode, so validate it here. The
+	// zero address is treated as missing (it can never own an organization).
+	orgAddr := common.BytesToAddress(req.OrgAddress)
+	if len(req.OrgAddress) != common.AddressLength || orgAddr == (common.Address{}) {
 		errors.ErrMalformedBody.Withf("missing or invalid org address").Write(w)
 		return
 	}
-	orgAddr := common.BytesToAddress(req.OrgAddress)
 	if !user.HasRoleFor(orgAddr, db.ManagerRole) && !user.HasRoleFor(orgAddr, db.AdminRole) {
 		errors.ErrUnauthorized.Withf("user is not admin or manager of the organization").Write(w)
 		return

--- a/api/processes_orgaddress_test.go
+++ b/api/processes_orgaddress_test.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/api/apicommon"
+)
+
+// TestVotingProcessOrgAddressWireFormat asserts that orgAddress is serialized on the wire as bare
+// lowercase hex (internal.HexBytes), with no 0x prefix or EIP-55 checksum. Struct-parsing tests can't
+// catch a format regression here, because internal.HexBytes decodes both 0x-prefixed and bare hex.
+func TestVotingProcessOrgAddressWireFormat(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(2)...)
+
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, newVotingProcessRequest(orgAddress, memberIDs(members)), processesCreateEndpoint)
+
+	raw, code := testRequest(t, http.MethodGet, token, nil, "processes", created.ProcessID)
+	c.Assert(code, qt.Equals, http.StatusOK)
+	// common.Address.Hex() returns "0x" + EIP-55 checksum; the wire form must be the bare lowercase hex.
+	want := `"orgAddress":"` + strings.ToLower(orgAddress.Hex()[2:]) + `"`
+	c.Assert(strings.Contains(string(raw), want), qt.IsTrue, qt.Commentf("raw body: %s", raw))
+	c.Assert(strings.Contains(string(raw), `"orgAddress":"0x`), qt.IsFalse)
+}

--- a/api/processes_review2_test.go
+++ b/api/processes_review2_test.go
@@ -36,7 +36,7 @@ func TestVotingProcessEmptyCensusRejected(t *testing.T) {
 // not need members.
 func minimalVotingProcessRequest(orgAddress common.Address) *apicommon.CreateVotingProcessRequest {
 	return &apicommon.CreateVotingProcessRequest{
-		OrgAddress: orgAddress,
+		OrgAddress: orgAddress.Bytes(),
 		Census:     apicommon.CensusSpec{TwoFaFields: db.OrgMemberTwoFaFields{db.OrgMemberTwoFaFieldEmail}},
 		Title:      db.MultiLangString{"default": "key proc"}, //nolint:goconst
 		StartDate:  time.Now().Add(time.Hour).UTC().Format(time.RFC3339),

--- a/api/processes_test.go
+++ b/api/processes_test.go
@@ -23,7 +23,7 @@ func newVotingProcessRequest(
 		{Title: db.MultiLangString{"default": "No"}, Value: 1},
 	}
 	return &apicommon.CreateVotingProcessRequest{
-		OrgAddress: orgAddress,
+		OrgAddress: orgAddress.Bytes(),
 		Census: apicommon.CensusSpec{
 			TwoFaFields: db.OrgMemberTwoFaFields{db.OrgMemberTwoFaFieldEmail},
 			MemberIDs:   memberIDs,

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -518,9 +518,9 @@ definitions:
       header:
         type: string
       orgAddress:
-        items:
-          type: integer
-        type: array
+        example: deadbeef
+        format: hex
+        type: string
       questions:
         items:
           $ref: '#/definitions/apicommon.VotingProcessQuestionRequest'
@@ -1819,9 +1819,9 @@ definitions:
       id:
         type: string
       orgAddress:
-        items:
-          type: integer
-        type: array
+        example: deadbeef
+        format: hex
+        type: string
       published:
         type: boolean
       questions:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -518,7 +518,7 @@ definitions:
       header:
         type: string
       orgAddress:
-        example: deadbeef
+        example: a1b2c3d4e5f60718293a4b5c6d7e8f9012345678
         format: hex
         type: string
       questions:
@@ -1819,7 +1819,7 @@ definitions:
       id:
         type: string
       orgAddress:
-        example: deadbeef
+        example: a1b2c3d4e5f60718293a4b5c6d7e8f9012345678
         format: hex
         type: string
       published:


### PR DESCRIPTION
## What

PR #571's `/processes` API types serialize `orgAddress` as `common.Address`, which JSON-marshals to a `0x`-prefixed, EIP-55-checksummed string — inconsistent with `upstreamId` (and the other hex ids in these types), which use `internal.HexBytes` and marshal to **bare lowercase hex**. This switches the org address in the `/processes` request/response types to `internal.HexBytes` so the API is internally consistent.

## Change

- `apicommon.CreateVotingProcessRequest.OrgAddress` and `apicommon.VotingProcessResponse.OrgAddress` → `internal.HexBytes` (with `swaggertype:"string" format:"hex"`, like `upstreamId`).
- `VotingProcessResponseFromDB` converts the stored `common.Address` via `.Bytes()` (the only response builder; used by the single-read and list handlers).
- `createVotingProcessHandler` validates `len(orgAddress) == common.AddressLength` — `internal.HexBytes`, unlike `common.Address`, doesn't enforce a 20-byte length on decode — then converts once to `common.Address` for the db/auth/subscription/census calls.

The db layer (`db.VotingProcess.OrgAddress common.Address`) is unchanged; conversion happens at the API boundary.

## Compatibility

- **Requests stay compatible:** `internal.HexBytes.UnmarshalJSON` strips an optional `0x` prefix, so clients may still send `"orgAddress": "0x…"`.
- **Response format changes:** `GET /processes` / `GET /processes/{id}` now return `orgAddress` as bare lowercase hex (matching `upstreamId`) instead of `0x`+checksum. Clients that string-compare the address should normalize.
- `GET /processes?orgAddress=` unchanged (query parsing via `common.IsHexAddress`/`HexToAddress` accepts both forms).

## Scope

Limited to what #571 introduced. Legacy `/process` (`CreateProcessRequest`) and census types keep `common.Address` and are untouched.

## Tests

- Two `/processes` request-builder test helpers now set `OrgAddress: orgAddress.Bytes()`; no response-side assertions changed.
- `go test -run TestVotingProcess ./api/` green (create → update → authoring errors → publish → results → CSP → participant).
- `make lint` new-issues clean; `make swagger` regenerated (fields render as hex strings).