### PR TITLE
feat(processes): per-question results (QuestionResults) on reads and results endpoint

### DIFF
--- a/api/apicommon/voting_processes.go
+++ b/api/apicommon/voting_processes.go
@@ -102,12 +102,12 @@ type VotingProcessListResponse struct {
 	Pagination *Pagination             `json:"pagination"`
 }
 
-// VotingProcessQuestionResults carries one question's on-chain election results (the same
-// trimmed shape as the legacy ProcessResultsResponse) keyed by the question id.
+// VotingProcessQuestionResults carries one question's on-chain election tally, keyed by the
+// question id. The embedded QuestionResults flattens voteCount/maxVoters/finalResults/results.
 type VotingProcessQuestionResults struct {
 	QuestionID string            `json:"questionId"`
 	UpstreamID internal.HexBytes `json:"upstreamId,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`
-	ProcessResultsResponse
+	db.QuestionResults
 }
 
 // VotingProcessResultsResponse is the multi-question results of a published voting process: one
@@ -183,6 +183,9 @@ type PublicQuestionResponse struct {
 	// publish the keys, so clients treat its absence as "not yet published" and poll. Voters seal
 	// encrypted ballots with them.
 	EncryptionKeys []db.EncryptionKey `json:"encryptionKeys,omitempty"`
+	// Results is this question's on-chain tally, present only once the question reaches RESULTS status
+	// (absent otherwise via omitempty), so clients treat its absence as "not yet final" and poll.
+	Results *db.QuestionResults `json:"results,omitempty"`
 }
 
 // PublicQuestionResponseFromDB builds the public question read from a question and its parent
