### PR TITLE
chore(lint): fix all golangci-lint issues for v2.12

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,12 @@ linters:
     - misspell
     - revive
   settings:
+    goconst:
+      ignore-tests: true # repeated literals in test fixtures are fine
+      ignore-string-values:
+        # single-token strings are overwhelmingly bson field names, mongo query
+        # operators ($set, $exists...) and schema keys; consting them adds churn
+        - '^[\w.$-]+$'
     lll:
       line-length: 130
     revive:
@@ -15,6 +21,14 @@ linters:
         disabled: true
       - name: unnecessary-format # we prefer fmt.Errorf rather than errors.New
         disabled: true
+      - name: unhandled-error # ignore errors from stdout printing and in-memory writers (which never fail)
+        arguments:
+          - "fmt\\.Print(f|ln)?"
+          - "fmt\\.Fprint(f|ln)?"
+          - "strings\\.Builder\\.WriteString"
+          - "bytes\\.Buffer\\.Write"
+      - name: package-naming # the errors package intentionally mirrors the stdlib name
+        exclude: ["**/errors/*.go"]
       - name: function-length # test funcs are usually long and complex, and that's ok
         exclude: ["**/*_test.go"]
       - name: cognitive-complexity # test funcs are usually long and complex, and that's ok

--- a/account/process.go
+++ b/account/process.go
@@ -93,15 +93,15 @@ func electionStartDuration(startDate, endDate time.Time) (startTime, duration ui
 			// range-check before truncating to the on-chain uint32 types: a wrapped
 			// start/duration would otherwise set a bogus election window and could slip a
 			// too-long duration under the plan limit (which compares the already-cast value).
-			start := startDate.Unix()
+			startSec := startDate.Unix()
 			dur := endDate.Sub(startDate).Seconds()
-			if start < 0 || start > math.MaxUint32 {
+			if startSec < 0 || startSec > math.MaxUint32 {
 				return 0, 0, fmt.Errorf("startDate out of range")
 			}
 			if dur < 0 || dur > math.MaxUint32 {
 				return 0, 0, fmt.Errorf("duration out of range")
 			}
-			return uint32(start), uint32(dur), nil
+			return uint32(startSec), uint32(dur), nil
 		}
 	}
 	d := time.Until(endDate)

--- a/cmd/client/api_client.go
+++ b/cmd/client/api_client.go
@@ -236,6 +236,8 @@ func stringField(obj map[string]any, key string) string {
 		if oid, ok := value["$oid"].(string); ok {
 			return strings.TrimSpace(oid)
 		}
+	default:
+		// unsupported type, fall back to the empty string below
 	}
 	return ""
 }

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -363,7 +363,7 @@ func sortedVerificationTargets(targets map[string]verificationTarget) []verifica
 	for key := range targets {
 		keys = append(keys, key)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 
 	ordered := make([]verificationTarget, 0, len(keys))
 	for _, key := range keys {

--- a/cmd/client/workflow.go
+++ b/cmd/client/workflow.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -352,7 +352,7 @@ func sortedMemberIDs(memberIDs map[string]struct{}) []string {
 	for memberID := range memberIDs {
 		ids = append(ids, memberID)
 	}
-	sort.Strings(ids)
+	slices.Sort(ids)
 	return ids
 }
 

--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -55,7 +55,7 @@ func main() {
 	flag.String("twilioFromNumber", "", "Twilio from number")
 	flag.String("stripeApiSecret", "", "Stripe API secret")
 	flag.String("stripeWebhookSecret", "", "Stripe Webhook secret")
-	flag.String("oauthServiceURL", "http://oauth.vocdoni.net", "OAuth service URL")
+	flag.String("oauthServiceURL", "https://oauth.vocdoni.net", "OAuth service URL")
 	// OTP / verification code tuning (0 = use built-in defaults, applies to both API and CSP)
 	flag.Duration("otpExpiry", 0, "validity window for one-time codes (0 = default 15m)")
 	flag.Duration("otpCooldown", 0, "min wait between notification requests for the same account (0 = default 60s)")

--- a/csp/signers/saltedkey/saltedkey.go
+++ b/csp/signers/saltedkey/saltedkey.go
@@ -61,6 +61,7 @@ func (sk *SaltedKey) SignECDSA(salt [SaltSize]byte, msg []byte) ([]byte, error) 
 	// get the bigNumber from salt
 	s := new(big.Int).SetBytes(salt[:])
 	// add it to the current key, so now we have a new private key (currentPrivKey + n)
+	//nolint:staticcheck // SA1019: mutating D is the point of salted-key derivation; predates the Go 1.26 deprecation
 	esk.Private.D.Add(esk.Private.D, s)
 	// return the signature
 	return esk.SignEthereum(msg)
@@ -117,6 +118,7 @@ func SaltECDSAPubKey(pubKey *ecdsa.PublicKey, salt [saltedkey.SaltSize]byte) ([]
 		return nil, fmt.Errorf("public key is nil")
 	}
 	x, y := pubKey.ScalarBaseMult(salt[:])
+	//nolint:staticcheck // SA1019: mutating X/Y is the point of salted-key derivation; predates the Go 1.26 deprecation
 	pubKey.X, pubKey.Y = pubKey.Add(pubKey.X, pubKey.Y, x, y)
 	return ethcrypto.FromECDSAPub(pubKey), nil
 }

--- a/db/organizations.go
+++ b/db/organizations.go
@@ -320,7 +320,6 @@ func (ms *MongoStorage) UpdateOrganizationMeta(address common.Address, metaUpdat
 		return fmt.Errorf("no organization found with address: %s", address)
 	}
 
-	fmt.Printf("Matched: %d, Modified: %d\n", result.MatchedCount, result.ModifiedCount)
 	return nil
 }
 

--- a/db/process_bundles.go
+++ b/db/process_bundles.go
@@ -12,6 +12,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.vocdoni.io/dvote/log"
 )
 
 // SetProcessBundle creates a new process bundle or updates an existing one.
