### PR TITLE
fix(members): take the org name for import emails from the database

### DIFF
--- a/api/apicommon/multilingual_test.go
+++ b/api/apicommon/multilingual_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/db"
 )
 
 func TestMultilingualTextUnmarshal(t *testing.T) {
@@ -57,15 +58,20 @@ func TestBuildOrgMeta(t *testing.T) {
 
 	// only name
 	m := BuildOrgMeta(nil, &name, nil, nil, nil)
-	c.Assert(m["name"], qt.DeepEquals, MultilingualText{"default": "Acme"})
+	c.Assert(m["name"], qt.DeepEquals, map[string]string{"default": "Acme"})
 	_, hasLogo := m["logo"]
 	c.Assert(hasLogo, qt.IsFalse)
 
 	// all three fields
 	m = BuildOrgMeta(nil, &name, &logo, &desc, nil)
-	c.Assert(m["name"], qt.DeepEquals, MultilingualText{"default": "Acme"})
-	c.Assert(m["logo"], qt.DeepEquals, MultilingualText{"default": "https://acme.com/logo.png"})
-	c.Assert(m["description"], qt.DeepEquals, MultilingualText{"default": "We make things"})
+	c.Assert(m["name"], qt.DeepEquals, map[string]string{"default": "Acme"})
+	c.Assert(m["logo"], qt.DeepEquals, map[string]string{"default": "https://acme.com/logo.png"})
+	c.Assert(m["description"], qt.DeepEquals, map[string]string{"default": "We make things"})
+
+	// db accessors must resolve the shorthand values before any Mongo round-trip
+	org := &db.Organization{Meta: m}
+	c.Assert(org.DisplayName(), qt.Equals, "Acme")
+	c.Assert(org.LogoURL(), qt.Equals, "https://acme.com/logo.png")
 
 	// explicit meta wins over shorthand
 	explicit := map[string]any{"name": MultilingualText{"default": "Override"}, "extra": "val"}
@@ -87,7 +93,7 @@ func TestBuildOrgMeta(t *testing.T) {
 	// base keys are preserved and shorthands override them; explicit wins last
 	base := map[string]any{"name": MultilingualText{"default": "Old"}, "keep": "me"}
 	m = BuildOrgMeta(base, &name, nil, nil, nil)
-	c.Assert(m["name"], qt.DeepEquals, MultilingualText{"default": "Acme"})
+	c.Assert(m["name"], qt.DeepEquals, map[string]string{"default": "Acme"})
 	c.Assert(m["keep"], qt.Equals, "me")
 }
 

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -94,14 +94,16 @@ func OrgDisplayName(meta map[string]any, fallback string) string {
 func BuildOrgMeta(base map[string]any, name, logo, description *MultilingualText, explicit map[string]any) map[string]any {
 	meta := make(map[string]any, len(base))
 	maps.Copy(meta, base)
+	// stored as unnamed map[string]string so db.Organization accessors
+	// (DisplayName/LogoURL) match the value before any Mongo round-trip
 	if name != nil {
-		meta["name"] = *name
+		meta["name"] = map[string]string(*name)
 	}
 	if logo != nil {
-		meta["logo"] = *logo
+		meta["logo"] = map[string]string(*logo)
 	}
 	if description != nil {
-		meta["description"] = *description
+		meta["description"] = map[string]string(*description)
 	}
 	maps.Copy(meta, explicit)
 	return meta

--- a/api/org_members.go
+++ b/api/org_members.go
@@ -41,13 +41,14 @@ func (a *API) sendMembersImportCompletionEmail(userEmail, userName string, org *
 	// Import the mailtemplates package dynamically to avoid import issues
 	// We'll use the sendMail method which handles the template execution
 	data := MembersImportCompletionData{
-		UserName:     userName,
-		TotalMembers: progress.Total,
-		AddedMembers: progress.Added,
-		Link:         link,
-		ErrorCount:   len(progress.Errors),
-		Errors:       progress.ErrorsAsStrings(),
-		CompletedAt:  time.Now(),
+		OrganizationName: org.DisplayName(),
+		UserName:         userName,
+		TotalMembers:     progress.Total,
+		AddedMembers:     progress.Added,
+		Link:             link,
+		ErrorCount:       len(progress.Errors),
+		Errors:           progress.ErrorsAsStrings(),
+		CompletedAt:      time.Now(),
 	}
 
 	// Create a background context for email sending

--- a/api/org_members_test.go
+++ b/api/org_members_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/vocdoni/saas-backend/errors"
 	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.vocdoni.io/dvote/api"
 )
 
 func TestOrganizationMembers(t *testing.T) {
@@ -797,49 +796,5 @@ func TestUpsertOrganizationMember(t *testing.T) {
 			Email:        members[1].Email,
 			Phone:        members[1].Phone,
 		})
-	})
-	c.Run("TestParsingVochainMetadata", func(c *qt.C) {
-		validMetadataJSON := `{
-			"version": "1.0",  
-			"name": {  
-				"default": "TestCSPORg"
-			},  
-			"description": {  
-				"default": ""
-			},  
-			"newsFeed": {  
-				"default": ""
-			},  
-			"media": {
-				"avatar": "https://example.com/logo.png"
-			},  
-			"meta": {} 
-		}`
-		var validMetadata api.AccountMetadata
-		err := json.Unmarshal([]byte(validMetadataJSON), &validMetadata)
-		c.Assert(err, qt.IsNil)
-		name, logo := db.ParseVochainOrganizationMeta(&validMetadata)
-		c.Assert(name, qt.Equals, "TestCSPORg")
-		c.Assert(logo, qt.Equals, "https://example.com/logo.png")
-
-		emptyMetadataJSON := `{
-			"version": "1.0",  
-			"name": {  
-			},  
-			"description": {  
-				"default": ""  
-			},  
-			"newsFeed": {  
-				"default": ""  
-			},  
-			"media": {},  
-			"meta": {}  
-		} `
-		var emptyMetadata api.AccountMetadata
-		err = json.Unmarshal([]byte(emptyMetadataJSON), &emptyMetadata)
-		c.Assert(err, qt.IsNil)
-		name, logo = db.ParseVochainOrganizationMeta(&emptyMetadata)
-		c.Assert(name, qt.Equals, "")
-		c.Assert(logo, qt.Equals, "")
 	})
 }

--- a/api/organization_users.go
+++ b/api/organization_users.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-chi/chi/v5"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
@@ -176,10 +175,10 @@ func (a *API) inviteOrganizationUserHandler(w http.ResponseWriter, r *http.Reque
 	// the invite link
 	if err := a.sendMail(r.Context(), invite.Email, mailtemplates.InviteNotification,
 		struct {
-			Organization common.Address
+			Organization string
 			Code         string
 			Link         string
-		}{org.Address, code, link},
+		}{apicommon.OrgDisplayName(org.Meta, org.Address.String()), code, link},
 		time.Now().Add(apicommon.InvitationExpiration),
 	); err != nil {
 		// in this case we don't DecrementOrganizationUsersCounter because the invite was actually created,
@@ -386,10 +385,10 @@ func (a *API) updatePendingUserInvitationHandler(w http.ResponseWriter, r *http.
 	// the invite link
 	if err := a.sendMail(r.Context(), orgInvite.NewUserEmail, mailtemplates.InviteNotification,
 		struct {
-			Organization common.Address
+			Organization string
 			Code         string
 			Link         string
-		}{org.Address, code, link},
+		}{apicommon.OrgDisplayName(org.Meta, org.Address.String()), code, link},
 		time.Now().Add(apicommon.InvitationExpiration),
 	); err != nil {
 		log.Warnw("could not send verification code email", "error", err)

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -480,11 +480,17 @@ func (a *API) organizationCreateTicket(w http.ResponseWriter, r *http.Request) {
 	notification, err := mailtemplates.SupportNotification.Localized(lang).ExecTemplate(
 		struct {
 			Type         string
-			Organization common.Address
+			Organization string
 			Title        string
 			Description  string
 			Email        string
-		}{ticketReq.TicketType, org.Address, ticketReq.Title, ticketReq.Description, user.Email},
+		}{
+			Type:         ticketReq.TicketType,
+			Organization: apicommon.OrgDisplayName(org.Meta, org.Address.String()),
+			Title:        ticketReq.Title,
+			Description:  ticketReq.Description,
+			Email:        user.Email,
+		},
 	)
 	if err != nil {
 		log.Warnw("could not execute support notification template", "error", err)

--- a/assets/members_import_done_ca.html
+++ b/assets/members_import_done_ca.html
@@ -356,7 +356,7 @@
                             </p>
                             
                             <p class="body-text">
-                                La importació de membres per a l'organització "<strong>{{.Organization}}</strong>" s'ha completat amb èxit.
+                                La importació de membres{{if .OrganizationName}} per a l'organització "<strong>{{.OrganizationName}}</strong>"{{end}} s'ha completat amb èxit.
                             </p>
                             
                             <div class="summary-box">

--- a/assets/members_import_done_ca.yaml
+++ b/assets/members_import_done_ca.yaml
@@ -1,8 +1,8 @@
-subject: "Importació de membres completada per {{.OrganizationName}}"
+subject: "Importació de membres completada{{if .OrganizationName}} per a {{.OrganizationName}}{{end}}"
 body: |
   Hola {{.UserName}},
 
-  La importació de membres per a l'organització "{{.OrganizationName}}" s'ha completat.
+  La importació de membres{{if .OrganizationName}} per a l'organització "{{.OrganizationName}}"{{end}} s'ha completat.
 
   Resum de la importació:
   - Total de membres processats: {{.TotalMembers}}

--- a/assets/members_import_done_en.html
+++ b/assets/members_import_done_en.html
@@ -356,7 +356,7 @@
                             </p>
                             
                             <p class="body-text">
-                                Your member import{{if .OrganizationName}} for organization "<strong>{{.OrganizationName}}</strong>"{{end}} has been completed successfully.
+                                Your members import{{if .OrganizationName}} for organization "<strong>{{.OrganizationName}}</strong>"{{end}} has been completed successfully.
                             </p>
                             
                             <div class="summary-box">

--- a/assets/members_import_done_en.html
+++ b/assets/members_import_done_en.html
@@ -356,7 +356,7 @@
                             </p>
                             
                             <p class="body-text">
-                                Your member import has been completed successfully.
+                                Your member import{{if .OrganizationName}} for organization "<strong>{{.OrganizationName}}</strong>"{{end}} has been completed successfully.
                             </p>
                             
                             <div class="summary-box">

--- a/assets/members_import_done_en.yaml
+++ b/assets/members_import_done_en.yaml
@@ -1,8 +1,8 @@
-subject: "Members import completed for {{.OrganizationName}}"
+subject: "Members import completed{{if .OrganizationName}} for {{.OrganizationName}}{{end}}"
 body: |
   Hello {{.UserName}},
 
-  Your members import for organization "{{.OrganizationName}}" has been completed.
+  Your members import{{if .OrganizationName}} for organization "{{.OrganizationName}}"{{end}} has been completed.
 
   Import Summary:
   - Total members processed: {{.TotalMembers}}

--- a/assets/members_import_done_es.html
+++ b/assets/members_import_done_es.html
@@ -356,7 +356,7 @@
                             </p>
                             
                             <p class="body-text">
-                                La importación de miembros para la organización "<strong>{{.Organization}}</strong>" se ha completado exitosamente.
+                                La importación de miembros{{if .OrganizationName}} para la organización "<strong>{{.OrganizationName}}</strong>"{{end}} se ha completado exitosamente.
                             </p>
                             
                             <div class="summary-box">

--- a/assets/members_import_done_es.yaml
+++ b/assets/members_import_done_es.yaml
@@ -1,8 +1,8 @@
-subject: "Importación de miembros completada para {{.OrganizationName}}"
+subject: "Importación de miembros completada{{if .OrganizationName}} para {{.OrganizationName}}{{end}}"
 body: |
   Hola {{.UserName}},
 
-  La importación de miembros para la organización "{{.OrganizationName}}" se ha completado exitosamente.
+  La importación de miembros{{if .OrganizationName}} para la organización "{{.OrganizationName}}"{{end}} se ha completado exitosamente.
 
   Resumen de la importación:
   - Total de miembros procesados: {{.TotalMembers}}

--- a/csp/handlers/handlers.go
+++ b/csp/handlers/handlers.go
@@ -265,16 +265,7 @@ func (c *CSPHandlers) BundleAuthResendHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	name := DefaultOrgName
-	logo := DefaultOrgLogo
-
-	if n, ok := org.Meta["name"].(string); ok {
-		name = n
-		// if name is found then retrieve the logo as well
-		if l, ok := org.Meta["logo"].(string); ok {
-			logo = l
-		}
-	}
+	name, logo := orgNameAndLogo(org)
 
 	// Resend the challenge with the same token and new contact information
 	if err := c.csp.ResendChallenge(req.AuthToken, toDestination, challengeType, lang, name, logo, org.Address); err != nil {
@@ -934,16 +925,7 @@ func (c *CSPHandlers) authFirstStep(
 		return nil, err
 	}
 
-	name := DefaultOrgName
-	logo := DefaultOrgLogo
-
-	if n, ok := org.Meta["name"].(string); ok {
-		name = n
-		// if name is found then retrieve the logo as well
-		if l, ok := org.Meta["logo"].(string); ok {
-			logo = l
-		}
-	}
+	name, logo := orgNameAndLogo(org)
 
 	// Generate the token
 	return c.csp.BundleAuthToken(

--- a/csp/handlers/processes.go
+++ b/csp/handlers/processes.go
@@ -424,7 +424,7 @@ func orgNameAndLogo(org *db.Organization) (name, logo string) {
 	name, logo = DefaultOrgName, DefaultOrgLogo
 	if n := org.DisplayName(); n != "" {
 		name = n
-		if l, ok := org.Meta["logo"].(string); ok {
+		if l := org.LogoURL(); l != "" {
 			logo = l
 		}
 	}

--- a/csp/handlers/processes.go
+++ b/csp/handlers/processes.go
@@ -422,7 +422,7 @@ func (c *CSPHandlers) orgMember(orgAddress common.Address, auth *db.CSPAuth) (*d
 // orgNameAndLogo returns the organization display name and logo, falling back to defaults.
 func orgNameAndLogo(org *db.Organization) (name, logo string) {
 	name, logo = DefaultOrgName, DefaultOrgLogo
-	if n, ok := org.Meta["name"].(string); ok {
+	if n := org.DisplayName(); n != "" {
 		name = n
 		if l, ok := org.Meta["logo"].(string); ok {
 			logo = l

--- a/db/helpers.go
+++ b/db/helpers.go
@@ -9,7 +9,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/log"
 )
 
@@ -127,21 +126,4 @@ func paginatedDocuments[T any](collection *mongo.Collection, page, limit int64,
 	}
 
 	return totalCount, list, nil
-}
-
-func ParseVochainOrganizationMeta(meta *api.AccountMetadata) (name string, logo string) {
-	if meta == nil {
-		return "", ""
-	}
-	// get the organization name
-	if meta.Name != nil {
-		if n, ok := meta.Name["default"]; ok {
-			name = n
-		}
-	}
-	// get the organization logo
-	if meta.Media != nil {
-		logo = meta.Media.Avatar
-	}
-	return name, logo
 }

--- a/db/organizations_test.go
+++ b/db/organizations_test.go
@@ -1,12 +1,10 @@
 package db
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
 	qt "github.com/frankban/quicktest"
-	vocapi "go.vocdoni.io/dvote/api"
 )
 
 func TestOrganizations(t *testing.T) {
@@ -82,26 +80,7 @@ func TestOrganizations(t *testing.T) {
 			Address: newOrgAddress,
 			Creator: testUserEmail,
 		}), qt.IsNil)
-		validMetadataJSON := `{
-			"version": "1.0",  
-			"name": {  
-				"default": "TestCSPORg"
-			},  
-			"description": {  
-				"default": ""
-			},  
-			"newsFeed": {  
-				"default": ""
-			},  
-			"media": {
-				"avatar": "https://example.com/logo.png"
-			},  
-			"meta": {} 
-		}`
-		var validMetadata vocapi.AccountMetadata
-		err = json.Unmarshal([]byte(validMetadataJSON), &validMetadata)
-		c.Assert(err, qt.IsNil)
-		org.Meta["name"], org.Meta["logo"] = ParseVochainOrganizationMeta(&validMetadata)
+		org.Meta["name"], org.Meta["logo"] = "TestCSPORg", "https://example.com/logo.png"
 		c.Assert(testDB.SetOrganization(org), qt.IsNil)
 		org, err = testDB.Organization(address)
 		c.Assert(err, qt.IsNil)

--- a/db/types.go
+++ b/db/types.go
@@ -97,6 +97,19 @@ type Organization struct {
 	IntegratorLimits *IntegratorLimits `json:"integratorLimits,omitempty" bson:"integratorLimits,omitempty"`
 }
 
+// DisplayName returns the organization display name stored in its metadata,
+// or an empty string if the organization has no name set.
+func (o *Organization) DisplayName() string {
+	if o == nil || o.Meta == nil {
+		return ""
+	}
+	name, ok := o.Meta["name"].(string)
+	if !ok {
+		return ""
+	}
+	return name
+}
+
 // IntegratorLimits caps how many organizations an integrator may manage. The
 // aggregate process and census-size caps across those managed orgs are taken from
 // the integrator's plan top-level limits (Plan.Organization.MaxProcesses /

--- a/db/types.go
+++ b/db/types.go
@@ -97,17 +97,41 @@ type Organization struct {
 	IntegratorLimits *IntegratorLimits `json:"integratorLimits,omitempty" bson:"integratorLimits,omitempty"`
 }
 
+// metaDefaultString extracts the "default" locale value from a meta entry that
+// may be stored as a plain string (legacy), a locale map, or the BSON-decoded
+// form of a locale map after a MongoDB round-trip (map[string]any).
+func metaDefaultString(v any) string {
+	switch m := v.(type) {
+	case string:
+		return m
+	case map[string]string:
+		return m["default"]
+	case map[string]any:
+		if s, ok := m["default"].(string); ok {
+			return s
+		}
+		return ""
+	default:
+		return ""
+	}
+}
+
 // DisplayName returns the organization display name stored in its metadata,
 // or an empty string if the organization has no name set.
 func (o *Organization) DisplayName() string {
 	if o == nil || o.Meta == nil {
 		return ""
 	}
-	name, ok := o.Meta["name"].(string)
-	if !ok {
+	return metaDefaultString(o.Meta["name"])
+}
+
+// LogoURL returns the organization logo URL stored in its metadata,
+// or an empty string if the organization has no logo set.
+func (o *Organization) LogoURL() string {
+	if o == nil || o.Meta == nil {
 		return ""
 	}
-	return name
+	return metaDefaultString(o.Meta["logo"])
 }
 
 // IntegratorLimits caps how many organizations an integrator may manage. The

--- a/db/types_test.go
+++ b/db/types_test.go
@@ -1,0 +1,54 @@
+package db
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestOrganizationDisplayNameAndLogoURL(t *testing.T) {
+	t.Run("MetaShapes", func(t *testing.T) {
+		c := qt.New(t)
+
+		// legacy plain-string storage
+		org := &Organization{Meta: map[string]any{
+			"name": "Acme",
+			"logo": "https://acme.org/logo.png",
+		}}
+		c.Assert(org.DisplayName(), qt.Equals, "Acme")
+		c.Assert(org.LogoURL(), qt.Equals, "https://acme.org/logo.png")
+
+		// locale map as set in memory by the API write path
+		org = &Organization{Meta: map[string]any{
+			"name": map[string]string{"default": "Acme"},
+			"logo": map[string]string{"default": "https://acme.org/logo.png"},
+		}}
+		c.Assert(org.DisplayName(), qt.Equals, "Acme")
+		c.Assert(org.LogoURL(), qt.Equals, "https://acme.org/logo.png")
+
+		// missing, empty and unexpected shapes
+		c.Assert((*Organization)(nil).DisplayName(), qt.Equals, "")
+		c.Assert((&Organization{}).DisplayName(), qt.Equals, "")
+		c.Assert((&Organization{Meta: map[string]any{}}).LogoURL(), qt.Equals, "")
+		c.Assert((&Organization{Meta: map[string]any{"name": 42}}).DisplayName(), qt.Equals, "")
+	})
+
+	t.Run("BsonRoundTrip", func(t *testing.T) {
+		c := qt.New(t)
+
+		// A locale-map name/logo must survive a BSON round-trip, where nested
+		// maps decode as map[string]any instead of their original Go type
+		org := Organization{Meta: map[string]any{
+			"name": map[string]string{"default": "Acme"},
+			"logo": map[string]string{"default": "https://acme.org/logo.png"},
+		}}
+		raw, err := bson.Marshal(org)
+		c.Assert(err, qt.IsNil)
+		var decoded Organization
+		c.Assert(bson.Unmarshal(raw, &decoded), qt.IsNil)
+
+		c.Assert(decoded.DisplayName(), qt.Equals, "Acme")
+		c.Assert(decoded.LogoURL(), qt.Equals, "https://acme.org/logo.png")
+	})
+}

--- a/notifications/mailtemplates/mailtemplates_test.go
+++ b/notifications/mailtemplates/mailtemplates_test.go
@@ -393,7 +393,7 @@ func TestMembersImportCompletionNotification(t *testing.T) {
 		c.Assert(notification.PlainBody, qt.Contains, "5")
 	})
 
-	t.Run("ExecTemplate_WithoutOrganizationName", func(_ *testing.T) {
+	t.Run("ExecTemplate_WithoutOrganizationName", func(t *testing.T) {
 		c := qt.New(t)
 
 		// An organization without a name in its metadata must not produce a
@@ -406,13 +406,13 @@ func TestMembersImportCompletionNotification(t *testing.T) {
 			AddedMembers     int
 			ErrorCount       int
 			Errors           []string
-			CompletedAt      string
+			CompletedAt      time.Time
 		}{
 			UserName:     "John Doe",
 			Link:         "https://example.com/complex",
 			TotalMembers: 10,
 			AddedMembers: 10,
-			CompletedAt:  "2023-10-03 12:00:00",
+			CompletedAt:  time.Date(2023, 10, 3, 12, 0, 0, 0, time.UTC),
 		}
 
 		notification, err := template.ExecTemplate(data)
@@ -421,7 +421,7 @@ func TestMembersImportCompletionNotification(t *testing.T) {
 		c.Assert(notification.PlainBody, qt.Not(qt.Contains), "for organization")
 	})
 
-	t.Run("ExecTemplate_AllLanguages", func(_ *testing.T) {
+	t.Run("ExecTemplate_AllLanguages", func(t *testing.T) {
 		c := qt.New(t)
 
 		// Every localization must execute against the real data shape,
@@ -434,14 +434,14 @@ func TestMembersImportCompletionNotification(t *testing.T) {
 			AddedMembers     int
 			ErrorCount       int
 			Errors           []string
-			CompletedAt      string
+			CompletedAt      time.Time
 		}{
 			UserName:         "John Doe",
 			OrganizationName: "Test Organization",
 			Link:             "https://example.com/complex",
 			TotalMembers:     10,
 			AddedMembers:     10,
-			CompletedAt:      "2023-10-03 12:00:00",
+			CompletedAt:      time.Date(2023, 10, 3, 12, 0, 0, 0, time.UTC),
 		}
 
 		for _, lang := range []string{"en", "es", "ca"} {

--- a/notifications/mailtemplates/mailtemplates_test.go
+++ b/notifications/mailtemplates/mailtemplates_test.go
@@ -309,7 +309,7 @@ func TestMembersImportCompletionNotification(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		// Test template field values
-		c.Assert(plaintext.Subject, qt.Contains, "Members import completed for {{.OrganizationName}}")
+		c.Assert(plaintext.Subject, qt.Contains, "Members import completed{{if .OrganizationName}} for {{.OrganizationName}}{{end}}")
 		c.Assert(plaintext.Body, qt.Contains, "Hello {{.UserName}}")
 		c.Assert(plaintext.Body, qt.Contains, "{{.TotalMembers}}")
 		c.Assert(plaintext.Body, qt.Contains, "{{.AddedMembers}}")
@@ -391,6 +391,66 @@ func TestMembersImportCompletionNotification(t *testing.T) {
 		c.Assert(notification.PlainBody, qt.Contains, "Duplicate entry")
 		c.Assert(notification.PlainBody, qt.Contains, "Missing phone number")
 		c.Assert(notification.PlainBody, qt.Contains, "5")
+	})
+
+	t.Run("ExecTemplate_WithoutOrganizationName", func(_ *testing.T) {
+		c := qt.New(t)
+
+		// An organization without a name in its metadata must not produce a
+		// dangling "for " in the subject or body
+		data := struct {
+			UserName         string
+			OrganizationName string
+			Link             string
+			TotalMembers     int
+			AddedMembers     int
+			ErrorCount       int
+			Errors           []string
+			CompletedAt      string
+		}{
+			UserName:     "John Doe",
+			Link:         "https://example.com/complex",
+			TotalMembers: 10,
+			AddedMembers: 10,
+			CompletedAt:  "2023-10-03 12:00:00",
+		}
+
+		notification, err := template.ExecTemplate(data)
+		c.Assert(err, qt.IsNil)
+		c.Assert(notification.Subject, qt.Equals, "Members import completed")
+		c.Assert(notification.PlainBody, qt.Not(qt.Contains), "for organization")
+	})
+
+	t.Run("ExecTemplate_AllLanguages", func(_ *testing.T) {
+		c := qt.New(t)
+
+		// Every localization must execute against the real data shape,
+		// including the HTML body (guards against stale template variables)
+		data := struct {
+			UserName         string
+			OrganizationName string
+			Link             string
+			TotalMembers     int
+			AddedMembers     int
+			ErrorCount       int
+			Errors           []string
+			CompletedAt      string
+		}{
+			UserName:         "John Doe",
+			OrganizationName: "Test Organization",
+			Link:             "https://example.com/complex",
+			TotalMembers:     10,
+			AddedMembers:     10,
+			CompletedAt:      "2023-10-03 12:00:00",
+		}
+
+		for _, lang := range []string{"en", "es", "ca"} {
+			notification, err := MembersImportCompletionNotification.Localized(lang).ExecTemplate(data)
+			c.Assert(err, qt.IsNil, qt.Commentf("lang %s", lang))
+			c.Assert(notification.Subject, qt.Contains, "Test Organization", qt.Commentf("lang %s", lang))
+			c.Assert(notification.PlainBody, qt.Contains, "Test Organization", qt.Commentf("lang %s", lang))
+			c.Assert(notification.Body, qt.Contains, "Test Organization", qt.Commentf("lang %s", lang))
+		}
 	})
 }
 

--- a/notifications/mailtemplates/mailtemplates_test.go
+++ b/notifications/mailtemplates/mailtemplates_test.go
@@ -317,7 +317,7 @@ func TestMembersImportCompletionNotification(t *testing.T) {
 		c.Assert(plaintext.Body, qt.Contains, "{{.CompletedAt}}")
 	})
 
-	t.Run("ExecTemplate_Success", func(_ *testing.T) {
+	t.Run("ExecTemplate_Success", func(t *testing.T) {
 		c := qt.New(t)
 
 		// Test data for successful import
@@ -329,7 +329,7 @@ func TestMembersImportCompletionNotification(t *testing.T) {
 			AddedMembers     int
 			ErrorCount       int
 			Errors           []string
-			CompletedAt      string
+			CompletedAt      time.Time
 		}{
 			UserName:         "John Doe",
 			OrganizationName: "Test Organization",
@@ -338,7 +338,7 @@ func TestMembersImportCompletionNotification(t *testing.T) {
 			AddedMembers:     100,
 			ErrorCount:       0,
 			Errors:           nil,
-			CompletedAt:      "2023-10-03 12:00:00",
+			CompletedAt:      time.Date(2023, 10, 3, 12, 0, 0, 0, time.UTC),
 		}
 
 		// Execute template
@@ -357,7 +357,7 @@ func TestMembersImportCompletionNotification(t *testing.T) {
 		c.Assert(notification.PlainBody, qt.Contains, "2023-10-03 12:00:00")
 	})
 
-	t.Run("ExecTemplate_WithErrors", func(_ *testing.T) {
+	t.Run("ExecTemplate_WithErrors", func(t *testing.T) {
 		c := qt.New(t)
 
 		// Test data with errors
@@ -369,7 +369,7 @@ func TestMembersImportCompletionNotification(t *testing.T) {
 			AddedMembers     int
 			ErrorCount       int
 			Errors           []string
-			CompletedAt      string
+			CompletedAt      time.Time
 		}{
 			UserName:         "Jane Smith",
 			OrganizationName: "Error Test Org",
@@ -378,7 +378,7 @@ func TestMembersImportCompletionNotification(t *testing.T) {
 			AddedMembers:     45,
 			ErrorCount:       5,
 			Errors:           []string{"Invalid email format", "Duplicate entry", "Missing phone number"},
-			CompletedAt:      "2023-10-03 13:00:00",
+			CompletedAt:      time.Date(2023, 10, 3, 13, 0, 0, 0, time.UTC),
 		}
 
 		// Execute template


### PR DESCRIPTION
This is Claude Fable 5 speaking on behalf of elboletaire.

## What

The members-import completion email now takes the organization name from the database (`org.Meta["name"]`) instead of relying on a value that was never populated. The org-name field the frontend used to send for imports is no longer needed (and was already ignored by the backend).

## Why

Since cc0e23f removed the old `OrganizationName` population (it was actually `org.Subdomain`/address hex, deemed confusing), two bugs were left behind:

1. **Dangling subject** — the en/es/ca subject templates still rendered `Members import completed for {{.OrganizationName}}` with the field always empty, producing *"Members import completed for "*.
2. **es/ca emails silently dropped** — their HTML bodies referenced `{{.Organization}}`, a field that doesn't exist on the data struct, so template execution errored and the completion email was never sent for those languages. (Verified by restoring the old template and watching the new all-languages test fail.)

## How

- New `Organization.DisplayName()` accessor for the meta name; used by the import email and by the CSP handlers (three copy-pasted `Meta["name"]` lookups deduplicated into `orgNameAndLogo()`).
- All `members_import_done` templates guard the name with `{{if .OrganizationName}}` so orgs without a name get a clean subject/body.
- Fixed `{{.Organization}}` → `{{.OrganizationName}}` in the es/ca HTML bodies and restored the (now correct) name in the en HTML body.
- Tests: the template is now executed in every language against the real data shape — this catches stale template variables like the `{{.Organization}}` one — plus a no-name fallback case.

Side note: an org whose meta name is an empty string now falls back to the "Vocdoni" default in CSP voter emails instead of rendering an empty name.

No API types changed, so no swagger regeneration needed. For the frontend: any org-name field still sent with import requests is ignored and can be removed at leisure.