@@ -202,6 +205,7 @@ func PublicQuestionResponseFromDB(q *db.VotingProcessQuestion, census *db.Census
 		UpstreamID:        q.UpstreamID,
 		Status:            q.Status,
 		EncryptionKeys:    q.EncryptionKeys,
+		Results:           q.Results,
 	}
 	if census != nil {
 		resp.Census = CensusSpec{

--- a/api/apicommon/voting_processes.go
+++ b/api/apicommon/voting_processes.go
@@ -111,7 +111,7 @@ type VotingProcessQuestionResults struct {
 }
 
 // VotingProcessResultsResponse is the multi-question results of a published voting process: one
-// entry per published question, each mirroring the legacy single-process results shape.
+// entry per published question, each carrying that question's QuestionResults tally.
 type VotingProcessResultsResponse struct {
 	ID        string                         `json:"id"`
 	Questions []VotingProcessQuestionResults `json:"questions"`

--- a/api/e2e_full_flow_test.go
+++ b/api/e2e_full_flow_test.go
@@ -160,4 +160,47 @@ func TestFullElectionLifecycle(t *testing.T) {
 	c.Assert(res.Results[0], qt.HasLen, 2)
 	c.Assert(res.Results[0][0], qt.Equals, "1") // value 0 ("No")
 	c.Assert(res.Results[0][1], qt.Equals, "2") // value 1 ("Yes")
+
+	// --- new /processes API: the same RESULTS election, surfaced per-question inline ---
+	// seed a published voting process whose first question points at the election above and is in
+	// RESULTS, plus a second question left READY (never on chain) that must NOT carry results.
+	vpID, err := testDB.SetVotingProcess(&db.VotingProcess{
+		OrgAddress: orgAddress, Published: true,
+		Title: db.MultiLangString{"default": "Results process"},
+	})
+	c.Assert(err, qt.IsNil)
+	qID, err := testDB.SetQuestion(&db.VotingProcessQuestion{
+		ProcessID: vpID, OrgAddress: orgAddress, Order: 0,
+		Title: db.MultiLangString{"default": "Do you approve?"},
+		Choices: []db.Choice{
+			{Title: db.MultiLangString{"default": "No"}, Value: 0},
+			{Title: db.MultiLangString{"default": "Yes"}, Value: 1},
+		},
+		UpstreamID: addr, Status: db.QuestionStatusResults,
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = testDB.SetQuestion(&db.VotingProcessQuestion{
+		ProcessID: vpID, OrgAddress: orgAddress, Order: 1,
+		Title: db.MultiLangString{"default": "Draft q"}, Status: db.QuestionStatusReady,
+	})
+	c.Assert(err, qt.IsNil)
+
+	// manager GET /processes/{id}: the RESULTS question carries the tally inline; the READY one omits it.
+	info := requestAndParse[apicommon.VotingProcessResponse](
+		t, http.MethodGet, token, nil, "processes", vpID.Hex())
+	c.Assert(info.Questions, qt.HasLen, 2)
+	qr := info.Questions[0].Results
+	c.Assert(qr, qt.Not(qt.IsNil))
+	c.Assert(qr.VoteCount, qt.Equals, uint64(numVoters))
+	c.Assert(qr.FinalResults, qt.IsTrue)
+	c.Assert(qr.MaxVoters, qt.Equals, uint64(100)) // the election's on-chain maxCensusSize
+	c.Assert(qr.Results, qt.DeepEquals, []string{"1", "2"})
+	c.Assert(info.Questions[1].Results, qt.IsNil)
+
+	// public GET /processes/{id}/questions/{qId}: same tally on the voter-facing read.
+	pub := requestAndParse[apicommon.PublicQuestionResponse](
+		t, http.MethodGet, "", nil, "processes", vpID.Hex(), "questions", qID.Hex())
+	c.Assert(pub.Results, qt.Not(qt.IsNil))
+	c.Assert(pub.Results.VoteCount, qt.Equals, uint64(numVoters))
+	c.Assert(pub.Results.Results, qt.DeepEquals, []string{"1", "2"})
 }

--- a/api/e2e_full_flow_test.go
+++ b/api/e2e_full_flow_test.go
@@ -194,7 +194,8 @@ func TestFullElectionLifecycle(t *testing.T) {
 	c.Assert(qr.VoteCount, qt.Equals, uint64(numVoters))
 	c.Assert(qr.FinalResults, qt.IsTrue)
 	c.Assert(qr.MaxVoters, qt.Equals, uint64(100)) // the election's on-chain maxCensusSize
-	c.Assert(qr.Results, qt.DeepEquals, []string{"1", "2"})
+	// singlechoice question -> one ballot field -> one results row of value buckets [No, Yes].
+	c.Assert(qr.Results, qt.DeepEquals, [][]string{{"1", "2"}})
 	c.Assert(info.Questions[1].Results, qt.IsNil)
 
 	// public GET /processes/{id}/questions/{qId}: same tally on the voter-facing read.
@@ -202,5 +203,5 @@ func TestFullElectionLifecycle(t *testing.T) {
 		t, http.MethodGet, "", nil, "processes", vpID.Hex(), "questions", qID.Hex())
 	c.Assert(pub.Results, qt.Not(qt.IsNil))
 	c.Assert(pub.Results.VoteCount, qt.Equals, uint64(numVoters))
-	c.Assert(pub.Results.Results, qt.DeepEquals, []string{"1", "2"})
+	c.Assert(pub.Results.Results, qt.DeepEquals, [][]string{{"1", "2"}})
 }

--- a/api/processes.go
+++ b/api/processes.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/log"
 )
 
@@ -342,6 +343,9 @@ func (a *API) votingProcessInfoHandler(w http.ResponseWriter, r *http.Request) {
 	// concurrently: each encrypted question without cached keys needs a Vochain round-trip, so a
 	// bounded pool keeps this read fast for a process with many encrypted questions.
 	a.resolveQuestionEncryptionKeysBatch(questions)
+	// resolve the on-chain tally of any question already in RESULTS status (concurrently), so a manager
+	// sees per-question results inline without a separate /results call. Non-RESULTS questions are skipped.
+	a.resolveQuestionResultsBatch(questions)
 	apicommon.HTTPWriteJSON(w, apicommon.VotingProcessResponseFromDB(vp, questions, census, a.account.ChainID()))
 }
 
@@ -506,6 +510,8 @@ func (a *API) votingProcessQuestionHandler(w http.ResponseWriter, r *http.Reques
 	a.enqueueReconcileIfStale(question)
 	// resolve the vote encryption keys so voters can seal an encrypted ballot for this question.
 	question.EncryptionKeys = a.resolveQuestionEncryptionKeys(question)
+	// surface the on-chain tally once the question is in RESULTS status (nil/no chain call otherwise).
+	question.Results = a.resolveQuestionResults(question)
 	apicommon.HTTPWriteJSON(w, apicommon.PublicQuestionResponseFromDB(question, census))
 }
 
@@ -561,6 +567,67 @@ func (a *API) resolveQuestionEncryptionKeys(q *db.VotingProcessQuestion) []db.En
 		log.Warnw("encryption keys: could not persist question keys", "question", q.ID.Hex(), "error", err)
 	}
 	return keys
+}
+
+// questionResultsFromElection maps a question's on-chain election onto the trimmed QuestionResults
+// shape. MaxVoters is the election's own maxCensusSize — already restricted to the question's
+// eligibility subset at publish (account.ComputeMaxCensusSize). Results is the single-field tally
+// (each question is its own one-field election), stringified; it stays nil until the tally publishes.
+func questionResultsFromElection(e *api.Election) db.QuestionResults {
+	qr := db.QuestionResults{
+		VoteCount:    e.VoteCount,
+		FinalResults: e.FinalResults,
+	}
+	if e.Census != nil {
+		qr.MaxVoters = e.Census.MaxCensusSize
+	}
+	if len(e.Results) > 0 {
+		values := make([]string, len(e.Results[0]))
+		for i, v := range e.Results[0] {
+			values[i] = v.String()
+		}
+		qr.Results = values
+	}
+	return qr
+}
+
+// resolveQuestionResults returns a question's on-chain tally, but only once the question has reached
+// the terminal RESULTS status; it is a no-op (nil, no chain call) for every other status and for
+// unpublished drafts. Unlike encryption keys it is not cached: RESULTS is terminal so the read is
+// bounded, and caching would need a db type/method — add one if this read ever gets hot.
+func (a *API) resolveQuestionResults(q *db.VotingProcessQuestion) *db.QuestionResults {
+	// gate: only surface results for questions the chain has moved to RESULTS; keeps others chain-free.
+	if q.Status != db.QuestionStatusResults {
+		return nil
+	}
+	if len(q.UpstreamID) == 0 {
+		return nil
+	}
+	election, err := a.account.Election(q.UpstreamID)
+	if err != nil {
+		log.Warnw("results: election fetch failed",
+			"question", q.ID.Hex(), "upstreamId", q.UpstreamID.String(), "error", err)
+		return nil
+	}
+	qr := questionResultsFromElection(election)
+	return &qr
+}
+
+// resolveQuestionResultsBatch resolves the on-chain tally of every RESULTS question concurrently
+// (bounded), setting q.Results in place. Non-RESULTS questions short-circuit to nil without a chain
+// call, so a bounded worker pool keeps GET /processes/{id} fast when several questions are in results.
+func (a *API) resolveQuestionResultsBatch(questions []db.VotingProcessQuestion) {
+	const workers = 8
+	sem := make(chan struct{}, workers)
+	var wg sync.WaitGroup
+	for i := range questions {
+		sem <- struct{}{}
+		wg.Go(func() {
+			defer func() { <-sem }()
+			questions[i].Results = a.resolveQuestionResults(&questions[i])
+		})
+	}
+	wg.Wait()
 }
 
 // votingProcessParticipantHandler godoc
@@ -647,29 +714,11 @@ func (a *API) votingProcessResultsHandler(w http.ResponseWriter, r *http.Request
 			errors.ErrVochainRequestFailed.WithErr(err).Write(w)
 			return
 		}
-		entry := apicommon.VotingProcessQuestionResults{
-			QuestionID: q.ID.Hex(),
-			UpstreamID: q.UpstreamID,
-			ProcessResultsResponse: apicommon.ProcessResultsResponse{
-				Status:       election.Status,
-				VoteCount:    election.VoteCount,
-				StartDate:    election.StartDate,
-				EndDate:      election.EndDate,
-				FinalResults: election.FinalResults,
-			},
-		}
-		if len(election.Results) > 0 {
-			results := make([][]string, len(election.Results))
-			for j, question := range election.Results {
-				values := make([]string, len(question))
-				for k, value := range question {
-					values[k] = value.String()
-				}
-				results[j] = values
-			}
-			entry.Results = results
-		}
-		resp.Questions = append(resp.Questions, entry)
+		resp.Questions = append(resp.Questions, apicommon.VotingProcessQuestionResults{
+			QuestionID:      q.ID.Hex(),
+			UpstreamID:      q.UpstreamID,
+			QuestionResults: questionResultsFromElection(election),
+		})
 	}
 	apicommon.HTTPWriteJSON(w, resp)
 }

