### PR TITLE
feat(processes): expose census totalWeight in CensusSpec

### DIFF
--- a/api/apicommon/voting_processes.go
+++ b/api/apicommon/voting_processes.go
@@ -19,6 +19,10 @@ type CensusSpec struct {
 	// Size is the number of members in the census. Response-only (ignored on create/update): for a
 	// published process it equals the on-chain maxCensusSize of its whole-census questions.
 	Size int64 `json:"size,omitempty"`
+	// TotalWeight is the whole-census total voting weight (sum of members' weights). Response-only;
+	// equals Size for a non-weighted census. Needed by clients (e.g. the results report) to turn
+	// per-answer weights into percentages.
+	TotalWeight int64 `json:"totalWeight,omitempty"`
 }
 
 // EligibilitySpec is an optional per-question subset of the process census, resolved to a

--- a/api/processes.go
+++ b/api/processes.go
@@ -568,7 +568,9 @@ func (a *API) resolveQuestionEncryptionKeys(q *db.VotingProcessQuestion) []db.En
 // censusTotalWeight returns the whole-census total voting weight (sum of members' weights) exposed
 // on CensusSpec. A non-weighted census contributes weight 1 per member, so the total is just the
 // participant count (Size) with no query; a weighted census sums OrgMember.Weight over its members.
-// On aggregation failure it falls back to Size (never worse than the count) so the field is still set.
+// On aggregation failure it returns 0 (NOT Size): totalWeight backs a report/certification denominator,
+// where a plausible-but-wrong total is worse than an absent one — 0 makes omitempty drop the field so
+// the client renders "not available" instead of computing every percentage against a wrong total.
 func (a *API) censusTotalWeight(census *db.Census) int64 {
 	if census == nil {
 		return 0
@@ -579,7 +581,7 @@ func (a *API) censusTotalWeight(census *db.Census) int64 {
 	total, err := a.db.CensusTotalWeight(census.ID.Hex())
 	if err != nil {
 		log.Warnw("census total weight: aggregation failed", "census", census.ID.Hex(), "error", err)
-		return census.Size
+		return 0
 	}
 	return total
 }

--- a/api/processes.go
+++ b/api/processes.go
@@ -342,7 +342,9 @@ func (a *API) votingProcessInfoHandler(w http.ResponseWriter, r *http.Request) {
 	// concurrently: each encrypted question without cached keys needs a Vochain round-trip, so a
 	// bounded pool keeps this read fast for a process with many encrypted questions.
 	a.resolveQuestionEncryptionKeysBatch(questions)
-	apicommon.HTTPWriteJSON(w, apicommon.VotingProcessResponseFromDB(vp, questions, census, a.account.ChainID()))
+	resp := apicommon.VotingProcessResponseFromDB(vp, questions, census, a.account.ChainID())
+	resp.Census.TotalWeight = a.censusTotalWeight(census)
+	apicommon.HTTPWriteJSON(w, resp)
 }
 
 // listVotingProcessesHandler godoc
@@ -561,6 +563,25 @@ func (a *API) resolveQuestionEncryptionKeys(q *db.VotingProcessQuestion) []db.En
 		log.Warnw("encryption keys: could not persist question keys", "question", q.ID.Hex(), "error", err)
 	}
 	return keys
+}
+
+// censusTotalWeight returns the whole-census total voting weight (sum of members' weights) exposed
+// on CensusSpec. A non-weighted census contributes weight 1 per member, so the total is just the
+// participant count (Size) with no query; a weighted census sums OrgMember.Weight over its members.
+// On aggregation failure it falls back to Size (never worse than the count) so the field is still set.
+func (a *API) censusTotalWeight(census *db.Census) int64 {
+	if census == nil {
+		return 0
+	}
+	if !census.Weighted {
+		return census.Size
+	}
+	total, err := a.db.CensusTotalWeight(census.ID.Hex())
+	if err != nil {
+		log.Warnw("census total weight: aggregation failed", "census", census.ID.Hex(), "error", err)
+		return census.Size
+	}
+	return total
 }
 
 // votingProcessParticipantHandler godoc

