### PR TITLE
fix(processes): backfill start date when publishing immediate-start processes

### DIFF
--- a/api/processes_publish.go
+++ b/api/processes_publish.go
@@ -390,7 +390,7 @@ func (pw *publishWorker) run() (result *db.JobResult, err error) {
 		pw.abandon()
 		return nil, fmt.Errorf("publish did not confirm all questions after %d rounds", maxPublishRounds)
 	}
-	if e := a.db.SetVotingProcessPublished(pw.vp.ID); e != nil {
+	if e := a.db.SetVotingProcessPublished(pw.vp.ID, pw.resolveStartDate()); e != nil {
 		// every election is already on-chain and its question persisted; clear the marker so a
 		// retry can re-run and simply re-mark the process published (pending is empty → no new
 		// elections). Leaving it set would make the process permanently unclaimable.
@@ -405,6 +405,19 @@ func (pw *publishWorker) run() (result *db.JobResult, err error) {
 		}
 	}
 	return &db.JobResult{Status: "READY"}, nil //nolint:goconst
+}
+
+// resolveStartDate returns the start date to persist on the process once its elections are
+// confirmed. An empty startDate becomes "start at the mined block" (StartTime=0) and a past
+// startDate is moved to "now" at build time (see electionStartDuration), so in both cases the
+// elections started at the block just mined and "now" is within seconds of the real start; a
+// still-future requested date is kept as-is. The N per-question elections may even mine in
+// different blocks (retry rounds), so a single exact chain date does not exist anyway.
+func (pw *publishWorker) resolveStartDate() time.Time {
+	if pw.vp.StartDate.After(time.Now()) {
+		return pw.vp.StartDate
+	}
+	return time.Now()
 }
 
 // abandon rolls back a failed/aborted publish: it resets the not-yet-mined questions (so a later