@@ -121,9 +122,8 @@ func (ms *MongoStorage) ProcessBundles() ([]*ProcessesBundle, error) {
 		return nil, fmt.Errorf("failed to find process bundles: %w", err)
 	}
 	defer func() {
-		err := cursor.Close(ctx)
-		if err != nil {
-			fmt.Println("failed to close cursor")
+		if err := cursor.Close(ctx); err != nil {
+			log.Warnw("failed to close cursor", "error", err)
 		}
 	}()
 
@@ -153,9 +153,8 @@ func (ms *MongoStorage) ProcessBundlesByProcess(processID internal.HexBytes) ([]
 		return nil, fmt.Errorf("failed to find process bundles by process ID: %w", err)
 	}
 	defer func() {
-		err := cursor.Close(ctx)
-		if err != nil {
-			fmt.Println("failed to close cursor")
+		if err := cursor.Close(ctx); err != nil {
+			log.Warnw("failed to close cursor", "error", err)
 		}
 	}()
 
@@ -185,9 +184,8 @@ func (ms *MongoStorage) ProcessBundlesByOrg(orgAddress common.Address) ([]*Proce
 		return nil, fmt.Errorf("failed to find process bundles by organization: %w", err)
 	}
 	defer func() {
-		err := cursor.Close(ctx)
-		if err != nil {
-			fmt.Println("failed to close cursor")
+		if err := cursor.Close(ctx); err != nil {
+			log.Warnw("failed to close cursor", "error", err)
 		}
 	}()
 
@@ -233,7 +231,7 @@ func (ms *MongoStorage) ProcessBundlesByCensus(census *Census) ([]*ProcessesBund
 	}
 	defer func() {
 		if err := cursor.Close(ctx); err != nil {
-			fmt.Printf("failed to close cursor: %v", err)
+			log.Warnw("failed to close cursor", "error", err)
 		}
 	}()
 

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -20,6 +20,7 @@ func TestErrorCodesAreUnique(t *testing.T) {
 	fset := token.NewFileSet()
 
 	// Parse all non-test .go files in this directory
+	//nolint:staticcheck // SA1019: parser.ParseDir suffices here, this package has no build-tagged files
 	pkgs, err := parser.ParseDir(fset, ".", func(info fs.FileInfo) bool {
 		name := info.Name()
 		return strings.HasSuffix(name, ".go") && !strings.HasSuffix(name, "_test.go")

--- a/migrations/0001_initial_collections.go
+++ b/migrations/0001_initial_collections.go
@@ -15,6 +15,13 @@ func init() {
 	AddMigration(1, "initial_collections", upInitialCollections, downInitialCollections)
 }
 
+// Shared validator description strings, reused across collection validators.
+const (
+	descRequiredInt    = "must be an integer and is required"
+	descRequiredEmail  = "must be an email and is required"
+	descRequiredString = "must be a string and is required"
+)
+
 var collectionsToCreate = []string{
 	"users",
 	"verifications",
@@ -48,17 +55,17 @@ var usersCollectionValidator = bson.M{
 		"properties": bson.M{
 			"id": bson.M{
 				"bsonType":    "int",
-				"description": "must be an integer and is required",
+				"description": descRequiredInt,
 				"minimum":     1,
 			},
 			"email": bson.M{
 				"bsonType":    "string",
-				"description": "must be an email and is required",
+				"description": descRequiredEmail,
 				"pattern":     internal.EmailRegexTemplate,
 			},
 			"password": bson.M{
 				"bsonType":    "string",
-				"description": "must be a string and is required",
+				"description": descRequiredString,
 				"minLength":   8,
 			},
 		},
@@ -72,7 +79,7 @@ var organizationInvitesCollectionValidator = bson.M{
 		"properties": bson.M{
 			"invitationCode": bson.M{
 				"bsonType":    "string",
-				"description": "must be a string and is required",
+				"description": descRequiredString,
 				"minimum":     6,
 				"pattern":     `^[\w]{6,}$`,
 			},
@@ -82,13 +89,13 @@ var organizationInvitesCollectionValidator = bson.M{
 			},
 			"currentUserID": bson.M{
 				"bsonType":    "long",
-				"description": "must be an integer and is required",
+				"description": descRequiredInt,
 				"minimum":     1,
 				"pattern":     `^[1-9]+$`,
 			},
 			"newUserEmail": bson.M{
 				"bsonType":    "string",
-				"description": "must be an email and is required",
+				"description": descRequiredEmail,
 				"pattern":     internal.EmailRegexTemplate,
 			},
 			"expiration": bson.M{
@@ -106,7 +113,7 @@ var subscriptionCollectionValidator = bson.M{
 		"properties": bson.M{
 			"id": bson.M{
 				"bsonType":    "int",
-				"description": "must be an integer and is required",
+				"description": descRequiredInt,
 				"minimum":     1,
 			},
 			"name": bson.M{

--- a/migrations/0009_add_oauth_providers.go
+++ b/migrations/0009_add_oauth_providers.go
@@ -6,6 +6,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.vocdoni.io/dvote/log"
 )
 
 func init() {
@@ -24,7 +25,7 @@ func upAddOAuthProviders(ctx context.Context, database *mongo.Database) error {
 
 	// If field already exists in any document, migration already applied
 	if count > 0 {
-		fmt.Println("oauth field already exists, skipping migration")
+		log.Infow("oauth field already exists, skipping migration")
 		return nil
 	}
 
@@ -37,7 +38,7 @@ func upAddOAuthProviders(ctx context.Context, database *mongo.Database) error {
 		return fmt.Errorf("failed to add oauth field: %w", err)
 	}
 
-	fmt.Printf("Added oauth field to %d user documents\n", result.ModifiedCount)
+	log.Infow("added oauth field to user documents", "modified", result.ModifiedCount)
 	return nil
 }
 
@@ -56,7 +57,7 @@ func downAddOAuthProviders(ctx context.Context, database *mongo.Database) error 
 	}
 	defer func() {
 		if err := cursor.Close(ctx); err != nil {
-			fmt.Printf("Warning: failed to close cursor: %v\n", err)
+			log.Warnw("failed to close cursor", "error", err)
 		}
 	}()
 
@@ -105,7 +106,7 @@ func downAddOAuthProviders(ctx context.Context, database *mongo.Database) error 
 		return fmt.Errorf("cursor error: %w", err)
 	}
 
-	fmt.Printf("Migrated %d OAuth users back to password-based storage\n", migratedCount)
+	log.Infow("migrated oauth users back to password-based storage", "migrated", migratedCount)
 
 	// Now remove the oauth field from all users
 	result, err := users.UpdateMany(ctx,
@@ -116,6 +117,6 @@ func downAddOAuthProviders(ctx context.Context, database *mongo.Database) error 
 		return fmt.Errorf("failed to remove oauth field: %w", err)
 	}
 
-	fmt.Printf("Removed oauth field from %d user documents\n", result.ModifiedCount)
+	log.Infow("removed oauth field from user documents", "modified", result.ModifiedCount)
 	return nil
 }

--- a/migrations/0010_update_user_validator.go
+++ b/migrations/0010_update_user_validator.go
@@ -7,6 +7,7 @@ import (
 	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.vocdoni.io/dvote/log"
 )
 
 func init() {
@@ -23,12 +24,12 @@ func upUpdateUserValidator(ctx context.Context, database *mongo.Database) error 
 			"properties": bson.M{
 				"id": bson.M{
 					"bsonType":    "int",
-					"description": "must be an integer and is required",
+					"description": descRequiredInt,
 					"minimum":     1,
 				},
 				"email": bson.M{
 					"bsonType":    "string",
-					"description": "must be an email and is required",
+					"description": descRequiredEmail,
 					"pattern":     internal.EmailRegexTemplate,
 				},
 				"password": bson.M{
@@ -52,7 +53,7 @@ func upUpdateUserValidator(ctx context.Context, database *mongo.Database) error 
 		return fmt.Errorf("failed to update users collection validator: %w", err)
 	}
 
-	fmt.Println("Updated users collection validator to allow empty passwords for OAuth users")
+	log.Infow("updated users collection validator to allow empty passwords for oauth users")
 	return nil
 }
 
@@ -66,17 +67,17 @@ func downUpdateUserValidator(ctx context.Context, database *mongo.Database) erro
 			"properties": bson.M{
 				"id": bson.M{
 					"bsonType":    "int",
-					"description": "must be an integer and is required",
+					"description": descRequiredInt,
 					"minimum":     1,
 				},
 				"email": bson.M{
 					"bsonType":    "string",
-					"description": "must be an email and is required",
+					"description": descRequiredEmail,
 					"pattern":     internal.EmailRegexTemplate,
 				},
 				"password": bson.M{
 					"bsonType":    "string",
-					"description": "must be a string and is required",
+					"description": descRequiredString,
 					"minLength":   8,
 				},
 			},
@@ -95,6 +96,6 @@ func downUpdateUserValidator(ctx context.Context, database *mongo.Database) erro
 		return fmt.Errorf("failed to revert users collection validator: %w", err)
 	}
 
-	fmt.Println("Reverted users collection validator to require 8-character passwords")
+	log.Infow("reverted users collection validator to require 8-character passwords")
 	return nil
 }

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -2,9 +2,10 @@
 package migrations
 
 import (
+	"cmp"
 	"context"
 	"maps"
-	"sort"
+	"slices"
 
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -42,7 +43,7 @@ func SortedByVersionAsc() []Migration {
 	for _, mig := range migrationRegistry {
 		migs = append(migs, mig)
 	}
-	sort.Slice(migs, func(i, j int) bool { return migs[i].Version < migs[j].Version })
+	slices.SortFunc(migs, func(a, b Migration) int { return cmp.Compare(a.Version, b.Version) })
 	return migs
 }
 


### PR DESCRIPTION
This is Fable speaking on behalf of elboletaire.

Makes a full `golangci-lint run` clean with **v2.12.2** (the version pinned in CI), which was reporting 170+ issues — 53 with the older 2.11.4 plus a large batch from goconst 1.10's extended detection. `scripts/check-qt-patterns.sh` also passes.

## Code fixes

- **`db/process_bundles.go`** — cursor-close defers printed to stdout with `fmt.Println`; now `log.Warnw("failed to close cursor", "error", err)`, matching the rest of `db/`.
- **`db/organizations.go`** — removed a stray `fmt.Printf("Matched: %d, ...")` debug print from the org meta update path.
- **`migrations/0009` & `0010`** — migration progress `fmt.Print*` converted to structured `log.Infow`/`log.Warnw`, matching newer migrations (0014/0015).
- **`migrations/0001` & `0010`** — repeated validator description strings extracted into shared constants (goconst).
- **`cmd/client`, `migrations/migrations.go`** — `sort.Strings` → `slices.Sort`, `sort.Slice` → `slices.SortFunc` (revive `use-slices-sort`).
- **`account/process.go`** — `start` → `startSec`, it holds a Unix timestamp (revive `epoch-naming`).
- **`cmd/service/main.go`** — default `oauthServiceURL` is now `https://`. Verified the host serves HTTPS and plain HTTP 301-redirects to it anyway (revive `unsecure-url-scheme`).
- **`cmd/client/api_client.go`** — added a `default` case to the type switch (revive `enforce-switch-style`).
- **`csp/signers/saltedkey`** — `//nolint:staticcheck` with justification for the SA1019 deprecations of `ecdsa.PrivateKey.D` / `PublicKey.X/Y` mutation: mutating the raw values *is* the salted-key derivation; migrating to the Go 1.25 encode/decode APIs is a crypto change out of scope here. Same for `parser.ParseDir` in `errors/errors_test.go` (flat, untagged package).

## Config changes (`.golangci.yml`) — the judgment calls

- **revive `unhandled-error`**: allowlist `fmt.Print*`/`Fprint*`, `strings.Builder.WriteString` and `bytes.Buffer.Write` — CLI stdout printing and in-memory writers that never fail accounted for ~40 issues of pure noise.
- **revive `package-naming`**: excluded `errors/*.go`; the package intentionally mirrors the stdlib name.
- **goconst**: `ignore-tests: true` plus ignore single-token strings (`^[\w.$-]+$`). goconst 1.10 (bundled since golangci-lint 2.12) now flags every repeated bson key and mongo operator — 167 of its 173 findings here (`_id` ×25, `orgAddress` ×10, `$set`, …). Consting every schema field name would be a sweeping db-layer refactor, the same class of change this config already defers (revive `add-constant` is disabled with a TODO). Multi-word strings stay detectable — that's how the six real ones fixed above surfaced.

## Verification

- `golangci-lint run` (v2.12.2 and 2.11.4): **0 issues**, including with `--max-issues-per-linter=0`.
- `./scripts/check-qt-patterns.sh`: clean.
- `go build ./...` passes; tests pass in every changed package: `db` + `migrations` (203 tests against containerized Mongo), `errors`, `csp`, `account`, `internal`, `cmd`.
- Only two behavioral changes anywhere: the https default and the removed/converted prints.