--- a/api/processes_census_total_weight_test.go
+++ b/api/processes_census_total_weight_test.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/api/apicommon"
+	"github.com/vocdoni/saas-backend/db"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// TestProcessesCensusTotalWeight verifies the whole-census totalWeight surfaced on
+// GET /processes/{id} census spec: for a weighted census it is the sum of the members' weights (not
+// the participant count), and for a non-weighted census it equals the size.
+func TestProcessesCensusTotalWeight(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "censusweightpass123")
+	orgAddress := testCreateOrganization(t, token)
+
+	// seed org members with distinct weights
+	weights := []uint64{3, 5, 2}
+	memberIDs := make([]string, 0, len(weights))
+	for i, w := range weights {
+		id, err := testDB.SetOrgMember("test_salt", &db.OrgMember{
+			OrgAddress:   orgAddress,
+			MemberNumber: fmt.Sprintf("W%d", i),
+			Weight:       w,
+		})
+		c.Assert(err, qt.IsNil)
+		memberIDs = append(memberIDs, id)
+	}
+	var wantTotal int64
+	for _, w := range weights {
+		wantTotal += int64(w)
+	}
+
+	// helper: build a published process over a census of the seeded members and read its census spec.
+	censusSpecOf := func(weighted bool) apicommon.CensusSpec {
+		censusID, err := testDB.SetCensus(&db.Census{
+			OrgAddress:  orgAddress,
+			Weighted:    weighted,
+			AuthFields:  db.OrgMemberAuthFields{db.OrgMemberAuthFieldsMemberNumber},
+			TwoFaFields: db.OrgMemberTwoFaFields{},
+		})
+		c.Assert(err, qt.IsNil)
+		added, _, err := testDB.AddCensusParticipantsByMemberIDs(censusID, memberIDs)
+		c.Assert(err, qt.IsNil)
+		c.Assert(added, qt.Equals, len(memberIDs))
+
+		censusOID, err := primitive.ObjectIDFromHex(censusID)
+		c.Assert(err, qt.IsNil)
+		vpID, err := testDB.SetVotingProcess(&db.VotingProcess{
+			OrgAddress: orgAddress, Published: true, CensusID: censusOID,
+			Title: db.MultiLangString{"default": "Weight process"},
+		})
+		c.Assert(err, qt.IsNil)
+
+		resp := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", vpID.Hex())
+		c.Assert(resp.Census.Size, qt.Equals, int64(len(memberIDs)))
+		return resp.Census
+	}
+
+	// weighted: totalWeight is the sum of the members' weights, distinct from the size.
+	weighted := censusSpecOf(true)
+	c.Assert(weighted.Weighted, qt.IsTrue)
+	c.Assert(weighted.TotalWeight, qt.Equals, wantTotal)
+	c.Assert(weighted.TotalWeight, qt.Not(qt.Equals), weighted.Size)
+
+	// non-weighted: totalWeight equals the size (every member counts as 1).
+	plain := censusSpecOf(false)
+	c.Assert(plain.Weighted, qt.IsFalse)
+	c.Assert(plain.TotalWeight, qt.Equals, plain.Size)
+}

--- a/db/census_participant.go
+++ b/db/census_participant.go
@@ -746,6 +746,49 @@ func (ms *MongoStorage) CountCensusParticipants(censusID string) (int64, error) 
 	return ms.censusParticipants.CountDocuments(ctx, filter)
 }
 
