### PR TITLE
feat(processes): expose per-question encryption keys for encrypted voting

### DIFF
--- a/api/apicommon/voting_processes.go
+++ b/api/apicommon/voting_processes.go
@@ -178,6 +178,9 @@ type PublicQuestionResponse struct {
 	UpstreamID        internal.HexBytes    `json:"upstreamId,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`
 	Status            string               `json:"status,omitempty"`
 	Census            CensusSpec           `json:"census"`
+	// EncryptionKeys are the on-chain vote-encryption public keys (only for secretUntilTheEnd
+	// questions, and empty until the keykeepers publish them). Voters seal encrypted ballots with them.
+	EncryptionKeys []db.EncryptionKey `json:"encryptionKeys,omitempty"`
 }
 
 // PublicQuestionResponseFromDB builds the public question read from a question and its parent
@@ -196,6 +199,7 @@ func PublicQuestionResponseFromDB(q *db.VotingProcessQuestion, census *db.Census
 		Metadata:          q.Metadata,
 		UpstreamID:        q.UpstreamID,
 		Status:            q.Status,
+		EncryptionKeys:    q.EncryptionKeys,
 	}
 	if census != nil {
 		resp.Census = CensusSpec{

--- a/api/apicommon/voting_processes.go
+++ b/api/apicommon/voting_processes.go
@@ -179,7 +179,9 @@ type PublicQuestionResponse struct {
 	Status            string               `json:"status,omitempty"`
 	Census            CensusSpec           `json:"census"`
 	// EncryptionKeys are the on-chain vote-encryption public keys (only for secretUntilTheEnd
-	// questions, and empty until the keykeepers publish them). Voters seal encrypted ballots with them.
+	// questions). Because of omitempty the field is absent (not an empty array) until the keykeepers
+	// publish the keys, so clients treat its absence as "not yet published" and poll. Voters seal
+	// encrypted ballots with them.
 	EncryptionKeys []db.EncryptionKey `json:"encryptionKeys,omitempty"`
 }
 

--- a/api/processes.go
+++ b/api/processes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -333,12 +334,14 @@ func (a *API) votingProcessInfoHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	census, _ := a.db.Census(vp.CensusID.Hex())
 	// serve the stored status now; refresh each published question from the chain in the background
-	// to catch status changes made directly on-chain (outside this API). Also resolve the vote
-	// encryption keys of encrypted questions so clients can seal encrypted ballots.
+	// to catch status changes made directly on-chain (outside this API).
 	for i := range questions {
 		a.enqueueReconcileIfStale(&questions[i])
-		questions[i].EncryptionKeys = a.resolveQuestionEncryptionKeys(&questions[i])
 	}
+	// resolve the vote encryption keys of encrypted questions (so clients can seal encrypted ballots)
+	// concurrently: each encrypted question without cached keys needs a Vochain round-trip, so a
+	// bounded pool keeps this read fast for a process with many encrypted questions.
+	a.resolveQuestionEncryptionKeysBatch(questions)
 	apicommon.HTTPWriteJSON(w, apicommon.VotingProcessResponseFromDB(vp, questions, census, a.account.ChainID()))
 }
 
@@ -504,6 +507,25 @@ func (a *API) votingProcessQuestionHandler(w http.ResponseWriter, r *http.Reques
 	// resolve the vote encryption keys so voters can seal an encrypted ballot for this question.
 	question.EncryptionKeys = a.resolveQuestionEncryptionKeys(question)
 	apicommon.HTTPWriteJSON(w, apicommon.PublicQuestionResponseFromDB(question, census))
+}
+
+// resolveQuestionEncryptionKeysBatch resolves the vote encryption keys of every question
+// concurrently (bounded), setting q.EncryptionKeys in place. Each encrypted question without cached
+// keys needs a Vochain round-trip; a bounded worker pool keeps GET /processes/{id} fast for a process
+// with many encrypted questions (up to maxQuestionsPerProcess) instead of doing the calls
+// sequentially. Gated/cached questions return immediately (no chain call).
+func (a *API) resolveQuestionEncryptionKeysBatch(questions []db.VotingProcessQuestion) {
+	const workers = 8
+	sem := make(chan struct{}, workers)
+	var wg sync.WaitGroup
+	for i := range questions {
+		sem <- struct{}{}
+		wg.Go(func() {
+			defer func() { <-sem }()
+			questions[i].EncryptionKeys = a.resolveQuestionEncryptionKeys(&questions[i])
+		})
+	}
+	wg.Wait()
 }
 
 // resolveQuestionEncryptionKeys returns the vote-encryption public keys of a question's on-chain

--- a/api/processes.go
+++ b/api/processes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.vocdoni.io/dvote/log"
 )
 
 // maxQuestionsPerProcess bounds the number of questions of a voting process (the node
