### PR TITLE
feat(members): point bulk-import validation errors at the offending line

### DIFF
--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -1226,7 +1226,9 @@ type AddMembersResponse struct {
 	// Number of members added
 	Added uint32 `json:"added"`
 
-	// Errors encountered during job
+	// Errors encountered during job. Validation errors are prefixed with
+	// "line N:", the 1-based position of the offending member in the
+	// submitted members list.
 	Errors []string `json:"errors"`
 
 	// Job ID for tracking the addition process

--- a/api/org_members_test.go
+++ b/api/org_members_test.go
@@ -192,9 +192,10 @@ func TestOrganizationMembers(t *testing.T) {
 		"organizations", orgAddress.String(), "members")
 	c.Assert(missingFieldsResponse.Added, qt.Equals, uint32(4))
 	c.Assert(missingFieldsResponse.Errors, qt.HasLen, 3)
-	c.Assert(missingFieldsResponse.Errors[0], qt.Matches, ".*invalid-email.*")
-	c.Assert(missingFieldsResponse.Errors[1], qt.Matches, ".*invalid-phone.*")
-	c.Assert(missingFieldsResponse.Errors[2], qt.Matches, ".*invalid-birthdate.*")
+	// errors point at the offending member's position (Pedro is the 3rd member)
+	c.Assert(missingFieldsResponse.Errors[0], qt.Matches, "line 3: .*invalid-email.*")
+	c.Assert(missingFieldsResponse.Errors[1], qt.Matches, "line 3: .*invalid-phone.*")
+	c.Assert(missingFieldsResponse.Errors[2], qt.Matches, "line 3: .*invalid-birthdate.*")
 
 	// Test 3: Get organization members (now with added members)
 	membersResponse := requestAndParse[apicommon.OrganizationMembersResponse](
@@ -320,9 +321,10 @@ func TestOrganizationMembers(t *testing.T) {
 	c.Assert(jobStatus.Result.Total, qt.Equals, 2)
 	c.Assert(jobStatus.Result.Progress, qt.Equals, 100)
 	c.Assert(jobStatus.Errors, qt.HasLen, 3)
-	c.Assert(jobStatus.Errors[0], qt.Matches, ".*invalid-email.*")
-	c.Assert(jobStatus.Errors[1], qt.Matches, ".*invalid-phone.*")
-	c.Assert(jobStatus.Errors[2], qt.Matches, ".*invalid-birthdate.*")
+	// errors point at the offending member's position (Alice is the 2nd member)
+	c.Assert(jobStatus.Errors[0], qt.Matches, "line 2: .*invalid-email.*")
+	c.Assert(jobStatus.Errors[1], qt.Matches, "line 2: .*invalid-phone.*")
+	c.Assert(jobStatus.Errors[2], qt.Matches, "line 2: .*invalid-birthdate.*")
 
 	// Check that the completion email was sent
 	mailBody := waitForEmail(t, user.Email)

--- a/db/org_members.go
+++ b/db/org_members.go
@@ -139,6 +139,8 @@ func (ms *MongoStorage) OrgMemberByMemberNumber(orgAddress common.Address, membe
 }
 
 // BulkOrgMembersJob is returned by SetBulkOrgMembers to provide the output.
+// Each entry in Errors is prefixed with "line N:", where N is the 1-based
+// position of the offending member in the submitted list.
 type BulkOrgMembersJob struct {
 	Progress int
 	Total    int
@@ -175,7 +177,7 @@ func prepareOrgMember(org *Organization, m *OrgMember, salt string, currentTime 
 	member.Email = internal.NormalizeEmail(member.Email)
 	if member.Email != "" {
 		if _, err := mail.ParseAddress(member.Email); err != nil {
-			errors = append(errors, fmt.Errorf("could not parse email: %s %v", member.Email, err))
+			errors = append(errors, fmt.Errorf("invalid email %q: %w", member.Email, err))
 			// If email is invalid, set it to empty and store the error
 			member.Email = ""
 		}
@@ -185,7 +187,8 @@ func prepareOrgMember(org *Organization, m *OrgMember, salt string, currentTime 
 	if member.PlaintextPhone != "" {
 		phone, err := NewHashedPhone(member.PlaintextPhone, org)
 		if err != nil {
-			errors = append(errors, fmt.Errorf("invalid phone %q: %w", member.PlaintextPhone, err))
+			// the error already identifies the offending phone number
+			errors = append(errors, err)
 		} else {
 			member.Phone = phone
 		}
@@ -213,19 +216,25 @@ func prepareOrgMember(org *Organization, m *OrgMember, salt string, currentTime 
 
 // createOrgMemberBulkOperations creates a batch of members using bulk write operations,
 // and returns the number of members added and any errors encountered.
+// firstLine is the 1-based position of members[0] in the originally submitted list;
+// validation errors are prefixed with the line each offending member sits at, so
+// users can locate it in the imported file.
 func (ms *MongoStorage) createOrgMemberBulkOperations(
 	org *Organization,
 	members []*OrgMember,
 	salt string,
 	currentTime time.Time,
+	firstLine int,
 ) (int, []error) {
 	var preparedMembers []any
 	var errors []error
 
-	for _, m := range members {
+	for i, m := range members {
 		// Prepare the member
 		member, validationErrors := prepareOrgMember(org, m, salt, currentTime)
-		errors = append(errors, validationErrors...)
+		for _, err := range validationErrors {
+			errors = append(errors, fmt.Errorf("line %d: %w", firstLine+i, err))
+		}
 		preparedMembers = append(preparedMembers, member)
 	}
 
@@ -245,9 +254,10 @@ func (ms *MongoStorage) createOrgMemberBulkOperations(
 	result, err := ms.orgMembers.InsertMany(batchCtx, preparedMembers)
 	if err != nil {
 		log.Warnw("error during bulk addition of members batch", "error", err)
-		firstID := members[0].ID
-		lastID := members[len(members)-1].ID
-		errors = append(errors, fmt.Errorf("batch %s - %s: %w", firstID.Hex(), lastID.Hex(), err))
+		errors = append(errors, fmt.Errorf("lines %d-%d: %w", firstLine, firstLine+len(members)-1, err))
+	}
+	if result == nil {
+		return 0, errors
 	}
 
 	return len(result.InsertedIDs), errors
@@ -328,6 +338,7 @@ func (ms *MongoStorage) addOrgMemberBatches(
 			orgMembers[start:end],
 			salt,
 			currentTime,
+			start+1,
 		)
 
 		// Update job stats

--- a/db/org_members_test.go
+++ b/db/org_members_test.go
@@ -273,6 +273,46 @@ func TestOrgMembers(t *testing.T) {
 		c.Assert(err, qt.Not(qt.IsNil))
 	})
 
+	t.Run("AddBulkOrgMembersLineErrors", func(_ *testing.T) {
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+		c.Assert(testDB.SetOrganization(&Organization{Address: testOrgAddress, Country: "ES"}), qt.IsNil)
+
+		// second and third members carry invalid data; errors must point at their position
+		members := []*OrgMember{
+			{
+				OrgAddress:   testOrgAddress,
+				MemberNumber: "line1",
+				Email:        testMemberEmail,
+			},
+			{
+				OrgAddress:     testOrgAddress,
+				MemberNumber:   "line2",
+				Email:          "not-an-email",
+				PlaintextPhone: "123",
+			},
+			{
+				OrgAddress:   testOrgAddress,
+				MemberNumber: "line3",
+				BirthDate:    "not-a-date",
+			},
+		}
+
+		progressChan, err := testDB.AddBulkOrgMembers(testOrg, members, testSalt)
+		c.Assert(err, qt.IsNil)
+
+		var lastStatus *BulkOrgMembersJob
+		for status := range progressChan {
+			lastStatus = status
+		}
+		c.Assert(lastStatus, qt.Not(qt.IsNil))
+
+		errs := lastStatus.ErrorsAsStrings()
+		c.Assert(errs, qt.HasLen, 3)
+		c.Assert(errs[0], qt.Matches, `line 2: invalid email "not-an-email":.*`)
+		c.Assert(errs[1], qt.Matches, `line 2: invalid phone number 123.*`)
+		c.Assert(errs[2], qt.Matches, `line 3: invalid birthdate format: not-a-date`)
+	})
+
 	t.Run("ZeroAddressValidation", func(_ *testing.T) {
 		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
 

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -73,7 +73,10 @@ definitions:
         description: Number of members added
         type: integer
       errors:
-        description: Errors encountered during job
+        description: |-
+          Errors encountered during job. Validation errors are prefixed with
+          "line N:", the 1-based position of the offending member in the
+          submitted members list.
         items:
           type: string
         type: array


### PR DESCRIPTION
This is Fable 5 speaking in behalf of elboletaire.

Closes #388.

## What

Member bulk-import validation errors were repeating the offending value while giving no clue where it sits in the imported file. Importing a 1k-row file with ~240 bad phones produced a wall of:

```
invalid phone "797217405": invalid phone number 797217405
invalid phone "791455196": invalid phone number 791455196
...
```

Now each error is prefixed with the position of the offending member and the duplicated phone wrapper is gone:

```
line 42: invalid phone number 797217405
```

## How

- `createOrgMemberBulkOperations` receives the 1-based position of its batch's first member (`firstLine`) and wraps every validation error from `prepareOrgMember` with `line N:`. Numbering stays correct across the 200-member batches.
- `prepareOrgMember` no longer re-wraps the phone error (`NewHashedPhone` already identifies the number) and the email error is now `invalid email "x": ...` instead of `could not parse email: x ...`.
- A failed batch insert reports the affected line range (`lines 1-200: ...`) instead of the internal ObjectID range, which meant nothing to users. While there, guarded a latent nil-pointer: a nil `InsertMany` result (e.g. context timeout) would have panicked on `result.InsertedIDs`.

Note on numbering: `N` is the position in the submitted members array. If the frontend stripped a CSV header row the real file line is N+1 — the backend can't know whether a header existed, and being off by one still points users right next to the bad row. Documented on `BulkOrgMembersJob` and the `AddMembersResponse.errors` swagger field.

## Testing

- New db-level subtest `AddBulkOrgMembersLineErrors` covering invalid members at different positions.
- Strengthened the sync and async API import tests to assert the `line N:` prefixes point at the right member.
- Reproduced the 1k-rows/240-bad-phones scenario at the db layer during development: all 240 errors surface, line-prefixed, with all rows still inserted (phone left empty, as before).