--- a/api/processes.go
+++ b/api/processes.go
@@ -569,10 +569,12 @@ func (a *API) resolveQuestionEncryptionKeys(q *db.VotingProcessQuestion) []db.En
 	return keys
 }
 
-// questionResultsFromElection maps a question's on-chain election onto the trimmed QuestionResults
-// shape. MaxVoters is the election's own maxCensusSize — already restricted to the question's
-// eligibility subset at publish (account.ComputeMaxCensusSize). Results is the single-field tally
-// (each question is its own one-field election), stringified; it stays nil until the tally publishes.
+// questionResultsFromElection maps a question's on-chain election onto the QuestionResults shape.
+// MaxVoters is the election's own maxCensusSize — already restricted to the question's eligibility
+// subset at publish (account.ComputeMaxCensusSize). Results is the full tally matrix stringified
+// verbatim (one row per ballot field), so both single-choice (one row of value buckets) and
+// multi-choice (one row per choice) questions are represented losslessly; it stays nil until the
+// tally publishes.
 func questionResultsFromElection(e *dvoteapi.Election) db.QuestionResults {
 	qr := db.QuestionResults{
 		VoteCount:    e.VoteCount,
@@ -582,11 +584,15 @@ func questionResultsFromElection(e *dvoteapi.Election) db.QuestionResults {
 		qr.MaxVoters = e.Census.MaxCensusSize
 	}
 	if len(e.Results) > 0 {
-		values := make([]string, len(e.Results[0]))
-		for i, v := range e.Results[0] {
-			values[i] = v.String()
+		results := make([][]string, len(e.Results))
+		for i, field := range e.Results {
+			values := make([]string, len(field))
+			for j, v := range field {
+				values[j] = v.String()
+			}
+			results[i] = values
 		}
-		qr.Results = values
+		qr.Results = results
 	}
 	return qr
 }

--- a/api/processes.go
+++ b/api/processes.go
@@ -14,7 +14,7 @@ import (
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.vocdoni.io/dvote/api"
+	dvoteapi "go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/log"
 )
 
@@ -573,7 +573,7 @@ func (a *API) resolveQuestionEncryptionKeys(q *db.VotingProcessQuestion) []db.En
 // shape. MaxVoters is the election's own maxCensusSize — already restricted to the question's
 // eligibility subset at publish (account.ComputeMaxCensusSize). Results is the single-field tally
 // (each question is its own one-field election), stringified; it stays nil until the tally publishes.
-func questionResultsFromElection(e *api.Election) db.QuestionResults {
+func questionResultsFromElection(e *dvoteapi.Election) db.QuestionResults {
 	qr := db.QuestionResults{
 		VoteCount:    e.VoteCount,
 		FinalResults: e.FinalResults,
@@ -674,8 +674,8 @@ func (a *API) votingProcessParticipantHandler(w http.ResponseWriter, r *http.Req
 //
 //	@Summary		Get a voting process results
 //	@Description	Public per-question on-chain results of a published voting process: one entry per
-//	@Description	published question, each with the trimmed election state (status, vote count,
-//	@Description	dates, whether final, and the tally). No authentication is required.
+//	@Description	published question, each with its tally (vote count, max voters, whether final, and
+//	@Description	the per-choice results). No authentication is required.
 //	@Tags			processes
 //	@Produce		json
 //	@Param			processId	path		string	true	"Process ID"

--- a/api/processes.go
+++ b/api/processes.go
@@ -515,23 +515,30 @@ func (a *API) votingProcessQuestionHandler(w http.ResponseWriter, r *http.Reques
 	apicommon.HTTPWriteJSON(w, apicommon.PublicQuestionResponseFromDB(question, census))
 }
 
-// resolveQuestionEncryptionKeysBatch resolves the vote encryption keys of every question
-// concurrently (bounded), setting q.EncryptionKeys in place. Each encrypted question without cached
-// keys needs a Vochain round-trip; a bounded worker pool keeps GET /processes/{id} fast for a process
-// with many encrypted questions (up to maxQuestionsPerProcess) instead of doing the calls
-// sequentially. Gated/cached questions return immediately (no chain call).
-func (a *API) resolveQuestionEncryptionKeysBatch(questions []db.VotingProcessQuestion) {
+// parallelForEach runs fn(0..n-1) concurrently with a bounded worker pool and waits for all to
+// finish. It backs the per-question read resolvers and the results handler, which each fan out one
+// Vochain round-trip per question: the bound keeps GET /processes/{id} and /results fast for a process
+// with many questions (up to maxQuestionsPerProcess) without an unbounded goroutine burst.
+func parallelForEach(n int, fn func(i int)) {
 	const workers = 8
 	sem := make(chan struct{}, workers)
 	var wg sync.WaitGroup
-	for i := range questions {
+	for i := range n {
 		sem <- struct{}{}
 		wg.Go(func() {
 			defer func() { <-sem }()
-			questions[i].EncryptionKeys = a.resolveQuestionEncryptionKeys(&questions[i])
+			fn(i)
 		})
 	}
 	wg.Wait()
+}
+
+// resolveQuestionEncryptionKeysBatch resolves the vote encryption keys of every question concurrently
+// (bounded), setting q.EncryptionKeys in place. Gated/cached questions return immediately (no chain call).
+func (a *API) resolveQuestionEncryptionKeysBatch(questions []db.VotingProcessQuestion) {
+	parallelForEach(len(questions), func(i int) {
+		questions[i].EncryptionKeys = a.resolveQuestionEncryptionKeys(&questions[i])
+	})
 }
 
 // resolveQuestionEncryptionKeys returns the vote-encryption public keys of a question's on-chain
@@ -623,17 +630,47 @@ func (a *API) resolveQuestionResults(q *db.VotingProcessQuestion) *db.QuestionRe
 // (bounded), setting q.Results in place. Non-RESULTS questions short-circuit to nil without a chain
 // call, so a bounded worker pool keeps GET /processes/{id} fast when several questions are in results.
 func (a *API) resolveQuestionResultsBatch(questions []db.VotingProcessQuestion) {
-	const workers = 8
-	sem := make(chan struct{}, workers)
-	var wg sync.WaitGroup
+	parallelForEach(len(questions), func(i int) {
+		questions[i].Results = a.resolveQuestionResults(&questions[i])
+	})
+}
+
+// electionResultsBatch fetches the on-chain tally of every published question concurrently (bounded)
+// and maps each to a results entry, preserving question order. Questions not yet on chain are skipped.
+// Unlike the read resolvers it is all-or-error: the first election fetch failure (by question order)
+// is returned so GET /processes/{id}/results never emits a silent partial tally set. Returns nil when
+// no question is on chain (preserving the endpoint's "questions": null shape for that case).
+func (a *API) electionResultsBatch(
+	questions []db.VotingProcessQuestion,
+) ([]apicommon.VotingProcessQuestionResults, error) {
+	entries := make([]*apicommon.VotingProcessQuestionResults, len(questions))
+	errs := make([]error, len(questions))
+	parallelForEach(len(questions), func(i int) {
+		q := &questions[i]
+		if len(q.UpstreamID) == 0 {
+			return // question not yet on chain
+		}
+		election, err := a.account.Election(q.UpstreamID)
+		if err != nil {
+			errs[i] = fmt.Errorf("question %s: %w", q.ID.Hex(), err)
+			return
+		}
+		entries[i] = &apicommon.VotingProcessQuestionResults{
+			QuestionID:      q.ID.Hex(),
+			UpstreamID:      q.UpstreamID,
+			QuestionResults: questionResultsFromElection(election),
+		}
+	})
+	var out []apicommon.VotingProcessQuestionResults
 	for i := range questions {
-		sem <- struct{}{}
-		wg.Go(func() {
-			defer func() { <-sem }()
-			questions[i].Results = a.resolveQuestionResults(&questions[i])
-		})
+		if errs[i] != nil {
+			return nil, errs[i]
+		}
+		if entries[i] != nil {
+			out = append(out, *entries[i])
+		}
 	}
-	wg.Wait()
+	return out, nil
 }
 
 // votingProcessParticipantHandler godoc
@@ -709,24 +746,14 @@ func (a *API) votingProcessResultsHandler(w http.ResponseWriter, r *http.Request
 		errors.ErrProcessNotFound.Withf("process not published").Write(w)
 		return
 	}
-	resp := &apicommon.VotingProcessResultsResponse{ID: oid.Hex()}
-	for i := range questions {
-		q := &questions[i]
-		if len(q.UpstreamID) == 0 {
-			continue // question not yet on chain
-		}
-		election, err := a.account.Election(q.UpstreamID)
-		if err != nil {
-			errors.ErrVochainRequestFailed.WithErr(err).Write(w)
-			return
-		}
-		resp.Questions = append(resp.Questions, apicommon.VotingProcessQuestionResults{
-			QuestionID:      q.ID.Hex(),
-			UpstreamID:      q.UpstreamID,
-			QuestionResults: questionResultsFromElection(election),
-		})
+	// fetch every published question's tally concurrently (bounded); all-or-error so this endpoint
+	// never emits a partial tally set (a transient chain error on one question fails the response).
+	entries, err := a.electionResultsBatch(questions)
+	if err != nil {
+		errors.ErrVochainRequestFailed.WithErr(err).Write(w)
+		return
 	}
-	apicommon.HTTPWriteJSON(w, resp)
+	apicommon.HTTPWriteJSON(w, &apicommon.VotingProcessResultsResponse{ID: oid.Hex(), Questions: entries})
 }
 
 // votingProcessID parses and validates the {processId} URL param.

--- a/api/processes_test.go
+++ b/api/processes_test.go
@@ -362,7 +362,10 @@ func TestVotingProcessResults(t *testing.T) {
 	job := enqueueAndPollJob(t, http.MethodPost, token, nil, "processes", created.ProcessID, "publish")
 	c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("job error: %s", job.Errors))
 
-	// published: one results entry per question, each with its on-chain election id and status
+	// published (no votes yet): one entry per question. Nothing has voted, so voteCount is 0, the
+	// tally is not final and every choice bucket reads "0" (both questions have two choices).
+	// maxVoters is the per-question eligible count: Q1 is whole-census (2 members), Q2 restricts
+	// eligibility to the first member (1).
 	res := requestAndParse[apicommon.VotingProcessResultsResponse](
 		t, http.MethodGet, "", nil, "processes", created.ProcessID, "results",
 	)
@@ -371,8 +374,12 @@ func TestVotingProcessResults(t *testing.T) {
 	for _, q := range res.Questions {
 		c.Assert(q.QuestionID, qt.Not(qt.Equals), "")
 		c.Assert(len(q.UpstreamID) > 0, qt.IsTrue)
-		c.Assert(q.Status, qt.Not(qt.Equals), "")
+		c.Assert(q.VoteCount, qt.Equals, uint64(0))
+		c.Assert(q.FinalResults, qt.IsFalse)
+		c.Assert(q.Results, qt.DeepEquals, []string{"0", "0"})
 	}
+	c.Assert(res.Questions[0].MaxVoters, qt.Equals, uint64(2)) // whole census
+	c.Assert(res.Questions[1].MaxVoters, qt.Equals, uint64(1)) // eligibility subset of one
 }
 
 // TestVotingProcessPublicQuestionCensus verifies the public single-question read of a PUBLISHED

--- a/api/processes_test.go
+++ b/api/processes_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	dvoteapi "go.vocdoni.io/dvote/api"
+	"go.vocdoni.io/dvote/types"
 )
 
 // newVotingProcessRequest builds a 2-question (singlechoice + multichoice) create request
@@ -340,6 +342,38 @@ func TestVotingProcessUpdateNoCensusOrphan(t *testing.T) {
 	}
 }
 
+// TestQuestionResultsFromElection checks the chain->QuestionResults mapping directly (no chain):
+// the full tally matrix is preserved verbatim, so single-choice (one field) and multi-choice (one
+// field per choice) shapes are both represented losslessly; maxVoters comes from the election census
+// (nil-safe); an untallied election yields nil results.
+func TestQuestionResultsFromElection(t *testing.T) {
+	c := qt.New(t)
+	bi := func(n uint64) *types.BigInt { return new(types.BigInt).SetUint64(n) }
+
+	// multi-choice: one row per choice, each [notSelected, selected].
+	multi := questionResultsFromElection(&dvoteapi.Election{
+		ElectionSummary: dvoteapi.ElectionSummary{
+			VoteCount: 3, FinalResults: true,
+			Results: [][]*types.BigInt{{bi(1), bi(2)}, {bi(1), bi(2)}, {bi(2), bi(1)}},
+		},
+		Census: &dvoteapi.ElectionCensus{MaxCensusSize: 5},
+	})
+	c.Assert(multi.VoteCount, qt.Equals, uint64(3))
+	c.Assert(multi.FinalResults, qt.IsTrue)
+	c.Assert(multi.MaxVoters, qt.Equals, uint64(5))
+	c.Assert(multi.Results, qt.DeepEquals, [][]string{{"1", "2"}, {"1", "2"}, {"2", "1"}})
+
+	// single-choice: one row of value buckets; nil census is tolerated (maxVoters 0).
+	single := questionResultsFromElection(&dvoteapi.Election{
+		ElectionSummary: dvoteapi.ElectionSummary{Results: [][]*types.BigInt{{bi(4), bi(6)}}},
+	})
+	c.Assert(single.Results, qt.DeepEquals, [][]string{{"4", "6"}})
+	c.Assert(single.MaxVoters, qt.Equals, uint64(0))
+
+	// no tally published yet: results absent.
+	c.Assert(questionResultsFromElection(&dvoteapi.Election{}).Results, qt.IsNil)
+}
+
 // TestVotingProcessResults verifies the public per-question results endpoint: a draft has no
 // results (404), and a published process returns one entry per question with its on-chain status.
 func TestVotingProcessResults(t *testing.T) {
@@ -362,10 +396,11 @@ func TestVotingProcessResults(t *testing.T) {
 	job := enqueueAndPollJob(t, http.MethodPost, token, nil, "processes", created.ProcessID, "publish")
 	c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("job error: %s", job.Errors))
 
-	// published (no votes yet): one entry per question. Nothing has voted, so voteCount is 0, the
-	// tally is not final and every choice bucket reads "0" (both questions have two choices).
+	// published (no votes yet): one entry per question, voteCount 0, tally not final, buckets "0".
 	// maxVoters is the per-question eligible count: Q1 is whole-census (2 members), Q2 restricts
-	// eligibility to the first member (1).
+	// eligibility to the first member (1). The results matrix has one row per ballot field: the
+	// singlechoice Q1 is one field (one row of value buckets), the multichoice Q2 is one field per
+	// choice (a row per choice), so the two shapes differ.
 	res := requestAndParse[apicommon.VotingProcessResultsResponse](
 		t, http.MethodGet, "", nil, "processes", created.ProcessID, "results",
 	)
@@ -376,8 +411,11 @@ func TestVotingProcessResults(t *testing.T) {
 		c.Assert(len(q.UpstreamID) > 0, qt.IsTrue)
 		c.Assert(q.VoteCount, qt.Equals, uint64(0))
 		c.Assert(q.FinalResults, qt.IsFalse)
-		c.Assert(q.Results, qt.DeepEquals, []string{"0", "0"})
 	}
+	// Q1 singlechoice: one field, two value buckets. Q2 multichoice: one field per choice (two), each
+	// [notSelected, selected].
+	c.Assert(res.Questions[0].Results, qt.DeepEquals, [][]string{{"0", "0"}})
+	c.Assert(res.Questions[1].Results, qt.DeepEquals, [][]string{{"0", "0"}, {"0", "0"}})
 	c.Assert(res.Questions[0].MaxVoters, qt.Equals, uint64(2)) // whole census
 	c.Assert(res.Questions[1].MaxVoters, qt.Equals, uint64(1)) // eligibility subset of one
 }

--- a/db/types.go
+++ b/db/types.go
@@ -630,6 +630,20 @@ type VotingProcessQuestion struct {
 	// JSON field is absent (not an empty array) until the keykeepers publish the keys, so clients
 	// treat its absence as "not yet published" and poll. Voters seal encrypted vote packages with these.
 	EncryptionKeys []EncryptionKey `json:"encryptionKeys,omitempty" bson:"encryptionKeys,omitempty"`
+	// Results is this question's on-chain tally, resolved on read only when the question is in RESULTS
+	// status (absent otherwise). Not persisted (bson:"-") — recomputed from the chain each read.
+	Results *QuestionResults `json:"results,omitempty" bson:"-"`
+}
+
+// QuestionResults is one question's on-chain election tally, resolved on read from its own election.
+// MaxVoters is that election's maxCensusSize — already restricted to the question's eligibility subset
+// (see account.ComputeMaxCensusSize) — not the whole process census. Results holds the per-choice vote
+// counts (stringified big integers) and is absent until the tally is published.
+type QuestionResults struct {
+	VoteCount    uint64   `json:"voteCount"`
+	MaxVoters    uint64   `json:"maxVoters"`
+	FinalResults bool     `json:"finalResults"`
+	Results      []string `json:"results,omitempty"`
 }
 
 // QuestionStatusRef is the minimal projection of a published question the status syncer and the

--- a/db/types.go
+++ b/db/types.go
@@ -631,19 +631,25 @@ type VotingProcessQuestion struct {
 	// treat its absence as "not yet published" and poll. Voters seal encrypted vote packages with these.
 	EncryptionKeys []EncryptionKey `json:"encryptionKeys,omitempty" bson:"encryptionKeys,omitempty"`
 	// Results is this question's on-chain tally, resolved on read only when the question is in RESULTS
-	// status (absent otherwise). Not persisted (bson:"-") — recomputed from the chain each read.
+	// status (absent otherwise). Not persisted (bson:"-") — recomputed from the chain each read. Only
+	// the single reads resolve it (GET /processes/{id} and the public question read); the list endpoint
+	// leaves it nil to avoid an N+1 chain fan-out, so its absence in a LIST response means "not resolved
+	// here", not "not final" — poll the single read for that.
 	Results *QuestionResults `json:"results,omitempty" bson:"-"`
 }
 
 // QuestionResults is one question's on-chain election tally, resolved on read from its own election.
 // MaxVoters is that election's maxCensusSize — already restricted to the question's eligibility subset
-// (see account.ComputeMaxCensusSize) — not the whole process census. Results holds the per-choice vote
-// counts (stringified big integers) and is absent until the tally is published.
+// (see account.ComputeMaxCensusSize) — not the whole process census.
 type QuestionResults struct {
-	VoteCount    uint64   `json:"voteCount"`
-	MaxVoters    uint64   `json:"maxVoters"`
-	FinalResults bool     `json:"finalResults"`
-	Results      []string `json:"results,omitempty"`
+	VoteCount    uint64 `json:"voteCount"`
+	MaxVoters    uint64 `json:"maxVoters"`
+	FinalResults bool   `json:"finalResults"`
+	// Results is the raw on-chain tally matrix (stringified big integers), one row per ballot field:
+	// a single-choice question has one row indexed by choice value (0..MaxValue, so sparse choice
+	// values leave empty buckets); a multi-choice question has one row per choice, each [notSelected,
+	// selected]. Absent until the tally is published.
+	Results [][]string `json:"results,omitempty"`
 }
 
 // QuestionStatusRef is the minimal projection of a published question the status syncer and the

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -6430,8 +6430,8 @@ paths:
     get:
       description: |-
         Public per-question on-chain results of a published voting process: one entry per
-        published question, each with the trimmed election state (status, vote count,
-        dates, whether final, and the tally). No authentication is required.
+        published question, each with its tally (vote count, max voters, whether final, and
+        the per-choice results). No authentication is required.
       parameters:
       - description: Process ID
         in: path

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1838,8 +1838,15 @@ definitions:
       questionId:
         type: string
       results:
+        description: |-
+          Results is the raw on-chain tally matrix (stringified big integers), one row per ballot field:
+          a single-choice question has one row indexed by choice value (0..MaxValue, so sparse choice
+          values leave empty buckets); a multi-choice question has one row per choice, each [notSelected,
+          selected]. Absent until the tally is published.
         items:
-          type: string
+          items:
+            type: string
+          type: array
         type: array
       upstreamId:
         example: deadbeef
@@ -2233,8 +2240,15 @@ definitions:
       maxVoters:
         type: integer
       results:
+        description: |-
+          Results is the raw on-chain tally matrix (stringified big integers), one row per ballot field:
+          a single-choice question has one row indexed by choice value (0..MaxValue, so sparse choice
+          values leave empty buckets); a multi-choice question has one row per choice, each [notSelected,
+          selected]. Absent until the tally is published.
         items:
-          type: string
+          items:
+            type: string
+          type: array
         type: array
       voteCount:
         type: integer
@@ -2313,7 +2327,10 @@ definitions:
         - $ref: '#/definitions/db.QuestionResults'
         description: |-
           Results is this question's on-chain tally, resolved on read only when the question is in RESULTS
-          status (absent otherwise). Not persisted (bson:"-") — recomputed from the chain each read.
+          status (absent otherwise). Not persisted (bson:"-") — recomputed from the chain each read. Only
+          the single reads resolve it (GET /processes/{id} and the public question read); the list endpoint
+          leaves it nil to avoid an N+1 chain fan-out, so its absence in a LIST response means "not resolved
+          here", not "not final" — poll the single read for that.
       secretUntilTheEnd:
         type: boolean
       status:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1303,6 +1303,12 @@ definitions:
         type: object
       parentProcessId:
         type: string
+      results:
+        allOf:
+        - $ref: '#/definitions/db.QuestionResults'
+        description: |-
+          Results is this question's on-chain tally, present only once the question reaches RESULTS status
+          (absent otherwise via omitempty), so clients treat its absence as "not yet final" and poll.
       secretUntilTheEnd:
         type: boolean
       status:
@@ -1825,22 +1831,16 @@ definitions:
     type: object
   apicommon.VotingProcessQuestionResults:
     properties:
-      endDate:
-        type: string
       finalResults:
         type: boolean
+      maxVoters:
+        type: integer
       questionId:
         type: string
       results:
         items:
-          items:
-            type: string
-          type: array
+          type: string
         type: array
-      startDate:
-        type: string
-      status:
-        type: string
       upstreamId:
         example: deadbeef
         format: hex
@@ -2226,6 +2226,19 @@ definitions:
       title:
         $ref: '#/definitions/db.MultiLangString'
     type: object
+  db.QuestionResults:
+    properties:
+      finalResults:
+        type: boolean
+      maxVoters:
+        type: integer
+      results:
+        items:
+          type: string
+        type: array
+      voteCount:
+        type: integer
+    type: object
   db.QuestionTypeSetup:
     properties:
       maxChoices:
@@ -2295,6 +2308,12 @@ definitions:
         type: object
       parentProcessId:
         type: string
+      results:
+        allOf:
+        - $ref: '#/definitions/db.QuestionResults'
+        description: |-
+          Results is this question's on-chain tally, resolved on read only when the question is in RESULTS
+          status (absent otherwise). Not persisted (bson:"-") — recomputed from the chain each read.
       secretUntilTheEnd:
         type: boolean
       status:


### PR DESCRIPTION
## What

Refine per-question results in the new `/processes` API. Introduces `db.QuestionResults`:

```go
type QuestionResults struct {
    VoteCount    uint64     `json:"voteCount"`
    MaxVoters    uint64     `json:"maxVoters"`
    FinalResults bool       `json:"finalResults"`
    Results      [][]string `json:"results,omitempty"`
}
```

### Changes
- **`GET /processes/{processId}/results`**: `VotingProcessQuestionResults` now embeds `QuestionResults` instead of the legacy `ProcessResultsResponse`. It drops `status`/`startDate`/`endDate` and adds `maxVoters`. `results` keeps the full `[][]string` tally matrix (one row per ballot field).
- **`GET /processes/{processId}` (manager)** and **`GET /processes/{processId}/questions/{questionId}` (public)**: each question now carries the tally inline via a new `results` field, **resolved on read only when the question is in `RESULTS` status** (absent otherwise via `omitempty`). Mirrors the existing encryption-keys resolve/batch pattern (bounded 8-worker pool; non-RESULTS questions never hit the chain).

### ⚠️ Breaking change
`GET /processes/{processId}/results` (exists on `main` since #571) changes shape: **`status`, `startDate`, `endDate` are removed** and **`maxVoters` is added**. `results` stays `[][]string`. Any existing consumer of the three removed fields must update. This is deliberate — the new per-question model has no need for the per-election status/date fields (those live on the process/question reads).

### Results matrix
`results` is the raw on-chain tally, **one row per ballot field**:
- **single-choice**: one row, indexed by choice **value** `0..MaxValue` (sparse choice values leave empty buckets).
- **multi-choice**: one row **per choice**, each `[notSelected, selected]` (each choice is its own on-chain field).

### MaxVoters semantics
`maxVoters` is the question's **own** on-chain `maxCensusSize`, already restricted to that question's eligibility subset at publish via `account.ComputeMaxCensusSize` — **not** the whole-process census total.

## Out of scope
- The legacy single-process endpoint `/process/{processId}/results` keeps `ProcessResultsResponse` (deprecated, untouched).
- The list endpoint `GET /processes` deliberately does **not** resolve results (avoids N+1). Because of that, an absent `results` on a **list** response means "not resolved here", not "not final" — poll the single read for finality. Documented on the field.

## Tests
- `TestQuestionResultsFromElection` (chain-free unit test): asserts the full matrix is preserved for single-choice (one row) and **multi-choice (one row per choice)**, `maxVoters` from the election census (nil-safe), and nil results before the tally publishes.
- `TestVotingProcessResults`: per-question `maxVoters` reflects the eligibility subset (whole-census = 2, restricted = 1); the single-choice question yields `[["0","0"]]` and the multichoice one `[["0","0"],["0","0"]]`.
- `TestFullElectionLifecycle`: extended to seed a new-API process over the same RESULTS election and assert the tally inline on both the manager and public reads (`[["1","2"]]`), and that a non-RESULTS question omits `results`.
- Regenerated `docs/swagger.yaml`. `go build`/`vet`/`golangci-lint` clean.