--- a/api/processes_publish_test.go
+++ b/api/processes_publish_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	qt "github.com/frankban/quicktest"
@@ -33,6 +34,7 @@ func testCreateProvisionedOrganization(t *testing.T, token string) common.Addres
 // on-chain id and become ready and the process is marked published.
 func TestVotingProcessPublish(t *testing.T) {
 	c := qt.New(t)
+	testStart := time.Now()
 	token := testCreateUser(t, "adminpassword123")
 	orgAddress := testCreateProvisionedOrganization(t, token)
 	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
@@ -58,6 +60,29 @@ func TestVotingProcessPublish(t *testing.T) {
 	for i := range got.Questions {
 		c.Assert(len(got.Questions[i].UpstreamID) > 0, qt.IsTrue, qt.Commentf("question %d has no upstreamId", i))
 	}
+
+	// the request carried no start date ("start immediately"), so publish backfills the actual
+	// on-chain start date and the read exposes it as a date around the publish moment
+	c.Assert(got.StartDate, qt.Not(qt.Equals), "")
+	startDate, err := time.Parse(time.RFC3339, got.StartDate)
+	c.Assert(err, qt.IsNil)
+	c.Assert(startDate.After(testStart.Add(-time.Minute)), qt.IsTrue,
+		qt.Commentf("backfilled start date %s is before the test started", got.StartDate))
+	c.Assert(startDate.Before(time.Now().Add(time.Minute)), qt.IsTrue,
+		qt.Commentf("backfilled start date %s is in the future", got.StartDate))
+
+	// the list endpoint carries the backfilled start date too
+	list := requestAndParse[apicommon.VotingProcessListResponse](
+		t, http.MethodGet, token, nil, fmt.Sprintf("processes?orgAddress=%s&limit=100", orgAddress.Hex()),
+	)
+	listed := false
+	for _, p := range list.Processes {
+		if p.ID == pid {
+			listed = true
+			c.Assert(p.StartDate, qt.Equals, got.StartDate)
+		}
+	}
+	c.Assert(listed, qt.IsTrue)
 
 	// the single-question read reports the ready status
 	q0 := requestAndParse[db.VotingProcessQuestion](

--- a/db/voting_processes.go
+++ b/db/voting_processes.go
@@ -219,13 +219,21 @@ func (ms *MongoStorage) ClearVotingProcessPublishing(id primitive.ObjectID) erro
 
 // SetVotingProcessPublished marks a process as published and clears the publishing marker.
 // Called once, atomically, after every question of the process has been confirmed on-chain.
-func (ms *MongoStorage) SetVotingProcessPublished(id primitive.ObjectID) error {
+// startDate is the actual start of the on-chain elections (the chain assigns one when the
+// process was created without a start date, meaning "start immediately"); a non-zero value
+// replaces the stored date so reads expose when the process really started, while a zero
+// value leaves the stored date untouched.
+func (ms *MongoStorage) SetVotingProcessPublished(id primitive.ObjectID, startDate time.Time) error {
 	if id == primitive.NilObjectID {
 		return ErrInvalidData
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
-	update := bson.M{"$set": bson.M{"published": true, "updatedAt": time.Now()}, "$unset": bson.M{"publishing": ""}} //nolint:goconst
+	set := bson.M{"published": true, "updatedAt": time.Now()}
+	if !startDate.IsZero() {
+		set["startDate"] = startDate
+	}
+	update := bson.M{"$set": set, "$unset": bson.M{"publishing": ""}} //nolint:goconst
 	res, err := ms.votingProcesses.UpdateOne(ctx, bson.M{"_id": id}, update)
 	if err != nil {
 		return fmt.Errorf("failed to mark voting process published: %w", err)

--- a/db/voting_processes_test.go
+++ b/db/voting_processes_test.go
@@ -63,11 +63,13 @@ func TestVotingProcessCRUD(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(byUp.ID, qt.Equals, q1ID)
 
-	// publish flips draft count and published flag
-	c.Assert(testDB.SetVotingProcessPublished(id), qt.IsNil)
+	// publish flips draft count and published flag, and backfills the chain-resolved start date
+	startDate := time.Now().Truncate(time.Millisecond)
+	c.Assert(testDB.SetVotingProcessPublished(id, startDate), qt.IsNil)
 	got, err = testDB.VotingProcess(id)
 	c.Assert(err, qt.IsNil)
 	c.Assert(got.Published, qt.IsTrue)
+	c.Assert(got.StartDate.Equal(startDate), qt.IsTrue)
 	n, err = testDB.CountVotingProcesses(org, DraftOnly)
 	c.Assert(err, qt.IsNil)
 	c.Assert(n, qt.Equals, int64(0))


### PR DESCRIPTION
This is Fable 5 speaking in behalf of elboletaire.

## What

A voting process created with an empty `startDate` (meaning "start immediately") never got a start date: the create path stored a zero `time.Time`, the publish worker mapped it to on-chain `StartTime=0` ("start at the mined block"), and nothing ever wrote the actual start moment back to Mongo. Since `VotingProcessResponseFromDB` only serializes non-zero dates, both `GET /processes` (list) and the single read omitted `startDate` entirely — forever, even for a published, running process — so clients had no way to tell when it actually started.

This PR backfills the date at the only moment the backend knows the elections are on-chain: in the publish worker, right after every question's election is confirmed mined.

- `publishWorker.resolveStartDate()` keeps a still-future requested date untouched (a scheduled publish must not be rewritten), and otherwise resolves to `time.Now()`.
- `db.SetVotingProcessPublished` now takes the resolved date and sets it atomically with the `published` flag, preserving the "published implies dated" invariant in a single write.

## Why `time.Now()` instead of syncing from the vochain

The worker calls this immediately after `WaitTxMined`, so wall clock is within seconds of the mined block timestamp. Fetching the chain value was considered, but a multi-question process is N elections and retry rounds can mine stragglers in later blocks, so a single exact chain date doesn't exist anyway — the first election's date would be just as much an approximation, at the cost of an extra chain round-trip. `time.Now()` also covers the past-`startDate` case, where `electionStartDuration` silently moves the start to "now" at build time and the stored date was equally wrong.

Semantics after this change: **draft → `startDate` omitted (meaning "will start when published"), published → always present.**

## Testing

- `TestVotingProcessPublish` (end-to-end against voconed) now publishes with an empty `startDate` and asserts the backfilled date appears in both the single read and the list endpoint, within a sane time window.
- `TestVotingProcessCRUD` (db) covers the new `SetVotingProcessPublished` signature and verifies the date is persisted.
- Full `make test` suite green; `golangci-lint run --new-from-rev=main` reports no new issues.