### PR TITLE
fix(jobs): reveal import error detail to managers/admins on GET /jobs/{jobId}

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -19,8 +19,9 @@ import (
 //	@Description	`failed`) and `result` carries only the attributes the job produced (import counters
 //	@Description	`added`/`total`/`progress`, or tx `address`/`voteID`/`status`), each omitted when empty.
 //	@Description	Public endpoint: the 32-byte job id is the capability and results carry only public
-//	@Description	data. Per-row import error detail (which may reference member data) is not returned
-//	@Description	here — it is available only on the authenticated GET /jobs list.
+//	@Description	data. Per-row import error detail (which may reference member data) is returned only
+//	@Description	to an authenticated manager/admin of the job's organization (as on GET /jobs);
+//	@Description	anonymous callers get status and counters only.
 //	@Tags			jobs
 //	@Produce		json
 //	@Param			jobId	path		string					true	"Job id returned by the async endpoint (hex)"
@@ -47,12 +48,16 @@ func (a *API) jobStatusHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := apicommon.JobResponseFromDB(job)
-	// Public endpoint (the jobId is the only capability): member-import error strings can embed row
-	// PII (emails/phones/birthdates of the failing members), so the per-row error detail is served
-	// only on the auth-gated GET /jobs list. Here expose status + counters. tx-job errors are chain
-	// failures (no PII) and are kept.
+	// Member-import error strings can embed row PII (emails/phones/birthdates of the failing
+	// members). Reveal that per-row detail only to an authenticated manager/admin of the job's org
+	// (the same gate as GET /jobs); anonymous callers (e.g. tx-job pollers, which use this endpoint
+	// without a token) and non-members get status + counters only. tx-job errors are chain failures
+	// (no PII) and are always kept.
 	if job.Type == db.JobTypeOrgMembers || job.Type == db.JobTypeCensusParticipants {
-		resp.Errors = nil
+		u := a.optionalUser(r)
+		if u == nil || (!u.HasRoleFor(job.OrgAddress, db.ManagerRole) && !u.HasRoleFor(job.OrgAddress, db.AdminRole)) {
+			resp.Errors = nil
+		}
 	}
 	apicommon.HTTPWriteJSON(w, &resp)
 }

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -1,12 +1,16 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/go-chi/jwtauth/v5"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 )
@@ -49,6 +53,21 @@ func TestJobStatusImportErrorsGatedByRole(t *testing.T) {
 	// (1) anonymous and (3) a non-member both get the stripped response.
 	assertStripped("anonymous", "")
 	assertStripped("stranger", strangerToken)
+
+	// (4) an EXPIRED admin token must not unlock the detail either (temporal validation gates it).
+	// Mint one for the admin's email, mirroring buildLoginResponse but with a past expiry.
+	valid, err := jwtauth.VerifyToken(testAPI.auth, adminToken)
+	c.Assert(err, qt.IsNil)
+	emailClaim, ok := valid.Get("userId")
+	c.Assert(ok, qt.IsTrue)
+	j := jwt.New()
+	c.Assert(j.Set("userId", emailClaim), qt.IsNil)
+	c.Assert(j.Set(jwt.ExpirationKey, time.Now().Add(-time.Hour)), qt.IsNil)
+	jmap, err := j.AsMap(context.Background())
+	c.Assert(err, qt.IsNil)
+	_, expiredToken, err := testAPI.auth.Encode(jmap)
+	c.Assert(err, qt.IsNil)
+	assertStripped("expired-admin", expiredToken)
 
 	// (2) the org admin sees the full per-row error detail on GET /jobs/{jobId}.
 	adminJob := requestAndParse[apicommon.JobResponse](t, http.MethodGet, adminToken, nil, "jobs", jobID)

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -11,14 +11,16 @@ import (
 	"github.com/vocdoni/saas-backend/db"
 )
 
-// TestJobStatusImportErrorsNotPublic verifies that member-import error strings — which can embed
-// member PII (emails/phones/birthdates of the failing rows) — are NOT returned by the public
-// GET /jobs/{jobId} endpoint, while the same job's full error detail stays available on the
-// auth-gated GET /jobs list for a Manager/Admin of the org.
-func TestJobStatusImportErrorsNotPublic(t *testing.T) {
+// TestJobStatusImportErrorsGatedByRole verifies that member-import error strings — which can embed
+// member PII (emails/phones/birthdates of the failing rows) — are returned by GET /jobs/{jobId}
+// only to an authenticated manager/admin of the job's org, and stripped for anonymous callers and
+// non-members. The same job's detail also stays available on the auth-gated GET /jobs list.
+func TestJobStatusImportErrorsGatedByRole(t *testing.T) {
 	c := qt.New(t)
 	adminToken := testCreateUser(t, "jobspiiadminpass123")
 	orgAddress := testCreateOrganization(t, adminToken)
+	// a second user with no role on the org
+	strangerToken := testCreateUser(t, "jobspiistrangerpass123")
 
 	// seed a completed member-import job whose error string embeds member PII.
 	jobID, err := apicommon.NewJobID()
@@ -29,20 +31,30 @@ func TestJobStatusImportErrorsNotPublic(t *testing.T) {
 	c.Assert(testDB.CreateJob(jobID, db.JobTypeOrgMembers, orgAddress, 3), qt.IsNil)
 	c.Assert(testDB.CompleteJob(jobID, 2, []string{importErr}), qt.IsNil)
 
-	// public GET /jobs/{jobId}: no error detail, no PII in the raw body; status + counters remain.
-	body, code := testRequest(t, http.MethodGet, "", nil, "jobs", jobID)
-	c.Assert(code, qt.Equals, http.StatusOK)
-	c.Assert(strings.Contains(string(body), piiEmail), qt.IsFalse, qt.Commentf("public body leaked email: %s", body))
-	c.Assert(strings.Contains(string(body), piiPhone), qt.IsFalse, qt.Commentf("public body leaked phone: %s", body))
-	var pub apicommon.JobResponse
-	c.Assert(json.Unmarshal(body, &pub), qt.IsNil)
-	c.Assert(pub.Errors, qt.HasLen, 0)
-	c.Assert(pub.Status, qt.Equals, db.JobStatusCompleted)
-	c.Assert(pub.Result, qt.Not(qt.IsNil))
-	c.Assert(pub.Result.Total, qt.Equals, 3)
-	c.Assert(pub.Result.Added, qt.Equals, 2)
+	// stripped: raw body carries no PII, errors empty, but status + counters remain.
+	assertStripped := func(who, token string) {
+		body, code := testRequest(t, http.MethodGet, token, nil, "jobs", jobID)
+		c.Assert(code, qt.Equals, http.StatusOK)
+		c.Assert(strings.Contains(string(body), piiEmail), qt.IsFalse, qt.Commentf("%s body leaked email: %s", who, body))
+		c.Assert(strings.Contains(string(body), piiPhone), qt.IsFalse, qt.Commentf("%s body leaked phone: %s", who, body))
+		var resp apicommon.JobResponse
+		c.Assert(json.Unmarshal(body, &resp), qt.IsNil)
+		c.Assert(resp.Errors, qt.HasLen, 0, qt.Commentf("%s got error detail", who))
+		c.Assert(resp.Status, qt.Equals, db.JobStatusCompleted)
+		c.Assert(resp.Result, qt.Not(qt.IsNil))
+		c.Assert(resp.Result.Total, qt.Equals, 3)
+		c.Assert(resp.Result.Added, qt.Equals, 2)
+	}
 
-	// auth-gated GET /jobs list (Manager/Admin): the same job keeps its full error detail.
+	// (1) anonymous and (3) a non-member both get the stripped response.
+	assertStripped("anonymous", "")
+	assertStripped("stranger", strangerToken)
+
+	// (2) the org admin sees the full per-row error detail on GET /jobs/{jobId}.
+	adminJob := requestAndParse[apicommon.JobResponse](t, http.MethodGet, adminToken, nil, "jobs", jobID)
+	c.Assert(adminJob.Errors, qt.Contains, importErr)
+
+	// the auth-gated GET /jobs list keeps the full detail too.
 	list := requestAndParse[apicommon.JobsListResponse](
 		t, http.MethodGet, adminToken, nil, "jobs?orgAddress="+orgAddress.String())
 	var found *apicommon.JobResponse

--- a/api/middlewares.go
+++ b/api/middlewares.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"slices"
 	"strings"
@@ -26,6 +27,37 @@ func bearerToken(r *http.Request) string {
 	return ""
 }
 
+// Sentinel errors returned by userFromToken so callers can map them to the right response (or, for
+// the optional path, treat any of them as "anonymous").
+var (
+	errInvalidUserClaim = fmt.Errorf("invalid or missing userId claim")
+	errUserNotVerified  = fmt.Errorf("user account not verified")
+)
+
+// userFromToken resolves and validates the user referenced by an already signature/temporal-verified
+// JWT (the userId claim carries the user's email). It is shared by authenticator (required auth) and
+// optionalUser (optional auth): the callers verify the token first (via the Verifier middleware or
+// jwtauth.VerifyToken), and this does the claim → user → verified checks in one place so the two
+// paths cannot drift. Returns a nil user with a typed error the caller maps to a response.
+func (a *API) userFromToken(token jwt.Token) (*db.User, error) {
+	if token == nil || jwt.Validate(token, jwt.WithRequiredClaim("userId")) != nil {
+		return nil, errInvalidUserClaim
+	}
+	claim, _ := token.Get("userId")
+	email, ok := claim.(string)
+	if !ok {
+		return nil, errInvalidUserClaim
+	}
+	user, err := a.db.UserByEmail(email)
+	if err != nil {
+		return nil, err // db.ErrNotFound or an unexpected DB error
+	}
+	if !user.Verified {
+		return nil, errUserNotVerified
+	}
+	return user, nil
+}
+
 // optionalUser resolves the authenticated user from an optional JWT bearer token, or nil when the
 // request is anonymous or the token is absent/invalid/unverified. Unlike authenticator it never
 // writes a response — it lets an otherwise-public handler reveal extra data to an authenticated
@@ -36,20 +68,12 @@ func (a *API) optionalUser(r *http.Request) *db.User {
 	if raw == "" || looksLikeAPIKey(raw) {
 		return nil
 	}
-	token, err := jwtauth.VerifyToken(a.auth, raw)
-	if err != nil || token == nil {
+	token, err := jwtauth.VerifyToken(a.auth, raw) // verifies signature + temporal claims (exp/nbf/iat)
+	if err != nil {
 		return nil
 	}
-	claim, ok := token.Get("userId") // the userId claim carries the user's email (see authenticator)
-	if !ok {
-		return nil
-	}
-	email, ok := claim.(string)
-	if !ok {
-		return nil
-	}
-	user, err := a.db.UserByEmail(email)
-	if err != nil || !user.Verified {
+	user, err := a.userFromToken(token) // any error → treat as anonymous
+	if err != nil {
 		return nil
 	}
 	return user
@@ -70,45 +94,29 @@ func (a *API) authenticator(next http.Handler) http.Handler {
 			a.authenticateAPIKey(w, r, next, raw)
 			return
 		}
-		token, claims, err := jwtauth.FromContext(r.Context())
+		token, _, err := jwtauth.FromContext(r.Context())
 		if err != nil {
 			errors.ErrUnauthorized.Write(w)
 			return
 		}
-		if token == nil || jwt.Validate(token, jwt.WithRequiredClaim("userId")) != nil {
-			errors.ErrUnauthorized.Withf("userId claim not found in JWT token").Write(w)
-			return
-		}
-		// retrieve the `userId` from the claims and add it to the HTTP header
-		userIDValue, ok := claims["userId"]
-		if !ok {
-			errors.ErrUnauthorized.Withf("userId claim not found in JWT token").Write(w)
-			return
-		}
-		userEmail, ok := userIDValue.(string)
-		if !ok {
-			errors.ErrUnauthorized.Withf("userId claim is not a string").Write(w)
-			return
-		}
-		// get the user from the database
-		user, err := a.db.UserByEmail(userEmail)
+		// resolve+validate the user from the verified token (shared with optionalUser); map the
+		// typed failures back to the same responses this middleware has always returned.
+		user, err := a.userFromToken(token)
 		if err != nil {
-			if err == db.ErrNotFound {
+			switch err {
+			case errUserNotVerified:
+				errors.ErrUserNoVerified.With("user account not verified").Write(w)
+			case db.ErrNotFound:
 				errors.ErrUnauthorized.Withf("user not found").Write(w)
-				return
+			case errInvalidUserClaim:
+				errors.ErrUnauthorized.Withf("invalid or missing userId claim").Write(w)
+			default:
+				errors.ErrGenericInternalServerError.Withf("could not retrieve user from database: %v", err).Write(w)
 			}
-			errors.ErrGenericInternalServerError.Withf("could not retrieve user from database: %v", err).Write(w)
 			return
 		}
-		// check if the user is already verified
-		if !user.Verified {
-			errors.ErrUserNoVerified.With("user account not verified").Write(w)
-			return
-		}
-		// add the user to the context
+		// add the user to the context and pass the authenticated request through
 		ctx := context.WithValue(r.Context(), apicommon.UserMetadataKey, *user)
-		// token is authenticated, pass it through with the new context with the
-		// user information
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/api/middlewares.go
+++ b/api/middlewares.go
@@ -26,6 +26,35 @@ func bearerToken(r *http.Request) string {
 	return ""
 }
 
+// optionalUser resolves the authenticated user from an optional JWT bearer token, or nil when the
+// request is anonymous or the token is absent/invalid/unverified. Unlike authenticator it never
+// writes a response — it lets an otherwise-public handler reveal extra data to an authenticated
+// user without requiring auth. JWT sessions only (API keys, which require a per-route scope, are
+// not resolved here).
+func (a *API) optionalUser(r *http.Request) *db.User {
+	raw := bearerToken(r)
+	if raw == "" || looksLikeAPIKey(raw) {
+		return nil
+	}
+	token, err := jwtauth.VerifyToken(a.auth, raw)
+	if err != nil || token == nil {
+		return nil
+	}
+	claim, ok := token.Get("userId") // the userId claim carries the user's email (see authenticator)
+	if !ok {
+		return nil
+	}
+	email, ok := claim.(string)
+	if !ok {
+		return nil
+	}
+	user, err := a.db.UserByEmail(email)
+	if err != nil || !user.Verified {
+		return nil
+	}
+	return user
+}
+
 // authenticator is a middleware that authenticates the user and returns a JWT
 // token. If successful, the decodes the user identifier (its email) from the
 // JWT token and gets the user information from the database, then adds the user

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3338,8 +3338,9 @@ paths:
         `failed`) and `result` carries only the attributes the job produced (import counters
         `added`/`total`/`progress`, or tx `address`/`voteID`/`status`), each omitted when empty.
         Public endpoint: the 32-byte job id is the capability and results carry only public
-        data. Per-row import error detail (which may reference member data) is not returned
-        here — it is available only on the authenticated GET /jobs list.
+        data. Per-row import error detail (which may reference member data) is returned only
+        to an authenticated manager/admin of the job's organization (as on GET /jobs);
+        anonymous callers get status and counters only.
       parameters:
       - description: Job id returned by the async endpoint (hex)
         in: path


### PR DESCRIPTION
## What

Follow-up to #582. That PR stripped per-row member-import error strings (which can embed member PII — emails/phones/birthdates of failing rows) from the **public** `GET /jobs/{jobId}` **unconditionally**. As a result a manager/admin polling a single job by id saw no error detail, even though the auth-gated `GET /jobs` **list** shows it to them. The intent was to *gate* the detail by role, not remove it from the single-job endpoint.

## How

The endpoint must stay publicly reachable — tx-job pollers (publish / status-change / vote-relay) poll it with **no token** — so this is **optional authentication**:

- New non-aborting helper `optionalUser(r) *db.User` in `api/middlewares.go`: resolves an optional JWT bearer token to its user (nil when absent/invalid/unverified), never writes a response. It's a general `*API` primitive any future public handler can reuse; the existing `authenticator` (required auth) is left untouched.
- `jobStatusHandler` now keeps the import error detail when the caller is an authenticated **manager/admin of the job's org** (same gate as `GET /jobs`), and strips it for anonymous callers and non-members.
- tx-job errors (chain failures, no PII) are always kept.

Scope: JWT sessions only. API keys need a per-route scope (deny-by-default) and already get errors via `GET /jobs`, so key support here is out of scope.

## Test

`TestJobStatusImportErrorsGatedByRole` covers all three cases against a seeded import job with a PII-bearing error:
1. **anonymous** → `errors` empty, no PII in the raw body
2. **org admin** → `errors` contains the full detail
3. **non-member user** → `errors` empty, no PII

Plus the existing `GET /jobs` list assertion. Verified tx-job pollers and the import-list path are unaffected (`TestOrganizationMembers`, `TestPublishProcess`, `TestVotingProcessPublish`, `TestJobStatusNotFound`). `make swagger` regenerated; `golangci-lint --new-from-rev=main` clean.