+// CensusTotalWeight returns the sum of the weights of a census's members, joining each participant
+// (whose participantID is its org member's hex ObjectID) to its OrgMember and summing OrgMember.Weight.
+// It backs the census total voting weight exposed on the /processes read; it is only meaningful for
+// weighted censuses (for a non-weighted census every member counts as 1, so the total equals the
+// participant count). Returns 0 for a census with no participants.
+func (ms *MongoStorage) CensusTotalWeight(censusID string) (int64, error) {
+	if len(censusID) == 0 {
+		return 0, ErrInvalidData
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	pipeline := mongo.Pipeline{
+		{{Key: "$match", Value: bson.M{"censusId": censusID}}},
+		// participantID is the member's ObjectID hex; convert it (bad/missing ids drop out via the join).
+		{{Key: "$addFields", Value: bson.M{"memberOID": bson.M{
+			"$convert": bson.M{"input": "$participantID", "to": "objectId", "onError": nil, "onNull": nil},
+		}}}},
+		{{Key: "$lookup", Value: bson.M{
+			"from":         "orgMembers",
+			"localField":   "memberOID",
+			"foreignField": "_id",
+			"as":           "member",
+		}}},
+		{{Key: "$unwind", Value: "$member"}},
+		{{Key: "$group", Value: bson.M{"_id": nil, "total": bson.M{"$sum": "$member.weight"}}}},
+	}
+	cur, err := ms.censusParticipants.Aggregate(ctx, pipeline)
+	if err != nil {
+		return 0, fmt.Errorf("failed to aggregate census total weight: %w", err)
+	}
+	defer func() { _ = cur.Close(ctx) }()
+	var res []struct {
+		Total int64 `bson:"total"`
+	}
+	if err := cur.All(ctx, &res); err != nil {
+		return 0, fmt.Errorf("failed to decode census total weight: %w", err)
+	}
+	if len(res) == 0 {
+		return 0, nil
+	}
+	return res[0].Total, nil
+}
+
 // CensusParticipants retrieves all the census participants for a given census.
 func (ms *MongoStorage) CensusParticipants(censusID string) ([]CensusParticipant, error) {
 	// create a context with a timeout

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -111,6 +111,12 @@ definitions:
           Size is the number of members in the census. Response-only (ignored on create/update): for a
           published process it equals the on-chain maxCensusSize of its whole-census questions.
         type: integer
+      totalWeight:
+        description: |-
+          TotalWeight is the whole-census total voting weight (sum of members' weights). Response-only;
+          equals Size for a non-weighted census. Needed by clients (e.g. the results report) to turn
+          per-answer weights into percentages.
+        type: integer
       twoFaFields:
         items:
           $ref: '#/definitions/db.OrgMemberTwoFaField'


### PR DESCRIPTION
Refs #494.

## Problem

The results / PDF report needs a census's **total voting weight** (Σ of members' weights) to turn per-answer weights into percentages. No saas endpoint exposed it, and for CSP censuses — which is every census in the new `/processes` model — it can't come from the chain: at publish the on-chain census root is set to the CSP public key (no census tree with summable leaf weights; `maxCensusSize` is only a member count). The total lives only in the saas Mongo DB, and nothing aggregated it.

## Fix

Add `totalWeight` to `apicommon.CensusSpec`, populated on the **detail read** `GET /processes/{id}`:

- **`db.CensusTotalWeight(censusID)`** — aggregation joining `censusParticipants` → `orgMembers` (by `participantID` → `_id`) and `$sum`-ing `weight`.
- **`censusTotalWeight(census)`** helper — a non-weighted census contributes weight 1 per member, so the total is just `Size` (no query); a weighted census uses the aggregation. On aggregation failure it returns **0** (not `Size`): the field backs a report/certification denominator, so a plausible-but-wrong total is worse than an absent one — `omitempty` drops the field and the client renders "not available".
- Public voter question read left untouched (deliberately omits `size`; the report is manager-facing).

### Scope: detail read only, not the list

`totalWeight` is resolved **only on `GET /processes/{id}`**, not on the `GET /processes` list. The list would incur a per-process weight aggregation (N+1) on the hot path, so it's deliberately omitted there — a `totalWeight` absent from a **list** row means "not resolved here", not "zero". Clients that need the denominator (e.g. the report) re-fetch the detail read. (The report reads a single process, so this is free in practice.)

**Computed on read, not stored/cached** — member weights are mutable, so a cached total would go stale and need a migration (unlike the immutable encryption keys). Non-weighted censuses cost nothing.

This covers all census types the new API supports (all CSP variants — the aggregation is type-agnostic), addressing "not only CSP censuses."

## Scope note

Whole-census total (per the issue's "census spec" framing). A question that restricts voters to an `eligibleMemberIds` subset of a **weighted** census would need a per-question total for a perfectly accurate per-answer denominator — a clean follow-up if needed.

## Test

`TestProcessesCensusTotalWeight`: a weighted census (members weighted 3/5/2) → `census.totalWeight == 10 != size`; a non-weighted census → `totalWeight == size`. `go build`/`vet`/`make swagger`/`golangci-lint --new-from-rev=origin/main` clean.