### PR TITLE
fix(processes): return the census groupId on process reads

### DIFF
--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -1068,16 +1068,21 @@ func OrganizationCensusFromDB(census *db.Census) OrganizationCensus {
 	if census == nil {
 		return OrganizationCensus{}
 	}
-	return OrganizationCensus{
+	out := OrganizationCensus{
 		ID:          census.ID.Hex(),
 		Type:        census.Type,
 		OrgAddress:  census.OrgAddress,
 		Size:        census.Size,
 		Weighted:    census.Weighted,
-		GroupID:     census.GroupID.Hex(),
 		AuthFields:  census.AuthFields,
 		TwoFaFields: census.TwoFaFields,
 	}
+	// guard the zero id so an organization-wide census reports no group at all: omitempty keys off the
+	// empty string, but a zero ObjectID hexes to 24 zeros and would serialize as a real group.
+	if !census.GroupID.IsZero() {
+		out.GroupID = census.GroupID.Hex()
+	}
+	return out
 }
 
 // OrganizationCensuses wraps a list of censuses of an organization.

--- a/api/apicommon/voting_processes.go
+++ b/api/apicommon/voting_processes.go
@@ -14,8 +14,13 @@ type CensusSpec struct {
 	Weighted    bool                    `json:"weighted"`
 	AuthFields  db.OrgMemberAuthFields  `json:"authFields,omitempty"`
 	TwoFaFields db.OrgMemberTwoFaFields `json:"twoFaFields,omitempty"`
-	GroupID     string                  `json:"groupId,omitempty"`
-	MemberIDs   []string                `json:"memberIds,omitempty"`
+	// GroupID is the org member group the census was built from. Round-trips: it is echoed back on
+	// process reads, so a client can restore the group a draft targeted. Absent (not a zero id) when
+	// the census is organization-wide.
+	GroupID string `json:"groupId,omitempty"`
+	// MemberIDs selects the census members explicitly, as an alternative to GroupID. Write-only: the
+	// census member list is never exposed on a read, only its config.
+	MemberIDs []string `json:"memberIds,omitempty"`
 	// Size is the number of members in the census. Response-only (ignored on create/update): for a
 	// published process it equals the on-chain maxCensusSize of its whole-census questions.
 	Size int64 `json:"size,omitempty"`
@@ -252,6 +257,11 @@ func VotingProcessResponseFromDB(
 			AuthFields:  census.AuthFields,
 			TwoFaFields: census.TwoFaFields,
 			Size:        census.Size,
+		}
+		// guard the zero id so an organization-wide census reports no group at all: omitempty keys off
+		// the empty string, but a zero ObjectID hexes to 24 zeros and would serialize as a real group.
+		if !census.GroupID.IsZero() {
+			resp.Census.GroupID = census.GroupID.Hex()
 		}
 	}
 	return resp

--- a/api/apicommon/voting_processes.go
+++ b/api/apicommon/voting_processes.go
@@ -18,8 +18,9 @@ type CensusSpec struct {
 	// process reads, so a client can restore the group a draft targeted. Absent (not a zero id) when
 	// the census is organization-wide.
 	GroupID string `json:"groupId,omitempty"`
-	// MemberIDs selects the census members explicitly, as an alternative to GroupID. Write-only: the
-	// census member list is never exposed on a read, only its config.
+	// MemberIDs selects the census members explicitly, as an alternative to GroupID. Write-only on
+	// this type: a process read echoes the census config, not the member list it resolved to. The
+	// list itself is read through the deprecated GET /census/{id}/participants (Manager/Admin).
 	MemberIDs []string `json:"memberIds,omitempty"`
 	// Size is the number of members in the census. Response-only (ignored on create/update): for a
 	// published process it equals the on-chain maxCensusSize of its whole-census questions.

--- a/api/processes_census_test.go
+++ b/api/processes_census_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/hex"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/csp/handlers"
 	"github.com/vocdoni/saas-backend/db"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 )
 
@@ -130,4 +132,61 @@ func TestUpdateProcessCensus(t *testing.T) {
 			AuthToken: tok, ProcessID: openElection, Payload: hex.EncodeToString(voter.Address().Bytes()),
 		}, "processes", pid, "sign")
 	c.Assert(sign.Signature, qt.Not(qt.HasLen), 0)
