### PR TITLE
ci(swagger): deploy swagger during stage deploys, not main ones

### DIFF
--- a/.github/workflows/swag.yml
+++ b/.github/workflows/swag.yml
@@ -3,7 +3,7 @@ name: API Swagger Docs
 on:
   push:
     branches:
-      - main
+      - stage
   pull_request:
     paths:
       - 'api/**/*'
@@ -54,7 +54,7 @@ jobs:
             ${{ steps.diff.outputs.stdout }}
             ```
 
-      - name: Commit and push if main is outdated
+      - name: Commit and push if stage is outdated
         if: ${{ github.event_name == 'push' && steps.diff.outputs.stdout }}
         run: |
           git config user.name "github-actions"


### PR DESCRIPTION
## Summary

- Changes the swagger auto-deploy trigger from `main` to `stage` branch
- The regenerated `docs/swagger.yaml` is now committed back during stage deploys, not main (develop) deploys
- PR diff comments on `api/**/*` changes are unaffected