### PR TITLE
feat(processes): live results + public draft-gated process reads

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -418,12 +418,10 @@ func (a *API) initRouter() http.Handler {
 		handle(r, http.MethodPost, processBundleEndpoint, a.createProcessBundleHandler)
 		handle(r, http.MethodPut, processBundleUpdateEndpoint, a.updateProcessBundleHandler)
 		handle(r, http.MethodPost, processBundleParticipantsCheckEndpoint, a.checkProcessBundleVotedParticipantsHandler)
-		// multi-question voting processes: authoring + protected reads
+		// multi-question voting processes: authoring (the GET reads are public — see below)
 		handle(r, http.MethodPost, processesCreateEndpoint, a.createVotingProcessHandler)
 		handle(r, http.MethodPost, processesCensusValidateEndpoint, a.validateProcessCensusHandler)
-		handle(r, http.MethodGet, processesCreateEndpoint, a.listVotingProcessesHandler)
 		handle(r, http.MethodPut, processesEndpoint, a.updateVotingProcessHandler)
-		handle(r, http.MethodGet, processesEndpoint, a.votingProcessInfoHandler)
 		handle(r, http.MethodGet, processesValidateEndpoint, a.validateVotingProcessHandler)
 		handle(r, http.MethodPost, processesPublishEndpoint, a.publishVotingProcessHandler)
 		handle(r, http.MethodPut, processesQuestionsStatusEndpoint, a.setVotingProcessQuestionsStatusHandler)
@@ -471,7 +469,11 @@ func (a *API) initRouter() http.Handler {
 		handle(r, http.MethodPost, processBundleSignEndpoint, cspHandlers.BundleSignHandler)
 		handle(r, http.MethodPost, processBundleCheckEndpoint, cspHandlers.BundleCheckHandler)
 		handle(r, http.MethodGet, processBundleMemberEndpoint, a.processBundleParticipantInfoHandler)
-		// multi-question voting processes: public voter reads + CSP
+		// multi-question voting processes: public voter reads + CSP. The process list and single-read
+		// are public for published processes; drafts + per-question eligibility are gated in-handler to
+		// a manager/admin (or a voting:write API key) via optionalManager.
+		handle(r, http.MethodGet, processesCreateEndpoint, a.listVotingProcessesHandler)
+		handle(r, http.MethodGet, processesEndpoint, a.votingProcessInfoHandler)
 		handle(r, http.MethodGet, processesQuestionEndpoint, a.votingProcessQuestionHandler)
 		handle(r, http.MethodGet, processesParticipantEndpoint, a.votingProcessParticipantHandler)
 		handle(r, http.MethodGet, processesResultsEndpoint, a.votingProcessResultsHandler)

--- a/api/apicommon/voting_processes.go
+++ b/api/apicommon/voting_processes.go
@@ -187,8 +187,9 @@ type PublicQuestionResponse struct {
 	// publish the keys, so clients treat its absence as "not yet published" and poll. Voters seal
 	// encrypted ballots with them.
 	EncryptionKeys []db.EncryptionKey `json:"encryptionKeys,omitempty"`
-	// Results is this question's on-chain tally, present only once the question reaches RESULTS status
-	// (absent otherwise via omitempty), so clients treat its absence as "not yet final" and poll.
+	// Results is this question's live on-chain tally, present for any published question; FinalResults
+	// marks live vs final. Absent (via omitempty) while a secretUntilTheEnd election is still encrypted
+	// or before any vote, so clients treat its absence as "nothing to show yet" and poll.
 	Results *db.QuestionResults `json:"results,omitempty"`
 }
 

--- a/api/apicommon/voting_processes.go
+++ b/api/apicommon/voting_processes.go
@@ -187,9 +187,11 @@ type PublicQuestionResponse struct {
 	// publish the keys, so clients treat its absence as "not yet published" and poll. Voters seal
 	// encrypted ballots with them.
 	EncryptionKeys []db.EncryptionKey `json:"encryptionKeys,omitempty"`
-	// Results is this question's live on-chain tally, present for any published question; FinalResults
-	// marks live vs final. Absent (via omitempty) while a secretUntilTheEnd election is still encrypted
-	// or before any vote, so clients treat its absence as "nothing to show yet" and poll.
+	// Results is this question's live on-chain tally, present (non-null) for any published question and
+	// carrying voteCount/maxVoters/finalResults; FinalResults marks live vs final. The inner per-choice
+	// matrix (results.results) is omitted until a tally exists — empty while a secretUntilTheEnd election
+	// is still encrypted or before any vote — so clients poll on an empty tally. The whole object is
+	// absent (omitempty) only for a draft (no election yet).
 	Results *db.QuestionResults `json:"results,omitempty"`
 }
 

--- a/api/apikeys.go
+++ b/api/apikeys.go
@@ -82,11 +82,10 @@ var apiKeyAllowlist = map[string]string{
 	"POST " + censusIDEndpoint:                     ScopeVotingWrite,
 	"POST " + processBundleEndpoint:                ScopeVotingWrite,
 	"PUT " + processBundleUpdateEndpoint:           ScopeVotingWrite,
-	// multi-question voting processes (writes + protected reads)
+	// multi-question voting processes (writes; the GET list/single reads are public — a voting:write
+	// key still unlocks drafts + eligibility there, resolved in-handler via optionalManager, not here)
 	"POST " + processesCreateEndpoint:         ScopeVotingWrite,
-	"GET " + processesCreateEndpoint:          ScopeVotingWrite,
 	"PUT " + processesEndpoint:                ScopeVotingWrite,
-	"GET " + processesEndpoint:                ScopeVotingWrite,
 	"GET " + processesValidateEndpoint:        ScopeVotingWrite,
 	"POST " + processesPublishEndpoint:        ScopeVotingWrite,
 	"PUT " + processesQuestionsStatusEndpoint: ScopeVotingWrite,

--- a/api/middlewares.go
+++ b/api/middlewares.go
@@ -80,6 +80,18 @@ func (a *API) optionalUser(r *http.Request) *db.User {
 	return user
 }
 
+// apiKeyActingUser loads the verified db.User an API key acts as (its CreatedBy owner), or nil if that
+// user is missing or unverified. Single source of truth for "which user does a key act as", shared by
+// authenticateAPIKey (required auth) and userFromAPIKey (optional public-read auth) so the two cannot
+// drift — a future hardening check on the acting user (e.g. a suspended-user flag) lives here once.
+func (a *API) apiKeyActingUser(key *db.APIKey) *db.User {
+	user, err := a.db.UserByEmail(key.CreatedBy)
+	if err != nil || !user.Verified {
+		return nil
+	}
+	return user
+}
+
 // userFromAPIKey resolves the db.User an API key acts as, but only when the key is valid (not
 // revoked/expired) and holds requiredScope. Returns nil otherwise. Like authenticateAPIKey, the key
 // acts as its creating user, so org authorization still flows through that user's roles. Used by the
@@ -89,11 +101,7 @@ func (a *API) userFromAPIKey(raw, requiredScope string) *db.User {
 	if err != nil || !slices.Contains(key.Scopes, requiredScope) {
 		return nil
 	}
-	user, err := a.db.UserByEmail(key.CreatedBy)
-	if err != nil || !user.Verified {
-		return nil
-	}
-	return user
+	return a.apiKeyActingUser(key)
 }
 
 // optionalCallerUser resolves the acting db.User from either a JWT bearer session or a voting:write
@@ -178,14 +186,11 @@ func (a *API) authenticateAPIKey(w http.ResponseWriter, r *http.Request, next ht
 		errors.ErrInsufficientAPIKeyScope.Withf("endpoint requires the %q scope", scope).Write(w)
 		return
 	}
-	// the key acts as its creating user, reusing the existing per-organization role checks
-	user, err := a.db.UserByEmail(key.CreatedBy)
-	if err != nil {
-		errors.ErrInvalidAPIKey.Withf("key owner no longer exists").Write(w)
-		return
-	}
-	if !user.Verified {
-		errors.ErrUserNoVerified.With("user account not verified").Write(w)
+	// the key acts as its creating user (shared resolver, so this and the public-read path can't drift),
+	// reusing the existing per-organization role checks
+	user := a.apiKeyActingUser(key)
+	if user == nil {
+		errors.ErrInvalidAPIKey.Withf("key owner missing or unverified").Write(w)
 		return
 	}
 	// best-effort last-used tracking; never block the request on it

--- a/api/middlewares.go
+++ b/api/middlewares.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/jwtauth/v5"
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -77,6 +78,42 @@ func (a *API) optionalUser(r *http.Request) *db.User {
 		return nil
 	}
 	return user
+}
+
+// userFromAPIKey resolves the db.User an API key acts as, but only when the key is valid (not
+// revoked/expired) and holds requiredScope. Returns nil otherwise. Like authenticateAPIKey, the key
+// acts as its creating user, so org authorization still flows through that user's roles. Used by the
+// optional-auth path of public handlers, so it never writes a response and skips last-used tracking.
+func (a *API) userFromAPIKey(raw, requiredScope string) *db.User {
+	key, err := a.db.APIKeyByHash(hashAPIKey(raw))
+	if err != nil || !slices.Contains(key.Scopes, requiredScope) {
+		return nil
+	}
+	user, err := a.db.UserByEmail(key.CreatedBy)
+	if err != nil || !user.Verified {
+		return nil
+	}
+	return user
+}
+
+// optionalCallerUser resolves the acting db.User from either a JWT bearer session or a voting:write
+// scoped API key (which acts as its creating user), or nil when the request is anonymous or the
+// credential is invalid/insufficient. Never writes a response — for public handlers that reveal extra
+// data to an authorized caller.
+func (a *API) optionalCallerUser(r *http.Request) *db.User {
+	if raw := bearerToken(r); looksLikeAPIKey(raw) {
+		return a.userFromAPIKey(raw, ScopeVotingWrite)
+	}
+	return a.optionalUser(r)
+}
+
+// optionalManager reports whether the request's optional credential (JWT or scoped API key) resolves
+// to a user with Manager or Admin role for orgAddress. Anonymous or insufficient callers get false —
+// the public view. Never writes a response.
+func (a *API) optionalManager(r *http.Request, orgAddress common.Address) bool {
+	user := a.optionalCallerUser(r)
+	return user != nil &&
+		(user.HasRoleFor(orgAddress, db.ManagerRole) || user.HasRoleFor(orgAddress, db.AdminRole))
 }
 
 // authenticator is a middleware that authenticates the user and returns a JWT

--- a/api/processes.go
+++ b/api/processes.go
@@ -153,7 +153,8 @@ func (a *API) buildQuestions(
 			case db.VotingTypeMultiChoice:
 				if q.TypeSetup.MaxChoices < 1 || q.TypeSetup.MaxChoices > uint32(len(q.Choices)) {
 					return nil, errors.ErrInvalidData.Withf(
-						"question %d: maxChoices must be between 1 and the number of choices (%d)", i, len(q.Choices))
+						"question %d: maxChoices must be between 1 and the number of choices (%d)", i, len(q.Choices),
+					)
 				}
 				if q.TypeSetup.MinChoices > q.TypeSetup.MaxChoices {
 					return nil, errors.ErrInvalidData.Withf("question %d: minChoices cannot exceed maxChoices", i)
@@ -301,23 +302,19 @@ func (a *API) updateVotingProcessHandler(w http.ResponseWriter, r *http.Request)
 // votingProcessInfoHandler godoc
 //
 //	@Summary		Get a voting process
-//	@Description	Read a voting process with its fully hydrated questions (protected read).
+//	@Description	Read a voting process with its hydrated questions (live per-question results included).
+//	@Description	Public for published processes; a draft is visible only to a Manager/Admin of the org
+//	@Description	(or a voting:write API key acting as one) and returns 404 otherwise. Non-managers never
+//	@Description	receive the per-question eligibleMemberIds.
 //	@Tags			processes
 //	@Produce		json
-//	@Security		BearerAuth
 //	@Param			processId	path		string	true	"Process ID"
 //	@Success		200			{object}	apicommon.VotingProcessResponse
-//	@Failure		401			{object}	errors.Error
 //	@Failure		404			{object}	errors.Error
 //	@Router			/processes/{processId} [get]
 func (a *API) votingProcessInfoHandler(w http.ResponseWriter, r *http.Request) {
 	oid, ok := a.votingProcessID(w, r)
 	if !ok {
-		return
-	}
-	user, ok := apicommon.UserFromContext(r.Context())
-	if !ok {
-		errors.ErrUnauthorized.Write(w)
 		return
 	}
 	vp, questions, err := a.db.ProcessWithQuestions(oid)
@@ -329,8 +326,11 @@ func (a *API) votingProcessInfoHandler(w http.ResponseWriter, r *http.Request) {
 		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
 		return
 	}
-	if !user.HasRoleFor(vp.OrgAddress, db.ManagerRole) && !user.HasRoleFor(vp.OrgAddress, db.AdminRole) {
-		errors.ErrUnauthorized.Write(w)
+	// public read: published processes are visible to anyone; a draft only to a manager/admin of the
+	// owning org (and its existence is hidden from everyone else via 404).
+	isManager := a.optionalManager(r, vp.OrgAddress)
+	if !vp.Published && !isManager {
+		errors.ErrProcessNotFound.Write(w)
 		return
 	}
 	census, _ := a.db.Census(vp.CensusID.Hex())
@@ -340,37 +340,45 @@ func (a *API) votingProcessInfoHandler(w http.ResponseWriter, r *http.Request) {
 		a.enqueueReconcileIfStale(&questions[i])
 	}
 	// resolve the vote encryption keys of encrypted questions (so clients can seal encrypted ballots)
-	// concurrently: each encrypted question without cached keys needs a Vochain round-trip, so a
-	// bounded pool keeps this read fast for a process with many encrypted questions.
+	// and the live on-chain tally of each published question (finalResults marks final), concurrently:
+	// each needs a Vochain round-trip, so bounded pools keep this read fast for a many-question process.
 	a.resolveQuestionEncryptionKeysBatch(questions)
-	// resolve the on-chain tally of any question already in RESULTS status (concurrently), so a manager
-	// sees per-question results inline without a separate /results call. Non-RESULTS questions are skipped.
 	a.resolveQuestionResultsBatch(questions)
+	// non-managers must not see the per-question eligibility member ids (who can vote).
+	if !isManager {
+		redactQuestionsForPublic(questions)
+	}
 	resp := apicommon.VotingProcessResponseFromDB(vp, questions, census, a.account.ChainID())
 	resp.Census.TotalWeight = a.censusTotalWeight(census)
 	apicommon.HTTPWriteJSON(w, resp)
 }
 
+// redactQuestionsForPublic strips manager-only fields from questions before serving them to a
+// non-manager (anonymous, viewer, or other-org) caller — currently the per-question eligibility member
+// ids (the list of who may vote). Mutates the passed slice in place.
+func redactQuestionsForPublic(questions []db.VotingProcessQuestion) {
+	for i := range questions {
+		questions[i].EligibleMemberIDs = nil
+	}
+}
+
 // listVotingProcessesHandler godoc
 //
 //	@Summary		List voting processes
-//	@Description	Paginated list of an organization's voting processes (protected). Filter by question status.
+//	@Description	Paginated list of an organization's voting processes. Public: anonymous callers get
+//	@Description	published processes only (without per-question eligibleMemberIds). A Manager/Admin of
+//	@Description	the org (or a voting:write API key acting as one) also gets drafts and the eligibility.
+//	@Description	Filter by question status.
 //	@Tags			processes
 //	@Produce		json
-//	@Security		BearerAuth
 //	@Param			orgAddress	query		string	true	"Organization address"
 //	@Param			status		query		string	false	"Filter by question status"
 //	@Param			page		query		int		false	"Page (1-based)"
 //	@Param			limit		query		int		false	"Page size"
 //	@Success		200			{object}	apicommon.VotingProcessListResponse
-//	@Failure		401			{object}	errors.Error
+//	@Failure		400			{object}	errors.Error
 //	@Router			/processes [get]
 func (a *API) listVotingProcessesHandler(w http.ResponseWriter, r *http.Request) {
-	user, ok := apicommon.UserFromContext(r.Context())
-	if !ok {
-		errors.ErrUnauthorized.Write(w)
-		return
-	}
 	orgAddressStr := r.URL.Query().Get("orgAddress")
 	if orgAddressStr == "" {
 		errors.ErrMalformedURLParam.Withf("missing orgAddress").Write(w)
@@ -381,9 +389,12 @@ func (a *API) listVotingProcessesHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	orgAddress := common.HexToAddress(orgAddressStr)
-	if !user.HasRoleFor(orgAddress, db.ManagerRole) && !user.HasRoleFor(orgAddress, db.AdminRole) {
-		errors.ErrUnauthorized.Write(w)
-		return
+	// public read: anonymous callers see published processes only; a manager/admin of the org (or a
+	// voting:write API key acting as one) also sees drafts (and keeps the per-question eligibility).
+	isManager := a.optionalManager(r, orgAddress)
+	draft := db.PublishedOnly
+	if isManager {
+		draft = db.AllProcesses
 	}
 	params, err := parsePaginationParams(r.URL.Query().Get(ParamPage), r.URL.Query().Get(ParamLimit))
 	if err != nil {
@@ -392,7 +403,7 @@ func (a *API) listVotingProcessesHandler(w http.ResponseWriter, r *http.Request)
 	}
 	// stored question status is uppercase; upper-case the filter so client input stays case-insensitive.
 	statusFilter := strings.ToUpper(r.URL.Query().Get("status"))
-	total, list, err := a.db.ListVotingProcesses(orgAddress, statusFilter, params.Page, params.Limit)
+	total, list, err := a.db.ListVotingProcesses(orgAddress, statusFilter, draft, params.Page, params.Limit)
 	if err != nil {
 		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
 		return
@@ -415,6 +426,9 @@ func (a *API) listVotingProcessesHandler(w http.ResponseWriter, r *http.Request)
 			return
 		}
 		census, _ := a.db.Census(vp.CensusID.Hex())
+		if !isManager {
+			redactQuestionsForPublic(questions)
+		}
 		resp.Processes = append(resp.Processes, *apicommon.VotingProcessResponseFromDB(vp, questions, census, chainID))
 	}
 	apicommon.HTTPWriteJSON(w, resp)
@@ -627,15 +641,15 @@ func questionResultsFromElection(e *dvoteapi.Election) db.QuestionResults {
 	return qr
 }
 
-// resolveQuestionResults returns a question's on-chain tally, but only once the question has reached
-// the terminal RESULTS status; it is a no-op (nil, no chain call) for every other status and for
-// unpublished drafts. Unlike encryption keys it is not cached: RESULTS is terminal so the read is
-// bounded, and caching would need a db type/method — add one if this read ever gets hot.
+// resolveQuestionResults returns a question's live on-chain tally for any published (on-chain)
+// question — the caller distinguishes live from final via QuestionResults.FinalResults. It is a no-op
+// (nil, no chain call) only for an unpublished draft (no UpstreamID). A secretUntilTheEnd question
+// returns empty results until the keys are revealed (the node hides the tally, not this gate).
+//
+// ponytail: not cached, so a live read hits the chain per poll (one Election call per published
+// question); add a short-TTL cache if this read gets hot — /results already does the same per poll.
 func (a *API) resolveQuestionResults(q *db.VotingProcessQuestion) *db.QuestionResults {
-	// gate: only surface results for questions the chain has moved to RESULTS; keeps others chain-free.
-	if q.Status != db.QuestionStatusResults {
-		return nil
-	}
+	// nothing on chain yet (draft) — no results.
 	if len(q.UpstreamID) == 0 {
 		return nil
 	}

--- a/api/processes.go
+++ b/api/processes.go
@@ -389,6 +389,12 @@ func (a *API) listVotingProcessesHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	orgAddress := common.HexToAddress(orgAddressStr)
+	// IsHexAddress accepts the zero address; reject it as malformed (400) so it never reaches the db
+	// layer (which errors on it and would otherwise surface as a 500 on this now-public endpoint).
+	if orgAddress == (common.Address{}) {
+		errors.ErrMalformedURLParam.Withf("invalid orgAddress").Write(w)
+		return
+	}
 	// public read: anonymous callers see published processes only; a manager/admin of the org (or a
 	// voting:write API key acting as one) also sees drafts (and keeps the per-question eligibility).
 	isManager := a.optionalManager(r, orgAddress)

--- a/api/processes_test.go
+++ b/api/processes_test.go
@@ -190,11 +190,14 @@ func TestVotingProcessAuthoringErrors(t *testing.T) {
 	requestAndAssertCode(http.StatusUnauthorized, t, http.MethodPost, otherToken,
 		newVotingProcessRequest(orgAddress, ids), processesCreateEndpoint)
 
-	// unauthenticated read of a process -> 401
+	// a draft is hidden from an anonymous caller (the single read is public, but drafts 404 for
+	// non-managers so their existence isn't revealed).
 	created := requestAndParse[apicommon.CreateVotingProcessResponse](
 		t, http.MethodPost, adminToken, newVotingProcessRequest(orgAddress, ids), processesCreateEndpoint,
 	)
-	requestAndAssertCode(http.StatusUnauthorized, t, http.MethodGet, "", nil, "processes", created.ProcessID)
+	requestAndAssertCode(http.StatusNotFound, t, http.MethodGet, "", nil, "processes", created.ProcessID)
+	// ...and from an authenticated user with no role on the org.
+	requestAndAssertCode(http.StatusNotFound, t, http.MethodGet, otherToken, nil, "processes", created.ProcessID)
 }
 
 // TestVotingProcessEmptyCensusRejected verifies the preflight rejects a process whose census has
@@ -273,6 +276,11 @@ func TestVotingProcessAPIKeyAuth(t *testing.T) {
 	)
 	c.Assert(proc.ProcessID, qt.Not(qt.Equals), "")
 
+	// the voting:write key reads its managed org's DRAFT via the now-public single read (optionalManager
+	// resolves the key to its admin user); anonymous callers get 404 (the draft's existence is hidden).
+	requestAndAssertCode(http.StatusOK, t, http.MethodGet, apiKey, nil, "processes", proc.ProcessID)
+	requestAndAssertCode(http.StatusNotFound, t, http.MethodGet, "", nil, "processes", proc.ProcessID)
+
 	// a key without voting:write is refused (403)
 	noScopeBody := &apicommon.CreateAPIKeyRequest{Label: "noscope", Scopes: []string{ScopeManagedRead}}
 	data, code = testRequest(t, http.MethodPost, token, noScopeBody, "integrator", "organizations", orgAddr.String(), "apikeys")
@@ -281,6 +289,8 @@ func TestVotingProcessAPIKeyAuth(t *testing.T) {
 	c.Assert(json.Unmarshal(data, &noScope), qt.IsNil)
 	requestAndAssertCode(http.StatusForbidden, t, http.MethodPost, noScope.Secret,
 		minimalVotingProcessRequest(managed.Address), processesCreateEndpoint)
+	// a key without voting:write is treated as anonymous on the public read, so the draft is 404.
+	requestAndAssertCode(http.StatusNotFound, t, http.MethodGet, noScope.Secret, nil, "processes", proc.ProcessID)
 }
 
 // TestVotingProcessPublishPreflight verifies the publish-readiness dry-run now catches plan
@@ -418,6 +428,89 @@ func TestVotingProcessResults(t *testing.T) {
 	c.Assert(res.Questions[1].Results, qt.DeepEquals, [][]string{{"0", "0"}, {"0", "0"}})
 	c.Assert(res.Questions[0].MaxVoters, qt.Equals, uint64(2)) // whole census
 	c.Assert(res.Questions[1].MaxVoters, qt.Equals, uint64(1)) // eligibility subset of one
+
+	// live results: the inline reads now surface the tally for a published (non-RESULTS) question too,
+	// with finalResults=false — the old gate would have left results nil until RESULTS.
+	info := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", created.ProcessID)
+	c.Assert(info.Questions, qt.HasLen, 2)
+	for _, q := range info.Questions {
+		c.Assert(q.Results, qt.Not(qt.IsNil), qt.Commentf("question %s missing live results", q.ID.Hex()))
+		c.Assert(q.Results.FinalResults, qt.IsFalse)
+	}
+	pub := requestAndParse[apicommon.PublicQuestionResponse](
+		t, http.MethodGet, "", nil, "processes", created.ProcessID, "questions", info.Questions[0].ID.Hex())
+	c.Assert(pub.Results, qt.Not(qt.IsNil))
+	c.Assert(pub.Results.FinalResults, qt.IsFalse)
+}
+
+// TestVotingProcessPublicReads verifies the process list and single read are public for published
+// processes (with per-question eligibleMemberIds stripped for non-managers), while drafts and the
+// eligibility are visible only to a manager/admin of the org.
+func TestVotingProcessPublicReads(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateProvisionedOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+	otherToken := testCreateUser(t, "otherpass123") // a user with no role in the org
+
+	// a published process (Q2 = multichoice, restricts eligibility to the first member)
+	pubReq := newVotingProcessRequest(orgAddress, ids)
+	pubReq.StartDate = ""
+	published := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, pubReq, processesCreateEndpoint)
+	job := enqueueAndPollJob(t, http.MethodPost, token, nil, "processes", published.ProcessID, "publish")
+	c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("publish error: %s", job.Errors))
+
+	// a draft, kept unpublished
+	draft := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, newVotingProcessRequest(orgAddress, ids), processesCreateEndpoint)
+
+	// eligibility of the restricted (multichoice) question in a hydrated response
+	restrictedEligibility := func(qs []db.VotingProcessQuestion) []string {
+		for _, q := range qs {
+			if q.Type == db.VotingTypeMultiChoice {
+				return q.EligibleMemberIDs
+			}
+		}
+		return nil
+	}
+	hasProcess := func(ps []apicommon.VotingProcessResponse, id string) bool {
+		for _, p := range ps {
+			if p.ID == id {
+				return true
+			}
+		}
+		return false
+	}
+
+	// anonymous single read of the PUBLISHED process: 200, eligibility stripped; manager sees it.
+	anon := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, "", nil, "processes", published.ProcessID)
+	c.Assert(anon.Questions, qt.HasLen, 2)
+	c.Assert(restrictedEligibility(anon.Questions), qt.HasLen, 0)
+	mgr := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", published.ProcessID)
+	c.Assert(restrictedEligibility(mgr.Questions), qt.HasLen, 1)
+
+	// the DRAFT is hidden (404) from anonymous and a non-manager user; the manager sees it with eligibility.
+	requestAndAssertCode(http.StatusNotFound, t, http.MethodGet, "", nil, "processes", draft.ProcessID)
+	requestAndAssertCode(http.StatusNotFound, t, http.MethodGet, otherToken, nil, "processes", draft.ProcessID)
+	draftMgr := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", draft.ProcessID)
+	c.Assert(restrictedEligibility(draftMgr.Questions), qt.HasLen, 1)
+
+	// anonymous list: only the published process, eligibility stripped.
+	listURL := fmt.Sprintf("processes?orgAddress=%s&limit=100", orgAddress.Hex())
+	anonList := requestAndParse[apicommon.VotingProcessListResponse](t, http.MethodGet, "", nil, listURL)
+	c.Assert(hasProcess(anonList.Processes, published.ProcessID), qt.IsTrue)
+	c.Assert(hasProcess(anonList.Processes, draft.ProcessID), qt.IsFalse)
+	for _, p := range anonList.Processes {
+		c.Assert(restrictedEligibility(p.Questions), qt.HasLen, 0)
+	}
+
+	// manager list: both the published process and the draft.
+	mgrList := requestAndParse[apicommon.VotingProcessListResponse](t, http.MethodGet, token, nil, listURL)
+	c.Assert(hasProcess(mgrList.Processes, published.ProcessID), qt.IsTrue)
+	c.Assert(hasProcess(mgrList.Processes, draft.ProcessID), qt.IsTrue)
 }
 
 // TestVotingProcessPublicQuestionCensus verifies the public single-question read of a PUBLISHED

--- a/api/processes_test.go
+++ b/api/processes_test.go
@@ -511,6 +511,10 @@ func TestVotingProcessPublicReads(t *testing.T) {
 	mgrList := requestAndParse[apicommon.VotingProcessListResponse](t, http.MethodGet, token, nil, listURL)
 	c.Assert(hasProcess(mgrList.Processes, published.ProcessID), qt.IsTrue)
 	c.Assert(hasProcess(mgrList.Processes, draft.ProcessID), qt.IsTrue)
+
+	// a zero orgAddress passes IsHexAddress but is malformed -> 400 (not a 500 from the db layer).
+	requestAndAssertCode(http.StatusBadRequest, t, http.MethodGet, "", nil,
+		"processes?orgAddress=0x0000000000000000000000000000000000000000")
 }
 
 // TestVotingProcessPublicQuestionCensus verifies the public single-question read of a PUBLISHED

--- a/db/types.go
+++ b/db/types.go
@@ -619,7 +619,7 @@ type VotingProcessQuestion struct {
 	TypeSetup         QuestionTypeSetup  `json:"typeSetup" bson:"typeSetup"`
 	BallotProtocol    *BallotProtocol    `json:"ballotProtocol,omitempty" bson:"ballotProtocol,omitempty"`
 	SecretUntilTheEnd bool               `json:"secretUntilTheEnd" bson:"secretUntilTheEnd"`
-	EligibleMemberIDs []string           `json:"eligibleMemberIds" bson:"eligibleMemberIds"`
+	EligibleMemberIDs []string           `json:"eligibleMemberIds,omitempty" bson:"eligibleMemberIds"`
 	Metadata          map[string]any     `json:"metadata,omitempty" bson:"metadata,omitempty"`
 	UpstreamID        internal.HexBytes  `json:"upstreamId,omitempty" bson:"upstreamId,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`
 	MetadataURL       string             `json:"-" bson:"metadataURL,omitempty"`
@@ -630,11 +630,12 @@ type VotingProcessQuestion struct {
 	// JSON field is absent (not an empty array) until the keykeepers publish the keys, so clients
 	// treat its absence as "not yet published" and poll. Voters seal encrypted vote packages with these.
 	EncryptionKeys []EncryptionKey `json:"encryptionKeys,omitempty" bson:"encryptionKeys,omitempty"`
-	// Results is this question's on-chain tally, resolved on read only when the question is in RESULTS
-	// status (absent otherwise). Not persisted (bson:"-") — recomputed from the chain each read. Only
-	// the single reads resolve it (GET /processes/{id} and the public question read); the list endpoint
-	// leaves it nil to avoid an N+1 chain fan-out, so its absence in a LIST response means "not resolved
-	// here", not "not final" — poll the single read for that.
+	// Results is this question's live on-chain tally, resolved on read for any published (on-chain)
+	// question; FinalResults marks live vs final (absent while a secretUntilTheEnd election is still
+	// encrypted, or before any vote). Not persisted (bson:"-") — recomputed from the chain each read.
+	// Only the single reads resolve it (GET /processes/{id} and the public question read); the list
+	// endpoint leaves it nil to avoid an N+1 chain fan-out, so its absence in a LIST response means "not
+	// resolved here", not "not final" — poll the single read for that.
 	Results *QuestionResults `json:"results,omitempty" bson:"-"`
 }
 

--- a/db/types.go
+++ b/db/types.go
@@ -631,11 +631,13 @@ type VotingProcessQuestion struct {
 	// treat its absence as "not yet published" and poll. Voters seal encrypted vote packages with these.
 	EncryptionKeys []EncryptionKey `json:"encryptionKeys,omitempty" bson:"encryptionKeys,omitempty"`
 	// Results is this question's live on-chain tally, resolved on read for any published (on-chain)
-	// question; FinalResults marks live vs final (absent while a secretUntilTheEnd election is still
-	// encrypted, or before any vote). Not persisted (bson:"-") — recomputed from the chain each read.
-	// Only the single reads resolve it (GET /processes/{id} and the public question read); the list
-	// endpoint leaves it nil to avoid an N+1 chain fan-out, so its absence in a LIST response means "not
-	// resolved here", not "not final" — poll the single read for that.
+	// question; FinalResults marks live vs final. The results object itself is present whenever the
+	// question is published — it's the inner per-choice matrix (QuestionResults.Results) that is omitted
+	// until a tally exists (empty while a secretUntilTheEnd election is still encrypted, or before any
+	// vote). The whole object is absent (omitempty) only for a draft (no election yet). Not persisted
+	// (bson:"-") — recomputed from the chain each read. Only the single reads resolve it (GET
+	// /processes/{id} and the public question read); the list endpoint leaves it nil to avoid an N+1
+	// chain fan-out, so its absence in a LIST response means "not resolved here", not "not published".
 	Results *QuestionResults `json:"results,omitempty" bson:"-"`
 }
 

--- a/db/voting_processes.go
+++ b/db/voting_processes.go
@@ -94,16 +94,25 @@ func (ms *MongoStorage) DeleteVotingProcess(id primitive.ObjectID) error {
 	return nil
 }
 
-// ListVotingProcesses returns a paginated list of voting processes for an organization.
-// When questionStatus is non-empty, only processes that have at least one question in
-// that status are returned.
+// ListVotingProcesses returns a paginated list of voting processes for an organization, filtered by
+// draft state (PublishedOnly serves the public/non-manager view; AllProcesses the manager view).
+// When questionStatus is non-empty, only processes that have at least one question in that status
+// are returned.
 func (ms *MongoStorage) ListVotingProcesses(
-	orgAddress common.Address, questionStatus string, page, limit int64,
+	orgAddress common.Address, questionStatus string, draft DraftFilter, page, limit int64,
 ) (int64, []VotingProcess, error) {
 	if orgAddress.Cmp(common.Address{}) == 0 {
 		return 0, nil, ErrInvalidData
 	}
 	filter := bson.M{"orgAddress": orgAddress} //nolint:goconst
+	switch draft {
+	case DraftOnly:
+		filter["published"] = false
+	case PublishedOnly:
+		filter["published"] = true
+	default:
+		// AllProcesses — no published filter
+	}
 	if questionStatus != "" {
 		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 		defer cancel()

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1313,8 +1313,9 @@ definitions:
         allOf:
         - $ref: '#/definitions/db.QuestionResults'
         description: |-
-          Results is this question's on-chain tally, present only once the question reaches RESULTS status
-          (absent otherwise via omitempty), so clients treat its absence as "not yet final" and poll.
+          Results is this question's live on-chain tally, present for any published question; FinalResults
+          marks live vs final. Absent (via omitempty) while a secretUntilTheEnd election is still encrypted
+          or before any vote, so clients treat its absence as "nothing to show yet" and poll.
       secretUntilTheEnd:
         type: boolean
       status:
@@ -2332,11 +2333,12 @@ definitions:
         allOf:
         - $ref: '#/definitions/db.QuestionResults'
         description: |-
-          Results is this question's on-chain tally, resolved on read only when the question is in RESULTS
-          status (absent otherwise). Not persisted (bson:"-") — recomputed from the chain each read. Only
-          the single reads resolve it (GET /processes/{id} and the public question read); the list endpoint
-          leaves it nil to avoid an N+1 chain fan-out, so its absence in a LIST response means "not resolved
-          here", not "not final" — poll the single read for that.
+          Results is this question's live on-chain tally, resolved on read for any published (on-chain)
+          question; FinalResults marks live vs final (absent while a secretUntilTheEnd election is still
+          encrypted, or before any vote). Not persisted (bson:"-") — recomputed from the chain each read.
+          Only the single reads resolve it (GET /processes/{id} and the public question read); the list
+          endpoint leaves it nil to avoid an N+1 chain fan-out, so its absence in a LIST response means "not
+          resolved here", not "not final" — poll the single read for that.
       secretUntilTheEnd:
         type: boolean
       status:
@@ -5828,7 +5830,10 @@ paths:
       - csp
   /processes:
     get:
-      description: Paginated list of an organization's voting processes (protected).
+      description: |-
+        Paginated list of an organization's voting processes. Public: anonymous callers get
+        published processes only (without per-question eligibleMemberIds). A Manager/Admin of
+        the org (or a voting:write API key acting as one) also gets drafts and the eligibility.
         Filter by question status.
       parameters:
       - description: Organization address
@@ -5855,12 +5860,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/apicommon.VotingProcessListResponse'
-        "401":
-          description: Unauthorized
+        "400":
+          description: Bad Request
           schema:
             $ref: '#/definitions/errors.Error'
-      security:
-      - BearerAuth: []
       summary: List voting processes
       tags:
       - processes
@@ -5944,8 +5947,11 @@ paths:
       tags:
       - processes
     get:
-      description: Read a voting process with its fully hydrated questions (protected
-        read).
+      description: |-
+        Read a voting process with its hydrated questions (live per-question results included).
+        Public for published processes; a draft is visible only to a Manager/Admin of the org
+        (or a voting:write API key acting as one) and returns 404 otherwise. Non-managers never
+        receive the per-question eligibleMemberIds.
       parameters:
       - description: Process ID
         in: path
@@ -5959,16 +5965,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/apicommon.VotingProcessResponse'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/errors.Error'
         "404":
           description: Not Found
           schema:
             $ref: '#/definitions/errors.Error'
-      security:
-      - BearerAuth: []
       summary: Get a voting process
       tags:
       - processes

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1313,9 +1313,11 @@ definitions:
         allOf:
         - $ref: '#/definitions/db.QuestionResults'
         description: |-
-          Results is this question's live on-chain tally, present for any published question; FinalResults
-          marks live vs final. Absent (via omitempty) while a secretUntilTheEnd election is still encrypted
-          or before any vote, so clients treat its absence as "nothing to show yet" and poll.
+          Results is this question's live on-chain tally, present (non-null) for any published question and
+          carrying voteCount/maxVoters/finalResults; FinalResults marks live vs final. The inner per-choice
+          matrix (results.results) is omitted until a tally exists — empty while a secretUntilTheEnd election
+          is still encrypted or before any vote — so clients poll on an empty tally. The whole object is
+          absent (omitempty) only for a draft (no election yet).
       secretUntilTheEnd:
         type: boolean
       status:
@@ -2334,11 +2336,13 @@ definitions:
         - $ref: '#/definitions/db.QuestionResults'
         description: |-
           Results is this question's live on-chain tally, resolved on read for any published (on-chain)
-          question; FinalResults marks live vs final (absent while a secretUntilTheEnd election is still
-          encrypted, or before any vote). Not persisted (bson:"-") — recomputed from the chain each read.
-          Only the single reads resolve it (GET /processes/{id} and the public question read); the list
-          endpoint leaves it nil to avoid an N+1 chain fan-out, so its absence in a LIST response means "not
-          resolved here", not "not final" — poll the single read for that.
+          question; FinalResults marks live vs final. The results object itself is present whenever the
+          question is published — it's the inner per-choice matrix (QuestionResults.Results) that is omitted
+          until a tally exists (empty while a secretUntilTheEnd election is still encrypted, or before any
+          vote). The whole object is absent (omitempty) only for a draft (no election yet). Not persisted
+          (bson:"-") — recomputed from the chain each read. Only the single reads resolve it (GET
+          /processes/{id} and the public question read); the list endpoint leaves it nil to avoid an N+1
+          chain fan-out, so its absence in a LIST response means "not resolved here", not "not published".
       secretUntilTheEnd:
         type: boolean
       status:


### PR DESCRIPTION
## What

Two related improvements to the new `/processes` API.

### 1. Live results (remove the RESULTS-status gate)
`resolveQuestionResults` only surfaced a question's tally once its stored status was `RESULTS`, so clients couldn't poll live/partial results while voting was open — even though `finalResults` exists to mark live-vs-final. Dropped the gate: the inline reads (`GET /processes/{id}` and `GET /processes/{id}/questions/{qid}`) now return the **live** tally for any published question, `finalResults` marking final. `GET /processes/{id}/results` was already live.

**Encrypted questions stay safe:** the dvote node hides per-choice tallies for `secretUntilTheEnd` elections until reveal (`HaveResults = !EncryptedVotes`) — before RESULTS it returns empty `results` + `finalResults:false` (only `voteCount` ticks up). No SaaS-side leak.

### 2. Public, draft-gated reads
`GET /processes/{processId}` and `GET /processes` (list) are now **public**:
- **Published** processes are readable by anyone.
- **Drafts** are visible only to a **Manager/Admin** of the org (or a `voting:write` API key acting as one). The single read returns **404** for everyone else (hides existence); the list returns published-only.
- **`eligibleMemberIds`** (the per-question list of who may vote) is **stripped** for non-managers — the one manager-only field the full response would otherwise leak. Voters get their *own* per-question eligibility (`canVote`) via the CSP `POST /processes/{id}/check` endpoint, so nothing is lost.

Authorization is resolved via a new `optionalManager` (JWT session **or** `voting:write` API key → its creating user's role), mirroring the existing `optionalUser`/`jobStatusHandler` pattern.

## Notable details
- `db.ListVotingProcesses` gains a `DraftFilter` (reusing the enum `CountVotingProcesses` already uses); non-managers get `PublishedOnly`, managers `AllProcesses`.
- `db.VotingProcessQuestion.EligibleMemberIDs` gains `omitempty` (stripped → absent, not `null`; whole-census questions were already empty).
- The two GET routes moved from the protected group to the public group; their now-dead `apiKeyAllowlist` entries removed (API-key access is handled in-handler).
- `// ponytail:` note: live inline reads now hit the chain per poll per published question (same as `/results`); a short-TTL cache is the upgrade path if it gets hot.

## Tests
- `TestVotingProcessResults` extended: the inline manager + public question reads now expose live results (`finalResults:false`) for a published, pre-RESULTS process.
- New `TestVotingProcessPublicReads`: anonymous published read (eligibility stripped) vs manager (eligibility present); draft → 404 for anonymous/other-user, 200 for manager; anonymous list = published-only + stripped, manager list = includes drafts.
- `TestVotingProcessAPIKeyAuth` extended: a `voting:write` key reads its managed org's **draft** via the public read; anonymous and no-scope keys get 404.
- `TestVotingProcessAuthoringErrors`: anonymous/other-user GET of a draft updated `401 → 404`.
- Regenerated `docs/swagger.yaml`. `go build`/`vet`/`golangci-lint` clean; `go test ./api/...` (process suites) green.

## Security note
Making these reads public deliberately exposes **published** process data (titles, choices, census config + size, live results) to anonymous callers — this is voter-facing data. The only PII-sensitive field (`eligibleMemberIds`) is redacted for non-managers, matching the existing public question read's allow-list.