@@ -332,9 +333,11 @@ func (a *API) votingProcessInfoHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	census, _ := a.db.Census(vp.CensusID.Hex())
 	// serve the stored status now; refresh each published question from the chain in the background
-	// to catch status changes made directly on-chain (outside this API).
+	// to catch status changes made directly on-chain (outside this API). Also resolve the vote
+	// encryption keys of encrypted questions so clients can seal encrypted ballots.
 	for i := range questions {
 		a.enqueueReconcileIfStale(&questions[i])
+		questions[i].EncryptionKeys = a.resolveQuestionEncryptionKeys(&questions[i])
 	}
 	apicommon.HTTPWriteJSON(w, apicommon.VotingProcessResponseFromDB(vp, questions, census, a.account.ChainID()))
 }
@@ -498,7 +501,44 @@ func (a *API) votingProcessQuestionHandler(w http.ResponseWriter, r *http.Reques
 	// serve the stored status now; refresh it from the chain in the background so a status change
 	// made directly on-chain (outside this API) is picked up.
 	a.enqueueReconcileIfStale(question)
+	// resolve the vote encryption keys so voters can seal an encrypted ballot for this question.
+	question.EncryptionKeys = a.resolveQuestionEncryptionKeys(question)
 	apicommon.HTTPWriteJSON(w, apicommon.PublicQuestionResponseFromDB(question, census))
+}
+
+// resolveQuestionEncryptionKeys returns the vote-encryption public keys of a question's on-chain
+// election, fetching them from the Vochain only when needed and caching them on the question once
+// published. It is a no-op (nil, no chain call) for non-encrypted questions and unpublished drafts,
+// and serves cached keys without a chain round-trip. The result is cached only when non-empty:
+// between an election's creation and the keykeepers publishing its keys the node returns an empty
+// set, and a later read must still resolve them (mirror of resolveProcessEncryptionKeys).
+func (a *API) resolveQuestionEncryptionKeys(q *db.VotingProcessQuestion) []db.EncryptionKey {
+	// gate: only encrypted questions have encryption keys; keeps every other question chain-free.
+	if !q.SecretUntilTheEnd {
+		return nil
+	}
+	// nothing on chain yet (draft) — no keys to fetch.
+	if len(q.UpstreamID) == 0 {
+		return nil
+	}
+	// immutable once published: serve the cached keys without a chain round-trip.
+	if len(q.EncryptionKeys) > 0 {
+		return q.EncryptionKeys
+	}
+	keys, err := a.account.ElectionEncryptionKeys(q.UpstreamID)
+	if err != nil {
+		log.Warnw("encryption keys: election keys fetch failed",
+			"question", q.ID.Hex(), "upstreamId", q.UpstreamID.String(), "error", err)
+		return nil
+	}
+	// not published yet — do not cache an empty set so a later read still resolves them.
+	if len(keys) == 0 {
+		return nil
+	}
+	if err := a.db.SetQuestionEncryptionKeys(q.ID, keys); err != nil {
+		log.Warnw("encryption keys: could not persist question keys", "question", q.ID.Hex(), "error", err)
+	}
+	return keys
 }
 
 // votingProcessParticipantHandler godoc