+}
+
+// TestProcessesCensusGroupID verifies the census groupId round-trips: a process created from an org
+// member group reports that group on both process reads and on the org census list, so a client can
+// restore the group a draft targeted. An organization-wide census reports no group at all — the
+// field must be absent, never a zero object id serialized as 24 zeros.
+func TestProcessesCensusGroupID(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "groupcensuspass123")
+	orgAddress := testCreateOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(3)...)
+	group := postGroup(t, token, orgAddress, memberIDs(members)...)
+
+	// a process whose census is built from a group, and one over the whole organization.
+	groupReq := minimalVotingProcessRequest(orgAddress)
+	groupReq.Census.GroupID = group.ID
+	grouped := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, groupReq, processesCreateEndpoint,
+	)
+	orgWide := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, minimalVotingProcessRequest(orgAddress), processesCreateEndpoint,
+	)
+
+	// GET /processes/{id}: the group round-trips, the org-wide census carries no group.
+	got := requestAndParse[apicommon.VotingProcessResponse](
+		t, http.MethodGet, token, nil, "processes", grouped.ProcessID,
+	)
+	c.Assert(got.Census.GroupID, qt.Equals, group.ID)
+	c.Assert(got.Census.Size, qt.Equals, int64(len(members)))
+	plain := requestAndParse[apicommon.VotingProcessResponse](
+		t, http.MethodGet, token, nil, "processes", orgWide.ProcessID,
+	)
+	c.Assert(plain.Census.GroupID, qt.Equals, "")
+
+	// GET /processes: the list builds its census through the same helper, so it must agree with the
+	// single read (totalWeight, set per-handler, already diverges here — groupId must not).
+	list := requestAndParse[apicommon.VotingProcessListResponse](t, http.MethodGet, token, nil,
+		fmt.Sprintf("processes?orgAddress=%s&limit=100", orgAddress.Hex()))
+	listed := make(map[string]apicommon.CensusSpec, len(list.Processes))
+	for _, p := range list.Processes {
+		listed[p.ID] = p.Census
+	}
+	c.Assert(listed[grouped.ProcessID].GroupID, qt.Equals, group.ID)
+	c.Assert(listed[orgWide.ProcessID].GroupID, qt.Equals, "")
+
+	// the org census list reports the same, and must not invent a zero group for the org-wide census.
+	censuses := requestAndParse[apicommon.OrganizationCensuses](t, http.MethodGet, token, nil,
+		"organizations", orgAddress.String(), "censuses")
+	groups := make([]string, 0, len(censuses.Censuses))
+	for _, census := range censuses.Censuses {
+		groups = append(groups, census.GroupID)
+	}
+	c.Assert(groups, qt.Contains, group.ID)
+	c.Assert(groups, qt.Contains, "")
+	c.Assert(groups, qt.Not(qt.Contains), primitive.NilObjectID.Hex())
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -104,8 +104,15 @@ definitions:
           $ref: '#/definitions/db.OrgMemberAuthField'
         type: array
       groupId:
+        description: |-
+          GroupID is the org member group the census was built from. Round-trips: it is echoed back on
+          process reads, so a client can restore the group a draft targeted. Absent (not a zero id) when
+          the census is organization-wide.
         type: string
       memberIds:
+        description: |-
+          MemberIDs selects the census members explicitly, as an alternative to GroupID. Write-only: the
+          census member list is never exposed on a read, only its config.
         items:
           type: string
         type: array

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -111,8 +111,9 @@ definitions:
         type: string
       memberIds:
         description: |-
-          MemberIDs selects the census members explicitly, as an alternative to GroupID. Write-only: the
-          census member list is never exposed on a read, only its config.
+          MemberIDs selects the census members explicitly, as an alternative to GroupID. Write-only on
+          this type: a process read echoes the census config, not the member list it resolved to. The
+          list itself is read through the deprecated GET /census/{id}/participants (Manager/Admin).
         items:
           type: string
         type: array


### PR DESCRIPTION
Closes #605.

## Problem

`CensusSpec.GroupID` is accepted on `POST`/`PUT /processes` but never returned by any process read, so a client cannot round-trip the census group of a process it created.

This breaks vocdoni-app, where drafts are now unpublished `/processes` resources restored by reading them back: re-opening or cloning a draft that targeted a member group silently falls back to the organization-wide census — a larger electorate than the user configured, with no error.

The value is already persisted (`db/census.go:111` sets it from the group) and already loaded by both handlers. It was simply not copied onto the response, so this is a copy, not a schema change.

## Changes

**1. Return `groupId` on process reads** — `VotingProcessResponseFromDB` now populates it, behind a `!census.GroupID.IsZero()` guard. Fixing it in the builder rather than the handler covers both `GET /processes/{id}` and `GET /processes` at once, at no cost since both already hold the `*db.Census`.

This deliberately does *not* follow the `TotalWeight` precedent, which is set in the get handler but not the list handler. That asymmetry is defensible for `TotalWeight` — `censusTotalWeight` runs a per-census DB aggregation, so a list loop would be N+1 — but `groupId` is a free field read.

**2. Fix the same bug in `OrganizationCensusFromDB`** — it *did* map the field, but unguarded. A zero `primitive.ObjectID` hexes to `"000000000000000000000000"`, not `""`, so `omitempty` never fires: `GET /organizations/{orgAddress}/censuses` has been reporting a fake 24-zero group id for every organization-wide census. Same root cause, adjacent code, so fixed here rather than left behind.

**3. `TestProcessesCensusGroupID`** — exercises the real write path (not the builder in isolation): create a group census via `POST /processes`, assert the group comes back on the single read, on the list read, and on the org census list, plus an org-wide negative case asserting absence rather than a zero hex.

Both assertions are load-bearing by construction: `resp.Census.GroupID` has exactly one writer (the lines added here), so without change 1 the round-trip assertion sees `""` against a real 24-hex group id, and without change 2 the org census list contains the 24-zero string the last assertion excludes.

## Out of scope

- **Per-question eligibility `groupId`.** `resolveEligibleMemberIDs` (`api/processes_census.go:82`) expands `EligibilitySpec.GroupID` into `EligibleMemberIDs` and discards the group id; `db.VotingProcessQuestion` has nowhere to store it. Needs a schema change and a migration — worth its own issue.
- **`censusId` on the process response.** #605 notes there is no census id to correlate against either. Left out deliberately: `groupId` resolves the actual bug, and a census identifier would be exposed on the public/anonymous read too.
- **`groupId` on `PublicQuestionResponse`.** Its doc comment defines it as a voter-safe allow-list; a voter does not need the org's group structure to cast a ballot.
- **`totalWeight` missing from the list handler.** A real inconsistency found while verifying, but the N+1 aggregation cost means it needs its own decision (batch it, or document the omission).

Note also a pre-existing wire inconsistency, left alone: `CensusSpec` uses `groupId`, `OrganizationCensus` uses `groupID`. Neither can be renamed without breaking clients.
