### PR TITLE
fix(ci): retry zk-circuit prefetch to survive transient download errors

### DIFF
--- a/scripts/circuits/main.go
+++ b/scripts/circuits/main.go
@@ -7,13 +7,27 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"go.vocdoni.io/dvote/crypto/zk/circuit"
 )
 
 func main() {
-	if _, err := circuit.LoadVersion(circuit.DefaultZkCircuitVersion); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to prefetch zk circuits (version=%v): %v\n", circuit.DefaultZkCircuitVersion, err)
-		os.Exit(1)
+	// The assets are fetched over the network (raw.githubusercontent.com), which occasionally
+	// returns transient errors (e.g. HTTP 503) that would otherwise abort the whole docker build.
+	// Retry with a linear backoff and only fail once every attempt has been exhausted.
+	const attempts = 5
+	var err error
+	for i := range attempts {
+		if _, err = circuit.LoadVersion(circuit.DefaultZkCircuitVersion); err == nil {
+			return // assets fetched (and cached under ~/.cache/vocdoni/zkCircuits)
+		}
+		fmt.Fprintf(os.Stderr, "attempt %d/%d: failed to prefetch zk circuits (version=%v): %v\n",
+			i+1, attempts, circuit.DefaultZkCircuitVersion, err)
+		if i < attempts-1 {
+			time.Sleep(time.Duration(i+1) * 5 * time.Second) // 5s, 10s, 15s, 20s
+		}
 	}
+	fmt.Fprintf(os.Stderr, "giving up prefetching zk circuits after %d attempts: %v\n", attempts, err)
+	os.Exit(1)
 }


### PR DESCRIPTION
## Problem

The `docker-release` job intermittently fails when publishing the image. Despite appearances it is **not** a Go-version issue — `golang:1.26.1` pulls and runs fine. The failure is in the builder step that bakes the zk-circuit assets into the image:

```
#15 [builder 6/7] RUN go run scripts/circuits/main.go
failed to prefetch zk circuits (version=v1.0.0): error downloading 'census_proving_key.zkey':
  https://raw.githubusercontent.com/vocdoni/zk-voceremony/.../census_proving_key.zkey: http status: 503
ERROR: process "go run scripts/circuits/main.go" did not complete successfully: exit code 1
```

`scripts/circuits/main.go` does a single HTTP GET of large `.zkey` files from `raw.githubusercontent.com`, which occasionally returns **HTTP 503**, and a single transient failure aborted the whole publish. An immediate re-run of the same commit succeeded, confirming it is flaky rather than a real error.

## Fix

Retry `circuit.LoadVersion` up to 5 times with a linear backoff (5s→20s) and only fail the build once every attempt is exhausted. Transient 503s/network blips are absorbed; the build still fails loudly if the assets are genuinely unreachable, so we never publish an image missing them.

`go build`/`vet`/`golangci-lint` clean. Real validation is this PR's `docker-release` job going green.