--- a/api/processes_encryption_keys_test.go
+++ b/api/processes_encryption_keys_test.go
@@ -1,0 +1,128 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/api/apicommon"
+	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/internal"
+	"go.vocdoni.io/proto/build/go/models"
+)
+
+// TestProcessesEncryptionKeys exercises the per-question encryptionKeys field of the new
+// /processes model:
+//   - a published secretUntilTheEnd question exposes its election's on-chain encryption public keys
+//     on both GET /processes/{id} (manager) and GET /processes/{id}/questions/{qId} (public voter),
+//     and they are cached on the stored question once resolved;
+//   - a non-encrypted question leaves the field absent (and the handler stays chain-free for it).
+func TestProcessesEncryptionKeys(t *testing.T) {
+	c := qt.New(t)
+
+	token := testCreateUser(t, "enckeyspass123")
+	vocdoniClient := testNewVocdoniClient(t)
+	orgAddress := testCreateOrganization(t, token)
+
+	// subscribe the org to a plan so NEW_PROCESS is permitted
+	plans, err := testDB.Plans()
+	c.Assert(err, qt.IsNil)
+	c.Assert(len(plans) > 1, qt.IsTrue)
+	c.Assert(testDB.SetOrganizationSubscription(orgAddress, &db.OrganizationSubscription{
+		PlanID:          plans[1].ID,
+		StartDate:       time.Now(),
+		RenewalDate:     time.Now().Add(time.Hour * 24),
+		LastPaymentDate: time.Now(),
+		Active:          true,
+	}), qt.IsNil)
+
+	// create the organization account on-chain
+	orgName := fmt.Sprintf("encorg-%d", internal.RandomInt(1000))
+	orgInfoURI := fmt.Sprintf("https://example.com/%d", internal.RandomInt(1000))
+	nonce := uint32(0)
+	accountTx := &models.Tx{Payload: &models.Tx_SetAccount{SetAccount: &models.SetAccountTx{
+		Nonce:   &nonce,
+		Txtype:  models.TxType_CREATE_ACCOUNT,
+		Account: orgAddress.Bytes(),
+		Name:    &orgName,
+		InfoURI: &orgInfoURI,
+	}}}
+	signRemoteSignerAndSendVocdoniTx(t, accountTx, token, vocdoniClient, orgAddress)
+
+	cspPubKey, err := testCSP.PubKey()
+	c.Assert(err, qt.IsNil)
+
+	// publish one ENCRYPTED on-chain election (its own election, as each question is in the new model)
+	processNonce := fetchVocdoniAccountNonce(t, vocdoniClient, orgAddress)
+	processTx := &models.Tx{Payload: &models.Tx_NewProcess{NewProcess: &models.NewProcessTx{
+		Txtype: models.TxType_NEW_PROCESS,
+		Nonce:  processNonce,
+		Process: &models.Process{
+			EntityId:      orgAddress.Bytes(),
+			Duration:      120,
+			Status:        models.ProcessStatus_READY,
+			CensusOrigin:  models.CensusOrigin_OFF_CHAIN_CA,
+			CensusRoot:    cspPubKey,
+			MaxCensusSize: 10,
+			EnvelopeType:  &models.EnvelopeType{EncryptedVotes: true},
+			VoteOptions:   &models.ProcessVoteOptions{MaxCount: 1, MaxValue: 5},
+			Mode:          &models.ProcessMode{AutoStart: true, Interruptible: true},
+		},
+	}}}
+	encElection := internal.HexBytes(signRemoteSignerAndSendVocdoniTx(t, processTx, token, vocdoniClient, orgAddress))
+
+	// wait until the keykeepers publish the election encryption keys on chain
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	nodeKeys, err := vocdoniClient.WaitUntilElectionKeys(ctx, encElection.Bytes())
+	cancel()
+	c.Assert(err, qt.IsNil)
+	c.Assert(nodeKeys.PublicKeys, qt.Not(qt.HasLen), 0)
+
+	// seed a published voting process with an encrypted question (points at the election above) and a
+	// non-encrypted one; the plain question keeps a distinct upstreamId to prove the secretUntilTheEnd
+	// gate short-circuits before any chain call.
+	vpID, err := testDB.SetVotingProcess(&db.VotingProcess{
+		OrgAddress: orgAddress, Published: true,
+		Title: db.MultiLangString{"default": "Enc process"},
+	})
+	c.Assert(err, qt.IsNil)
+	qEncID, err := testDB.SetQuestion(&db.VotingProcessQuestion{
+		ProcessID: vpID, OrgAddress: orgAddress, Order: 0,
+		Title: db.MultiLangString{"default": "Q enc"}, UpstreamID: encElection,
+		Status: db.QuestionStatusReady, SecretUntilTheEnd: true,
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = testDB.SetQuestion(&db.VotingProcessQuestion{
+		ProcessID: vpID, OrgAddress: orgAddress, Order: 1,
+		Title: db.MultiLangString{"default": "Q plain"}, UpstreamID: internal.HexBytes{0x01, 0x02, 0x03, 0x04},
+		Status: db.QuestionStatusReady, SecretUntilTheEnd: false,
+	})
+	c.Assert(err, qt.IsNil)
+
+	assertMatchesNode := func(who string, keys []db.EncryptionKey) {
+		c.Assert(keys, qt.HasLen, len(nodeKeys.PublicKeys), qt.Commentf("%s key count", who))
+		for i, k := range nodeKeys.PublicKeys {
+			c.Assert(keys[i].Index, qt.Equals, k.Index, qt.Commentf("%s key %d index", who, i))
+			c.Assert(keys[i].Key.String(), qt.Equals, k.Key.String(), qt.Commentf("%s key %d value", who, i))
+		}
+	}
+
+	// GET /processes/{id} (manager read): the encrypted question carries the keys, the plain one none.
+	info := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", vpID.Hex())
+	c.Assert(info.Questions, qt.HasLen, 2)
+	assertMatchesNode("info.questions[0]", info.Questions[0].EncryptionKeys)
+	c.Assert(info.Questions[1].EncryptionKeys, qt.HasLen, 0)
+
+	// GET /processes/{id}/questions/{qId} (public voter read): same keys present.
+	pub := requestAndParse[apicommon.PublicQuestionResponse](
+		t, http.MethodGet, "", nil, "processes", vpID.Hex(), "questions", qEncID.Hex())
+	assertMatchesNode("public question", pub.EncryptionKeys)
+
+	// keys are immutable once published, so they are cached on the stored question.
+	stored, err := testDB.Question(qEncID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stored.EncryptionKeys, qt.HasLen, len(nodeKeys.PublicKeys))
+}

--- a/db/processes_questions.go
+++ b/db/processes_questions.go
@@ -131,7 +131,9 @@ func (ms *MongoStorage) SetQuestionStatus(id primitive.ObjectID, status string) 
 // by the keykeepers, so this is written once and only with a non-empty set (mirrors
 // SetProcessEncryptionKeys for the legacy single-election model).
 func (ms *MongoStorage) SetQuestionEncryptionKeys(id primitive.ObjectID, keys []EncryptionKey) error {
-	if id == primitive.NilObjectID {
+	// keys are immutable and written once; reject an empty set so a stray call can never clobber
+	// already-cached keys with an empty array (matches the "non-empty" contract above).
+	if id == primitive.NilObjectID || len(keys) == 0 {
 		return ErrInvalidData
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)

--- a/db/processes_questions.go
+++ b/db/processes_questions.go
@@ -126,6 +126,26 @@ func (ms *MongoStorage) SetQuestionStatus(id primitive.ObjectID, status string) 
 	return nil
 }
 
+// SetQuestionEncryptionKeys sets only the encryptionKeys field of a question (targeted update),
+// leaving every other field untouched. The vote-encryption public keys are immutable once published
+// by the keykeepers, so this is written once and only with a non-empty set (mirrors
+// SetProcessEncryptionKeys for the legacy single-election model).
+func (ms *MongoStorage) SetQuestionEncryptionKeys(id primitive.ObjectID, keys []EncryptionKey) error {
+	if id == primitive.NilObjectID {
+		return ErrInvalidData
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	res, err := ms.processesQuestions.UpdateOne(ctx, bson.M{"_id": id}, bson.M{"$set": bson.M{"encryptionKeys": keys}})
+	if err != nil {
+		return fmt.Errorf("failed to set question encryption keys: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // DeleteQuestion removes a single question document (used when replacing a draft's
 // questions on update).
 func (ms *MongoStorage) DeleteQuestion(id primitive.ObjectID) error {

--- a/db/types.go
+++ b/db/types.go
@@ -626,8 +626,9 @@ type VotingProcessQuestion struct {
 	Status            string             `json:"status,omitempty" bson:"status,omitempty"`
 	SyncedAt          time.Time          `json:"-" bson:"syncedAt,omitempty"`
 	// EncryptionKeys are the on-chain vote-encryption public keys of this question's election,
-	// resolved on read and cached (only for secretUntilTheEnd questions; empty until the keykeepers
-	// publish them). Voters seal encrypted vote packages with these.
+	// resolved on read and cached (only for secretUntilTheEnd questions). Because of omitempty the
+	// JSON field is absent (not an empty array) until the keykeepers publish the keys, so clients
+	// treat its absence as "not yet published" and poll. Voters seal encrypted vote packages with these.
 	EncryptionKeys []EncryptionKey `json:"encryptionKeys,omitempty" bson:"encryptionKeys,omitempty"`
 }
 

--- a/db/types.go
+++ b/db/types.go
@@ -625,6 +625,10 @@ type VotingProcessQuestion struct {
 	MetadataURL       string             `json:"-" bson:"metadataURL,omitempty"`
 	Status            string             `json:"status,omitempty" bson:"status,omitempty"`
 	SyncedAt          time.Time          `json:"-" bson:"syncedAt,omitempty"`
+	// EncryptionKeys are the on-chain vote-encryption public keys of this question's election,
+	// resolved on read and cached (only for secretUntilTheEnd questions; empty until the keykeepers
+	// publish them). Voters seal encrypted vote packages with these.
+	EncryptionKeys []EncryptionKey `json:"encryptionKeys,omitempty" bson:"encryptionKeys,omitempty"`
 }
 
 // QuestionStatusRef is the minimal projection of a published question the status syncer and the

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1284,6 +1284,13 @@ definitions:
         type: array
       description:
         $ref: '#/definitions/db.MultiLangString'
+      encryptionKeys:
+        description: |-
+          EncryptionKeys are the on-chain vote-encryption public keys (only for secretUntilTheEnd
+          questions, and empty until the keykeepers publish them). Voters seal encrypted ballots with them.
+        items:
+          $ref: '#/definitions/db.EncryptionKey'
+        type: array
       id:
         type: string
       metadata:
@@ -2266,6 +2273,14 @@ definitions:
       eligibleMemberIds:
         items:
           type: string
+        type: array
+      encryptionKeys:
+        description: |-
+          EncryptionKeys are the on-chain vote-encryption public keys of this question's election,
+          resolved on read and cached (only for secretUntilTheEnd questions; empty until the keykeepers
+          publish them). Voters seal encrypted vote packages with these.
+        items:
+          $ref: '#/definitions/db.EncryptionKey'
         type: array
       id:
         type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1287,7 +1287,9 @@ definitions:
       encryptionKeys:
         description: |-
           EncryptionKeys are the on-chain vote-encryption public keys (only for secretUntilTheEnd
-          questions, and empty until the keykeepers publish them). Voters seal encrypted ballots with them.
+          questions). Because of omitempty the field is absent (not an empty array) until the keykeepers
+          publish the keys, so clients treat its absence as "not yet published" and poll. Voters seal
+          encrypted ballots with them.
         items:
           $ref: '#/definitions/db.EncryptionKey'
         type: array
@@ -2277,8 +2279,9 @@ definitions:
       encryptionKeys:
         description: |-
           EncryptionKeys are the on-chain vote-encryption public keys of this question's election,
-          resolved on read and cached (only for secretUntilTheEnd questions; empty until the keykeepers
-          publish them). Voters seal encrypted vote packages with these.
+          resolved on read and cached (only for secretUntilTheEnd questions). Because of omitempty the
+          JSON field is absent (not an empty array) until the keykeepers publish the keys, so clients
+          treat its absence as "not yet published" and poll. Voters seal encrypted vote packages with these.
         items:
           $ref: '#/definitions/db.EncryptionKey'
         type: array


### PR DESCRIPTION
Closes #593.

## Problem

Encrypted voting (`secretUntilTheEnd`) can't be cast through the new multi-question `/processes` model: no new-model endpoint exposes the vote-encryption public keys, so SDK/frontend clients have nothing to seal the vote package with. Keys are served only by the deprecated legacy `/process` route.

The issue's analysis was verified correct: the question struct and both read responses omit keys, publish never persists them, and each question is its own on-chain election — so keys are inherently **per question** (a shared process key is impossible).

## Fix

Mirror the legacy `resolveProcessEncryptionKeys`, per question:

- `db.VotingProcessQuestion` gains `EncryptionKeys []db.EncryptionKey` (json+bson, `omitempty`); new `db.SetQuestionEncryptionKeys` caches them (mirrors `SetProcessEncryptionKeys`).
- New `resolveQuestionEncryptionKeys(q)`: resolve-on-read, gated on `secretUntilTheEnd` + published, serve cache, else fetch `account.ElectionEncryptionKeys(upstreamId)`, cache **only when non-empty** (keykeepers publish asynchronously, so the field is legitimately empty right after publish).
- Wired into `GET /processes/{id}` (manager, `questions[]`) and `GET /processes/{id}/questions/{qId}` (public voter). The list endpoint serves cached keys for free but doesn't fan out chain reads.
- `encryptionKeys` added to `PublicQuestionResponse`; the manager read serializes via the struct tag.

`omitempty` is preserved so clients can distinguish "not yet published" (poll/tolerate absence), as the issue requested.

## Test

`TestProcessesEncryptionKeys` (mirrors the legacy `TestProcessEncryptionKeys`): publishes an encrypted on-chain election, waits for the keykeepers, then asserts the keys appear on both reads, match the node's public keys, are cached on the stored question, and that a non-encrypted question stays keyless (and chain-free).

`go build`/`vet`/`make swagger`/`golangci-lint --new-from-rev=origin/main` clean; new + legacy keys tests green.