### PR TITLE
ci: drop Coveralls for go-test-coverage + soften commitlint

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -12,6 +12,10 @@ jobs:
   main:
     name: Lint
     runs-on: ubuntu-latest
+    # Skip promotion PRs (e.g. main -> stage): their commits were already
+    # linted in the PRs that introduced them, and re-linting old history
+    # would flag the whole PR range forever.
+    if: github.head_ref != 'main'
     permissions:
       pull-requests: write
       contents: read
@@ -20,9 +24,17 @@ jobs:
       - uses: wagoid/commitlint-github-action@v6 # lint commit messages
         if: always()
         id: lint_commits
+        with:
+          # Advisory only: results are reported via the sticky PR comment
+          # below instead of failing the check.
+          failOnErrors: false
+          failOnWarnings: false
       - uses: amannn/action-semantic-pull-request@v6
         if: always()
         id: lint_pr_title
+        # Advisory only: the error_message output feeds the sticky PR
+        # comment below; a bad title must not block the merge.
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build combined message

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,24 +108,58 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  job_gocoverage_coveralls:
-    name: Publish coverage (Coveralls)
+  coverage:
+    name: Coverage report
     runs-on: ubuntu-latest
     needs: [test]
     continue-on-error: true # never mark the whole CI as failed because of this job
+    permissions:
+      contents: read
+      actions: read # download the baseline breakdown artifact from main runs
+      pull-requests: write # post the coverage report as a PR comment
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: 'go.mod'
-          cache: false
       - uses: benjlevesque/short-sha@v3.0 # sets env.SHA to the first 7 chars of github.sha
       - uses: actions/download-artifact@v4
         with:
           name: gocoverage@${{ env.SHA }}.txt
-      - name: Send coverage to coveralls.io
-        if: ${{ always() }}
-        uses: shogo82148/actions-goveralls@v1
+      - name: Download coverage baseline from main
+        id: baseline
+        if: github.event_name == 'pull_request'
+        uses: dawidd6/action-download-artifact@v6
         with:
-          path-to-profile: gocoverage.txt
-          flag-name: unit
+          branch: main
+          event: push
+          workflow_conclusion: success
+          name: main.breakdown
+          if_no_artifact_found: warn
+      - name: Check test coverage
+        id: coverage
+        uses: vladopajic/go-test-coverage@v2
+        with:
+          profile: gocoverage.txt
+          # on main pushes, save the breakdown that PRs will diff against
+          breakdown-file-name: ${{ github.ref_name == 'main' && 'main.breakdown' || '' }}
+          # on PRs, diff against the latest main baseline (if one exists yet)
+          diff-base-breakdown-file-name: >-
+            ${{ github.event_name == 'pull_request' && steps.baseline.outputs.found_artifact == 'true' && 'main.breakdown' || '' }}
+      - name: Upload coverage baseline
+        if: github.ref_name == 'main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: main.breakdown
+          path: main.breakdown
+          if-no-files-found: error
+      - name: Post coverage report on the PR
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: go-coverage
+          message: |
+            ## 🧪 Coverage report
+
+            Total coverage: **${{ steps.coverage.outputs.total-coverage }}%**
+
+            ```
+            ${{ fromJSON(steps.coverage.outputs.report) }}
+            ```

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,8 +121,17 @@ jobs:
       actions: read # download coverage artifacts (current PR run + main baseline)
       pull-requests: write # post the coverage report as a PR comment
     steps:
-      - name: Post per-package coverage diff report on the PR
+      - name: Generate per-package coverage diff report
+        id: coverage
         uses: fgrosse/go-coverage-report@v1.3.1
         with:
           coverage-artifact-name: code-coverage
           coverage-file-name: gocoverage.txt
