### PR TITLE
feat(processes): filter the process list by published state

### DIFF
--- a/api/processes.go
+++ b/api/processes.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -368,15 +369,21 @@ func redactQuestionsForPublic(questions []db.VotingProcessQuestion) {
 //	@Description	Paginated list of an organization's voting processes. Public: anonymous callers get
 //	@Description	published processes only (without per-question eligibleMemberIds). A Manager/Admin of
 //	@Description	the org (or a voting:write API key acting as one) also gets drafts and the eligibility.
-//	@Description	Filter by question status.
+//	@Description	Filter by question status, and by published state.
+//	@Description	published=true returns published processes only; published=false returns drafts only and
+//	@Description	requires Manager/Admin (401 otherwise). Omitting it keeps the caller's default view.
+//	@Description	Combining published=false with status returns nothing: a draft's questions have no
+//	@Description	on-chain status yet, and status matches on that field.
 //	@Tags			processes
 //	@Produce		json
 //	@Param			orgAddress	query		string	true	"Organization address"
 //	@Param			status		query		string	false	"Filter by question status"
+//	@Param			published	query		bool	false	"Filter by published state; false (drafts) requires Manager/Admin"
 //	@Param			page		query		int		false	"Page (1-based)"
 //	@Param			limit		query		int		false	"Page size"
 //	@Success		200			{object}	apicommon.VotingProcessListResponse
 //	@Failure		400			{object}	errors.Error
+//	@Failure		401			{object}	errors.Error
 //	@Router			/processes [get]
 func (a *API) listVotingProcessesHandler(w http.ResponseWriter, r *http.Request) {
 	orgAddressStr := r.URL.Query().Get("orgAddress")
@@ -401,6 +408,24 @@ func (a *API) listVotingProcessesHandler(w http.ResponseWriter, r *http.Request)
 	draft := db.PublishedOnly
 	if isManager {
 		draft = db.AllProcesses
+	}
+	// the optional published filter narrows that default view. Asking for drafts is manager-only,
+	// mirroring organizationListProcessDraftsHandler on the legacy routes.
+	if s := r.URL.Query().Get("published"); s != "" {
+		published, err := strconv.ParseBool(s)
+		if err != nil {
+			errors.ErrMalformedURLParam.Withf("invalid published").Write(w)
+			return
+		}
+		switch {
+		case published:
+			draft = db.PublishedOnly
+		case !isManager:
+			errors.ErrUnauthorized.Withf("user is not admin of organization").Write(w)
+			return
+		default:
+			draft = db.DraftOnly
+		}
 	}
 	params, err := parsePaginationParams(r.URL.Query().Get(ParamPage), r.URL.Query().Get(ParamLimit))
 	if err != nil {

--- a/api/processes_test.go
+++ b/api/processes_test.go
@@ -445,7 +445,9 @@ func TestVotingProcessResults(t *testing.T) {
 
 // TestVotingProcessPublicReads verifies the process list and single read are public for published
 // processes (with per-question eligibleMemberIds stripped for non-managers), while drafts and the
-// eligibility are visible only to a manager/admin of the org.
+// eligibility are visible only to a manager/admin of the org. It also covers the optional published
+// filter on the list: it narrows the caller's default view, and asking for drafts without a
+// manager/admin role is refused rather than silently returning an empty list.
 func TestVotingProcessPublicReads(t *testing.T) {
 	c := qt.New(t)
 	token := testCreateUser(t, "adminpassword123")
@@ -511,6 +513,38 @@ func TestVotingProcessPublicReads(t *testing.T) {
 	mgrList := requestAndParse[apicommon.VotingProcessListResponse](t, http.MethodGet, token, nil, listURL)
 	c.Assert(hasProcess(mgrList.Processes, published.ProcessID), qt.IsTrue)
 	c.Assert(hasProcess(mgrList.Processes, draft.ProcessID), qt.IsTrue)
+
+	// published=false narrows the manager view to drafts, published=true to published processes. The
+	// unfiltered manager list above is the third case: omitting the param still returns both.
+	draftsURL := listURL + "&published=false"
+	mgrDrafts := requestAndParse[apicommon.VotingProcessListResponse](t, http.MethodGet, token, nil, draftsURL)
+	c.Assert(hasProcess(mgrDrafts.Processes, draft.ProcessID), qt.IsTrue)
+	c.Assert(hasProcess(mgrDrafts.Processes, published.ProcessID), qt.IsFalse)
+	mgrPublished := requestAndParse[apicommon.VotingProcessListResponse](
+		t, http.MethodGet, token, nil, listURL+"&published=true")
+	c.Assert(hasProcess(mgrPublished.Processes, published.ProcessID), qt.IsTrue)
+	c.Assert(hasProcess(mgrPublished.Processes, draft.ProcessID), qt.IsFalse)
+
+	// the value is parsed with strconv.ParseBool, so "0" filters drafts exactly like "false".
+	mgrZero := requestAndParse[apicommon.VotingProcessListResponse](t, http.MethodGet, token, nil, listURL+"&published=0")
+	c.Assert(hasProcess(mgrZero.Processes, draft.ProcessID), qt.IsTrue)
+	c.Assert(hasProcess(mgrZero.Processes, published.ProcessID), qt.IsFalse)
+
+	// drafts are manager-only: anonymous and a non-member user are refused (401) rather than being
+	// served an empty list, which would read as "this org has no drafts".
+	requestAndAssertCode(http.StatusUnauthorized, t, http.MethodGet, "", nil, draftsURL)
+	requestAndAssertCode(http.StatusUnauthorized, t, http.MethodGet, otherToken, nil, draftsURL)
+
+	// published=true stays public.
+	anonPublished := requestAndParse[apicommon.VotingProcessListResponse](
+		t, http.MethodGet, "", nil, listURL+"&published=true")
+	c.Assert(hasProcess(anonPublished.Processes, published.ProcessID), qt.IsTrue)
+	c.Assert(hasProcess(anonPublished.Processes, draft.ProcessID), qt.IsFalse)
+
+	// an unparseable value is malformed (400) whatever the credentials — the parse precedes the
+	// manager check, so a bad param is never reported as an auth failure.
+	requestAndAssertCode(http.StatusBadRequest, t, http.MethodGet, token, nil, listURL+"&published=notabool")
+	requestAndAssertCode(http.StatusBadRequest, t, http.MethodGet, "", nil, listURL+"&published=notabool")
 
 	// a zero orgAddress passes IsHexAddress but is malformed -> 400 (not a 500 from the db layer).
 	requestAndAssertCode(http.StatusBadRequest, t, http.MethodGet, "", nil,

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -5838,7 +5838,11 @@ paths:
         Paginated list of an organization's voting processes. Public: anonymous callers get
         published processes only (without per-question eligibleMemberIds). A Manager/Admin of
         the org (or a voting:write API key acting as one) also gets drafts and the eligibility.
-        Filter by question status.
+        Filter by question status, and by published state.
+        published=true returns published processes only; published=false returns drafts only and
+        requires Manager/Admin (401 otherwise). Omitting it keeps the caller's default view.
+        Combining published=false with status returns nothing: a draft's questions have no
+        on-chain status yet, and status matches on that field.
       parameters:
       - description: Organization address
         in: query
@@ -5849,6 +5853,10 @@ paths:
         in: query
         name: status
         type: string
+      - description: Filter by published state; false (drafts) requires Manager/Admin
+        in: query
+        name: published
+        type: boolean
       - description: Page (1-based)
         in: query
         name: page
@@ -5866,6 +5874,10 @@ paths:
             $ref: '#/definitions/apicommon.VotingProcessListResponse'
         "400":
           description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "401":
+          description: Unauthorized
           schema:
             $ref: '#/definitions/errors.Error'
       summary: List voting processes


### PR DESCRIPTION
## Problem

`GET /processes` has no way to ask for *only* drafts or *only* published processes. The draft state is implicit in who is asking: an anonymous caller gets published processes, a manager gets everything. A manager who wants just their drafts has to fetch all of them and filter client-side.

vocdoni-app needs this — drafts are now unpublished `/processes` resources, and the drafts list is its own screen. #605 referred to this as "the missing drafts-only filter on `GET /processes` that we reported separately", but no such issue was ever filed, so this PR stands alone.

## Change

An optional `published` query param on `GET /processes`, alongside the existing `orgAddress` and `status` filters.

| `published` | anonymous / non-manager | manager or admin |
|---|---|---|
| absent | `PublishedOnly` (unchanged) | `AllProcesses` (unchanged) |
| `true` | `PublishedOnly` | `PublishedOnly` |
| `false` | **401** | `DraftOnly` |
| unparseable | 400 | 400 |

**Omitting the param preserves today's behaviour exactly** — the filter only ever narrows the caller's default view, so this is backward compatible.

**No db change was needed.** `db.DraftOnly` already exists (`db/const.go:123`) and `ListVotingProcesses` already switches on all three `DraftFilter` values — `DraftOnly` is already used in production by the legacy drafts endpoint. This is purely API-layer parsing and authorization.

## Notes on the design

- **Drafts are manager-only and return 401, not an empty list.** An empty list would read as "this org has no drafts" — the same silent-fallback failure mode behind #605. This mirrors `organizationListProcessDraftsHandler` (`api/process.go:455`), which already refuses non-managers with this exact error and message.
- **Parsed with `strconv.ParseBool`**, so `1`/`0`/`True`/`FALSE` work as well as `true`/`false`. Case-insensitivity matches the sibling `status` filter, which upper-cases client input.
- **The parse precedes the manager check**, so a malformed value is always a 400 and never surfaces as an auth failure.
- **`published=false` combined with `status` returns nothing**, because a draft's questions have no stored `status` (bson `omitempty`) and the status filter matches on that field. Correct behaviour, but surprising enough to document in the swagger description.

## Verification

Run locally, not just on CI:

- `TestVotingProcessPublicReads` (extended) — **PASS**. It already had the right fixtures: a published process, a draft, a manager token and a non-member token.
- **Revert check** — with the handler hunk removed, the test **fails** at `processes_test.go:522`: `published=false` returns the published process too. The new assertions are load-bearing. (`qt.Assert` aborts on first failure, so the later 401 assertions weren't reached; without the filter those code paths don't exist at all.)
- `golangci-lint run ./api/...` — **0 issues**.
- `docs/swagger.yaml` regenerated with `make swagger`; the diff is confined to this endpoint.

New coverage: manager drafts-only / published-only / unfiltered, a `ParseBool` alias (`published=0`), anonymous and non-member 401s, anonymous `published=true` staying public, and invalid values as 400 with and without credentials.

## Out of scope

- **The legacy `/process` endpoints** — they already have a dedicated `/organizations/{orgAddress}/processes/drafts` route and are being deprecated in favour of `/processes`.
- **A `published` filter on `CountVotingProcesses`** — it already takes a `DraftFilter`; no caller needs a new one.