+          # the action skips commenting when no Go files changed; post the
+          # comment ourselves so the PR always gets feedback
+          skip-comment: true
+      - name: Post coverage report on the PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: go-coverage
+          message: ${{ steps.coverage.outputs.coverage_report || '✅ No coverage changes detected in this PR.' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,11 +50,11 @@ jobs:
         run: go test -vet=off -failfast -timeout=30m -race ./...
                 -cover -coverpkg=./... -covermode=atomic -coverprofile=gocoverage.txt
 
-      - uses: benjlevesque/short-sha@v3.0 # sets env.SHA to the first 7 chars of github.sha
       - name: Store code coverage artifact
+        # fixed name: pushes to main become the baseline PRs are compared against
         uses: actions/upload-artifact@v4
         with:
-          name: gocoverage@${{ env.SHA }}.txt
+          name: code-coverage
           path: gocoverage.txt
 
   docker-release:
@@ -112,54 +112,17 @@ jobs:
     name: Coverage report
     runs-on: ubuntu-latest
     needs: [test]
+    # only on PRs: pushes to main just upload the code-coverage artifact
+    # (in the test job) which becomes the baseline PRs are compared against
+    if: github.event_name == 'pull_request'
     continue-on-error: true # never mark the whole CI as failed because of this job
     permissions:
       contents: read
-      actions: read # download the baseline breakdown artifact from main runs
+      actions: read # download coverage artifacts (current PR run + main baseline)
       pull-requests: write # post the coverage report as a PR comment
     steps:
-      - uses: actions/checkout@v5
-      - uses: benjlevesque/short-sha@v3.0 # sets env.SHA to the first 7 chars of github.sha
-      - uses: actions/download-artifact@v4
+      - name: Post per-package coverage diff report on the PR
+        uses: fgrosse/go-coverage-report@v1.3.1
         with:
-          name: gocoverage@${{ env.SHA }}.txt
-      - name: Download coverage baseline from main
-        id: baseline
-        if: github.event_name == 'pull_request'
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          branch: main
-          event: push
-          workflow_conclusion: success
-          name: main.breakdown
-          if_no_artifact_found: warn
-      - name: Check test coverage
-        id: coverage
-        uses: vladopajic/go-test-coverage@v2
-        with:
-          profile: gocoverage.txt
-          # on main pushes, save the breakdown that PRs will diff against
-          breakdown-file-name: ${{ github.ref_name == 'main' && 'main.breakdown' || '' }}
-          # on PRs, diff against the latest main baseline (if one exists yet)
-          diff-base-breakdown-file-name: >-
-            ${{ github.event_name == 'pull_request' && steps.baseline.outputs.found_artifact == 'true' && 'main.breakdown' || '' }}
-      - name: Upload coverage baseline
-        if: github.ref_name == 'main'
-        uses: actions/upload-artifact@v4
-        with:
-          name: main.breakdown
-          path: main.breakdown
-          if-no-files-found: error
-      - name: Post coverage report on the PR
-        if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: go-coverage
-          message: |
-            ## 🧪 Coverage report
-
-            Total coverage: **${{ steps.coverage.outputs.total-coverage }}%**
-
-            ```
-            ${{ fromJSON(steps.coverage.outputs.report) }}
-            ```
+          coverage-artifact-name: code-coverage
+          coverage-file-name: gocoverage.txt


### PR DESCRIPTION
This is Claude Fable 5 speaking in behalf of elboletaire.

## Commit / PR-title lint (commitlint.yml)

The Conventional Commits check was failing on every `main` -> `stage` promotion PR (e.g. [this run](https://github.com/vocdoni/saas-backend/actions/runs/29813735329/job/88580198427), PR #583). The wagoid action lints **every commit in the PR range**, so a single non-conforming message in already-merged history (`2dd01f1`, header over 100 chars) re-flags the whole promoted history on every promotion — and since the PR head branch is `main`, the red ✗ attaches to main's commits, making main look broken on every push.

- **Skip promotion PRs**: job-level `if: github.head_ref != 'main'`. Those commits were already linted in the PRs that introduced them.
- **Commit lint is advisory**: `failOnErrors: false` / `failOnWarnings: false` on `wagoid/commitlint-github-action`. It still emits the `results` output, so the sticky PR comment keeps listing offending commits — it just can't block a merge anymore.
- **PR-title lint is advisory**: `continue-on-error: true` on `amannn/action-semantic-pull-request` (it has no fail-off input); its `error_message` output still feeds the comment.

## Coverage: Coveralls -> fgrosse/go-coverage-report (main.yml)

coveralls.io fails frequently (right now it's in read-only mode, returning 500 "Build processing error" on every upload) and it's an external service we don't actually need — everything can be computed from the coverage profile the `test` job already produces.

The goveralls job is replaced with [`fgrosse/go-coverage-report`](https://github.com/fgrosse/go-coverage-report), which runs entirely inside the workflow and posts a **per-package coverage table with the increase/decrease against `main`** as a PR comment — close to what Coveralls showed:

- The `test` job now uploads the coverage profile under the fixed artifact name `code-coverage` (pushes to `main` thereby produce the baseline; PR runs produce the side to compare).
- The `coverage` job runs only on PRs and is a single action step: it downloads both artifacts itself and posts/updates the comment. `continue-on-error: true` so it can never block CI.

## Notes

- With everything advisory, sticky comments are the only enforcement left for commit messages/titles. If a middle ground is ever wanted, `commitDepth: 1` on the wagoid action lints only the newest commit.
- The lint skip condition assumes promotion PRs always have `main` as head; extend it if promoting from other branches.
- **The coverage comment will only start working after this merges**: the baseline is the `code-coverage` artifact from the latest `main` push run, which doesn't exist until the renamed artifact lands on `main`. Until then the coverage job warns/fails harmlessly (`continue-on-error`). Artifacts expire after 90 days; any push to `main` refreshes the baseline.
- Fork PRs can't receive the comment (`GITHUB_TOKEN` limitation of the action); org-branch PRs are unaffected.