### PR TITLE
feat(api): relay a batch of signed votes at POST /votes

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -71,6 +71,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -168,6 +169,7 @@ type API struct {
 	oauthServiceURL string
 	stripeHandlers  *StripeHandlers
 	txQueue         chan txTask
+	txQueueMu       sync.Mutex
 	orgTxLocks      *orgTxMutex
 	otpExpiry       time.Duration
 	otpCooldown     time.Duration
@@ -459,6 +461,7 @@ func (a *API) initRouter() http.Handler {
 		handle(r, http.MethodGet, jobStatusEndpoint, a.jobStatusHandler)
 		handle(r, http.MethodGet, processEndpoint, a.processInfoHandler)
 		handle(r, http.MethodPost, voteEndpoint, a.relayVoteHandler)
+		handle(r, http.MethodPost, votesEndpoint, a.relayVotesHandler)
 		handle(r, http.MethodGet, processResultsEndpoint, a.processResultsHandler)
 		handle(r, http.MethodGet, processMetadataEndpoint, a.processMetadataHandler)
 		handle(r, http.MethodPost, processSignInfoEndpoint, cspHandlers.ConsumedAddressHandler)

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -1307,6 +1307,16 @@ type RelayVoteRequest struct {
 	TxPayload internal.HexBytes `json:"txPayload" swaggertype:"string" format:"hex" example:"deadbeef"`
 }
 
+// RelayVotesRequest is the body of POST /votes: the already-signed voter transactions of
+// one voter, typically the questions of a multi-question voting process. The batch is
+// accepted or rejected as a unit and relayed under a single job, whose result reports the
+// votes in the order they are given here.
+// swagger:model RelayVotesRequest
+type RelayVotesRequest struct {
+	// Signed vote transactions, at most 100
+	Votes []RelayVoteRequest `json:"votes"`
+}
+
 // RelayVoteResponse is returned by POST /vote with the vote nullifier (voteID)
 // assigned on chain.
 // swagger:model RelayVoteResponse
@@ -1524,20 +1534,25 @@ type CreateOrganizationTicketRequest struct {
 }
 
 // UnifiedJobResult is the merged result payload of GET /jobs: a superset of the tx-job outcome
-// (address/status/voteID) and the import-job counters (added/progress/total). Empty attributes are
-// omitted so a job only surfaces what its type produced.
+// (address/status/processId/nullifier/voteID, or votes for a batch vote relay) and the import-job
+// counters (added/progress/total). Empty attributes are omitted so a job only surfaces what its
+// type produced.
 type UnifiedJobResult struct {
-	Address  internal.HexBytes `json:"address,omitempty" swaggertype:"string" example:"deadbeef"`
-	Status   string            `json:"status,omitempty"`
-	VoteID   internal.HexBytes `json:"voteID,omitempty" swaggertype:"string" example:"deadbeef"`
-	Added    int               `json:"added,omitempty"`
-	Progress int               `json:"progress,omitempty"`
-	Total    int               `json:"total,omitempty"`
+	Address   internal.HexBytes `json:"address,omitempty" swaggertype:"string" example:"deadbeef"`
+	Status    string            `json:"status,omitempty"`
+	ProcessID internal.HexBytes `json:"processId,omitempty" swaggertype:"string" example:"deadbeef"`
+	Nullifier internal.HexBytes `json:"nullifier,omitempty" swaggertype:"string" example:"deadbeef"`
+	VoteID    internal.HexBytes `json:"voteID,omitempty" swaggertype:"string" example:"deadbeef"`
+	// Votes is the per-envelope outcome of a batch vote relay, in request order
+	Votes    []db.VoteJobResult `json:"votes,omitempty"`
+	Added    int                `json:"added,omitempty"`
+	Progress int                `json:"progress,omitempty"`
+	Total    int                `json:"total,omitempty"`
 }
 
 func (r *UnifiedJobResult) isEmpty() bool {
-	return len(r.Address) == 0 && r.Status == "" && len(r.VoteID) == 0 &&
-		r.Added == 0 && r.Progress == 0 && r.Total == 0
+	return len(r.Address) == 0 && r.Status == "" && len(r.ProcessID) == 0 && len(r.Nullifier) == 0 &&
+		len(r.VoteID) == 0 && len(r.Votes) == 0 && r.Added == 0 && r.Progress == 0 && r.Total == 0
 }
 
 // JobResponse is one job in the GET /jobs list: the unified shape across import and tx jobs.
@@ -1559,7 +1574,8 @@ type JobsListResponse struct {
 
 // JobResponseFromDB builds the unified job response from a db.Job. Import jobs (which don't set
 // Status) fall back to completed/pending derived from CompletedAt, and expose added/progress/total;
-// tx jobs expose their Result (address/status/voteID). The result is omitted when empty.
+// tx jobs expose their Result (address/status/processId/nullifier/voteID, or the per-vote entries of
+// a batch relay). The result is omitted when empty.
 func JobResponseFromDB(job *db.Job) JobResponse {
 	status := job.Status
 	if status == "" {
@@ -1576,7 +1592,10 @@ func JobResponseFromDB(job *db.Job) JobResponse {
 	if job.Result != nil {
 		res.Address = job.Result.Address
 		res.Status = job.Result.Status
+		res.ProcessID = job.Result.ProcessID
+		res.Nullifier = job.Result.Nullifier
 		res.VoteID = job.Result.VoteID
+		res.Votes = job.Result.Votes
 	}
 	if job.Total > 0 {
 		res.Progress = job.Added * 100 / job.Total

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -1588,6 +1588,15 @@ func JobResponseFromDB(job *db.Job) JobResponse {
 	if len(errs) == 0 && job.Error != "" {
 		errs = []string{job.Error}
 	}
+	// A batch vote job whose envelopes have all reported is finished, whatever its stored status
+	// says. The worker increments the counter and writes the terminal status as two operations, so
+	// a read can land between them — and if the process dies in that gap the job would otherwise
+	// stay pending forever, even though the outcome is fully determined by the entries. Derive it
+	// with the same function the worker closes the job with, so the two can never disagree.
+	if job.Type == db.JobTypeRelayVotes && status == db.JobStatusPending &&
+		job.Total > 0 && job.Added >= job.Total && job.Result != nil {
+		status, errs = db.TerminalVoteBatchStatus(job.Result.Votes)
+	}
 	res := &UnifiedJobResult{Added: job.Added, Total: job.Total}
 	if job.Result != nil {
 		res.Address = job.Result.Address

--- a/api/apicommon/types_test.go
+++ b/api/apicommon/types_test.go
@@ -1,0 +1,65 @@
+package apicommon
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/db"
+)
+
+// TestJobResponseFromDBBatchVoteTerminal covers the read-path derivation for batch vote jobs: the
+// worker bumps the progress counter and writes the terminal status as two separate operations, so a
+// job can legitimately be read with every envelope reported and no status stored — briefly during
+// normal operation, or forever if the process died in between. The response must not call that
+// pending.
+func TestJobResponseFromDBBatchVoteTerminal(t *testing.T) {
+	c := qt.New(t)
+
+	batch := func(total, added int, votes []db.VoteJobResult) *db.Job {
+		return &db.Job{
+			JobID:  "job",
+			Type:   db.JobTypeRelayVotes,
+			Status: db.JobStatusPending,
+			Total:  total,
+			Added:  added,
+			Result: &db.JobResult{Votes: votes},
+		}
+	}
+	completed := db.VoteJobResult{Status: db.JobStatusCompleted}
+	failed := db.VoteJobResult{Status: db.JobStatusFailed, Error: "vote already exists"}
+
+	c.Run("every envelope succeeded", func(c *qt.C) {
+		got := JobResponseFromDB(batch(2, 2, []db.VoteJobResult{completed, completed}))
+		c.Assert(got.Status, qt.Equals, db.JobStatusCompleted)
+		c.Assert(got.Errors, qt.HasLen, 0)
+	})
+
+	c.Run("one envelope failed", func(c *qt.C) {
+		got := JobResponseFromDB(batch(2, 2, []db.VoteJobResult{completed, failed}))
+		c.Assert(got.Status, qt.Equals, db.JobStatusFailed)
+		c.Assert(got.Errors, qt.DeepEquals, []string{"vote 1: vote already exists"})
+	})
+
+	c.Run("still waiting on an envelope", func(c *qt.C) {
+		got := JobResponseFromDB(batch(2, 1, []db.VoteJobResult{completed, {Status: db.JobStatusPending}}))
+		c.Assert(got.Status, qt.Equals, db.JobStatusPending,
+			qt.Commentf("a job with envelopes still outstanding is genuinely pending"))
+		c.Assert(got.Result.Progress, qt.Equals, 50)
+	})
+
+	c.Run("a stored terminal status wins", func(c *qt.C) {
+		job := batch(2, 2, []db.VoteJobResult{completed, failed})
+		job.Status = db.JobStatusCompleted // already closed by the worker
+		got := JobResponseFromDB(job)
+		c.Assert(got.Status, qt.Equals, db.JobStatusCompleted,
+			qt.Commentf("the derivation only fills a gap; it never overrides what the worker wrote"))
+	})
+
+	c.Run("other job types are untouched", func(c *qt.C) {
+		got := JobResponseFromDB(&db.Job{
+			JobID: "job", Type: db.JobTypeOrgMembers, Status: db.JobStatusPending, Total: 2, Added: 2,
+		})
+		c.Assert(got.Status, qt.Equals, db.JobStatusPending,
+			qt.Commentf("an import job's added==total does not mean it is finished"))
+	})
+}

--- a/api/docs.md
+++ b/api/docs.md
@@ -2412,6 +2412,10 @@ If the worker queue is saturated the handler returns `503` and the client should
   relayed. Returns `202` + a single `{ "jobId" }` covering the batch; the job result
   carries one entry per vote, in request order.
 
+  Both relay endpoints are public, so their request body is capped before it is buffered
+  (8 KiB per envelope — a signed envelope is ~600 hex characters). An oversized body is
+  refused with `413` / `40167`.
+
 #### 🔍 Poll job status
 
 * **Path** `/jobs/{jobId}`

--- a/api/docs.md
+++ b/api/docs.md
@@ -2400,7 +2400,17 @@ If the worker queue is saturated the handler returns `503` and the client should
   Body `{ "status": "ready|paused|ended|canceled" }`. Returns `202` + `{ "jobId" }`.
 * **Relay a signed vote** — `POST /vote` (public).
   Body `{ "txPayload": "<hex>" }`. Returns `202` + `{ "jobId" }`; the job result carries
-  the vote nullifier (`voteID`).
+  the target `processId` and the vote `nullifier` — both derived from the envelope, so
+  they are readable while the job is still pending — plus the chain-assigned `voteID`
+  once the vote is accepted.
+* **Relay a batch of signed votes** — `POST /votes` (public).
+  Body `{ "votes": [{ "txPayload": "<hex>" }, ...] }`, at most 100. A multi-question
+  voting process is one on-chain process per question, so relaying the questions one by
+  one can leave a voter half-voted; this endpoint takes them together. The batch is
+  validated and enqueued **all or nothing** — one bad envelope, a batch spanning two
+  organizations, or a queue without room for all of them rejects the call with nothing
+  relayed. Returns `202` + a single `{ "jobId" }` covering the batch; the job result
+  carries one entry per vote, in request order.
 
 #### 🔍 Poll job status
 
@@ -2419,10 +2429,34 @@ If the worker queue is saturated the handler returns `503` and the client should
   "status": "completed",
   "result": {
     "address": "deadbeef",   // on-chain process id (publish)
-    "voteID": "deadbeef",    // vote nullifier (relay vote)
+    "processId": "deadbeef", // target process (relay vote)
+    "nullifier": "deadbeef", // vote nullifier, known before submission (relay vote)
+    "voteID": "deadbeef",    // vote nullifier as assigned on chain (relay vote)
     "status": "READY"        // process status (publish / status change)
   },
   "error": ""                // failure reason when status is "failed"
+}
+```
+
+  A batch vote relay (`type: "relay_votes"`) reports every envelope instead, in the order
+  they were sent. `total` is the batch size and `added` the number that have finished, so
+  `progress` advances as the votes land; the job stays `pending` until the last one
+  reports and then ends `completed` only if every vote was accepted.
+```json
+{
+  "jobId": "a1b2c3...",
+  "type": "relay_votes",
+  "status": "failed",
+  "errors": ["vote 2: vote already exists"],
+  "result": {
+    "total": 3, "added": 3, "progress": 100,
+    "votes": [
+      { "processId": "9d3f...", "nullifier": "7ac1...", "voteID": "7ac1...", "status": "completed" },
+      { "processId": "4e77...", "nullifier": "b209...", "voteID": "b209...", "status": "completed" },
+      { "processId": "c015...", "nullifier": "33fa...", "status": "failed",
+        "error": "vote already exists" }
+    ]
+  }
 }
 ```
 

--- a/api/jobqueue.go
+++ b/api/jobqueue.go
@@ -50,10 +50,15 @@ const (
 
 // txTask is a unit of background transaction work. run performs the on-chain submit
 // plus any post-submit DB writes, returning the job result on success or an error on
-// failure. The worker records the terminal outcome via db.SetJobStatus.
+// failure. The worker records the terminal outcome via db.SetJobStatus, unless record
+// is set.
 type txTask struct {
 	jobID string
 	run   func() (*db.JobResult, error)
+	// record, when non-nil, takes over writing the outcome of this task. Tasks that
+	// share a job with other tasks — the envelopes of one batch vote relay — need it:
+	// the default path would mark the whole job terminal on the first outcome.
+	record func(result *db.JobResult, err error)
 }
 
 // startTxQueue creates the buffered queue and launches the worker pool. Called once
@@ -79,12 +84,20 @@ func (a *API) runTxTask(task txTask) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Errorw(fmt.Errorf("tx task %s panicked: %v", task.jobID, r), "tx task panicked")
-			if e := a.db.SetJobStatus(task.jobID, db.JobStatusFailed, nil, fmt.Sprintf("panic: %v", r)); e != nil {
-				log.Warnw("could not record panicked job", "jobId", task.jobID, "error", e)
-			}
+			a.recordTxOutcome(task, nil, fmt.Errorf("panic: %v", r))
 		}
 	}()
 	result, err := task.run()
+	a.recordTxOutcome(task, result, err)
+}
+
+// recordTxOutcome persists the outcome of a finished task, handing over to the task's
+// own recorder when it has one.
+func (a *API) recordTxOutcome(task txTask, result *db.JobResult, err error) {
+	if task.record != nil {
+		task.record(result, err)
+		return
+	}
 	if err != nil {
 		if e := a.db.SetJobStatus(task.jobID, db.JobStatusFailed, nil, err.Error()); e != nil {
 			log.Warnw("could not record failed job", "jobId", task.jobID, "error", e)
@@ -99,10 +112,24 @@ func (a *API) runTxTask(task txTask) {
 // enqueueTx hands a task to the worker pool without blocking. It returns false when
 // the queue is full so the caller can respond 503.
 func (a *API) enqueueTx(task txTask) bool {
-	select {
-	case a.txQueue <- task:
-		return true
-	default:
+	return a.enqueueTxBatch([]txTask{task})
+}
+
+// enqueueTxBatch hands a group of tasks to the worker pool all or nothing: it returns
+// false, having enqueued none of them, when the queue cannot take the whole group. A
+// caller relaying several votes at once therefore never leaves a voter half-voted
+// because the queue filled up midway. The mutex makes the free-slot check and the sends
+// atomic against each other; workers only ever drain the queue, so no concurrent
+// producer can invalidate a check taken under the lock.
+func (a *API) enqueueTxBatch(tasks []txTask) bool {
+	a.txQueueMu.Lock()
+	defer a.txQueueMu.Unlock()
+
+	if cap(a.txQueue)-len(a.txQueue) < len(tasks) {
 		return false
 	}
+	for _, task := range tasks {
+		a.txQueue <- task
+	}
+	return true
 }

--- a/api/jobqueue.go
+++ b/api/jobqueue.go
@@ -41,8 +41,15 @@ func (o *orgTxMutex) lock(addr common.Address) *sync.Mutex {
 
 // pool sizes are consts; promote to config only if tuning is needed.
 const (
-	// txQueueSize bounds the number of queued-but-not-yet-running tx tasks.
-	txQueueSize = 100
+	// txQueueSize bounds the number of queued-but-not-yet-running tx tasks. It is sized to hold
+	// several full vote batches at once: POST /votes reserves one slot per envelope all-or-nothing,
+	// so a queue merely as large as maxVotesPerBatch would accept a full batch only on a completely
+	// idle service, and a client turned away falls back to relaying one vote at a time — the
+	// half-voted window that endpoint exists to close. The buffer is not the bottleneck (the
+	// workers below are), so a bigger one adds no chain load or concurrency; it only stops
+	// rejecting work the service can serve. A txTask is a string and two func pointers, so this
+	// costs tens of kilobytes.
+	txQueueSize = 512
 	// txQueueWorkers caps concurrent on-chain submits so a chain stall cannot drain
 	// the router's shared request budget or starve the public CSP voter path.
 	txQueueWorkers = 16

--- a/api/process_vote.go
+++ b/api/process_vote.go
@@ -86,10 +86,22 @@ func (a *API) relayVoteHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 const (
-	// maxVotesPerBatch bounds a POST /votes call. It matches the cap of the vochain batch
-	// transaction endpoint and equals txQueueSize, so the largest accepted batch can at most
-	// fill an empty queue.
-	maxVotesPerBatch = 100
+	// maxVotesPerBatch bounds a POST /votes call. A voter casts one vote per question, and a
+	// process cannot hold more questions than this, so the cap is expressed as what it actually
+	// depends on rather than a duplicated literal: raising it means raising maxQuestionsPerProcess
+	// first, and the vochain batch transaction endpoint above that. It is deliberately NOT tied to
+	// txQueueSize — the queue is sized to hold several full batches (see api/jobqueue.go), because
+	// a batch rejected for lack of queue room sends the client back to relaying one vote at a time,
+	// which is the half-voted window this endpoint exists to close.
+	//
+	// On the denial-of-service trade-off: one request can occupy up to this many worker slots, each
+	// blocked until its transaction is mined, and the endpoint is public and unauthenticated. That
+	// amortizes the existing relay surface, it does not enlarge it — the same client can reach the
+	// same state with maxVotesPerBatch sequential POST /vote calls, and the all-or-nothing 503 here
+	// is strictly better behaved than relaying a prefix and stopping. Rate limiting is intentionally
+	// out of scope for this endpoint; it belongs with the API-wide throttling applied to every route
+	// in initRouter (api/api.go).
+	maxVotesPerBatch = maxQuestionsPerProcess
 	// maxVoteBodyBytes bounds the request body of a single relayed envelope. A CSP-signed vote
 	// envelope marshals to ~300 bytes, ~600 characters once hex-encoded into the JSON field, so
 	// this leaves an order of magnitude of headroom for larger proofs while keeping these public,

--- a/api/process_vote.go
+++ b/api/process_vote.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	stderrors "errors"
 	"net/http"
 	"strings"
 
@@ -39,13 +40,14 @@ import (
 //	@Success		202		{object}	apicommon.EnqueuedResponse	"Job accepted; poll GET /jobs/{jobId}"
 //	@Failure		400		{object}	errors.Error				"Invalid input data"
 //	@Failure		404		{object}	errors.Error				"Process not found"
+//	@Failure		413		{object}	errors.Error				"Request body too large"
 //	@Failure		500		{object}	errors.Error				"Internal server error"
 //	@Failure		503		{object}	errors.Error				"Transaction queue is full"
 //	@Router			/vote [post]
 func (a *API) relayVoteHandler(w http.ResponseWriter, r *http.Request) {
 	var req apicommon.RelayVoteRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		errors.ErrMalformedBody.Write(w)
+	if err := decodeCappedJSON(w, r, &req, maxVoteBodyBytes); err != nil {
+		err.Write(w)
 		return
 	}
 
@@ -83,10 +85,35 @@ func (a *API) relayVoteHandler(w http.ResponseWriter, r *http.Request) {
 	apicommon.HTTPWriteJSONStatus(w, http.StatusAccepted, &apicommon.EnqueuedResponse{JobID: jobID})
 }
 
-// maxVotesPerBatch bounds a POST /votes call. It matches the cap of the vochain batch
-// transaction endpoint and equals txQueueSize, so the largest accepted batch can at most
-// fill an empty queue.
-const maxVotesPerBatch = 100
+const (
+	// maxVotesPerBatch bounds a POST /votes call. It matches the cap of the vochain batch
+	// transaction endpoint and equals txQueueSize, so the largest accepted batch can at most
+	// fill an empty queue.
+	maxVotesPerBatch = 100
+	// maxVoteBodyBytes bounds the request body of a single relayed envelope. A CSP-signed vote
+	// envelope marshals to ~300 bytes, ~600 characters once hex-encoded into the JSON field, so
+	// this leaves an order of magnitude of headroom for larger proofs while keeping these public,
+	// unauthenticated endpoints from reading an unbounded body.
+	maxVoteBodyBytes = 8 << 10
+	// maxVotesBodyBytes bounds a whole batch: one envelope allowance each, plus slack for the
+	// JSON framing around them.
+	maxVotesBodyBytes = maxVotesPerBatch*maxVoteBodyBytes + 4<<10
+)
+
+// decodeCappedJSON reads at most limit bytes of the request body and decodes them into dst,
+// returning the API error to write back on a body that is too large or not the expected JSON.
+// The relay endpoints are public, so the body has to be bounded before it is buffered.
+func decodeCappedJSON(w http.ResponseWriter, r *http.Request, dst any, limit int64) *errors.Error {
+	r.Body = http.MaxBytesReader(w, r.Body, limit)
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		var tooLarge *http.MaxBytesError
+		if stderrors.As(err, &tooLarge) {
+			return asPtr(errors.ErrRequestBodyTooLarge.Withf("the limit is %d bytes", limit))
+		}
+		return asPtr(errors.ErrMalformedBody)
+	}
+	return nil
+}
 
 // relayVotesHandler godoc
 //
@@ -113,13 +140,14 @@ const maxVotesPerBatch = 100
 //	@Success		202		{object}	apicommon.EnqueuedResponse	"Job accepted; poll GET /jobs/{jobId}"
 //	@Failure		400		{object}	errors.Error				"Invalid input data"
 //	@Failure		404		{object}	errors.Error				"Process not found"
+//	@Failure		413		{object}	errors.Error				"Request body too large"
 //	@Failure		500		{object}	errors.Error				"Internal server error"
 //	@Failure		503		{object}	errors.Error				"Transaction queue is full"
 //	@Router			/votes [post]
 func (a *API) relayVotesHandler(w http.ResponseWriter, r *http.Request) {
 	var req apicommon.RelayVotesRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		errors.ErrMalformedBody.Write(w)
+	if err := decodeCappedJSON(w, r, &req, maxVotesBodyBytes); err != nil {
+		err.Write(w)
 		return
 	}
 	switch {

--- a/api/process_vote.go
+++ b/api/process_vote.go
@@ -13,7 +13,9 @@ import (
 	"github.com/vocdoni/saas-backend/errors"
 	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/dvote/vochain/state"
 	"go.vocdoni.io/proto/build/go/models"
 	"google.golang.org/protobuf/proto"
 )
@@ -46,32 +48,189 @@ func (a *API) relayVoteHandler(w http.ResponseWriter, r *http.Request) {
 		errors.ErrMalformedBody.Write(w)
 		return
 	}
-	if len(req.TxPayload) == 0 {
-		errors.ErrMalformedBody.Withf("missing txPayload").Write(w)
+
+	vote, apiErr := a.parseRelayVote(req.TxPayload)
+	if apiErr != nil {
+		apiErr.Write(w)
 		return
 	}
 
-	signedTx := &models.SignedTx{}
-	if err := proto.Unmarshal(req.TxPayload, signedTx); err != nil {
-		errors.ErrInvalidTxFormat.Withf("could not decode signed tx: %v", err).Write(w)
+	// submit + confirm on the worker pool; the vote nullifier (voteID) is recorded on the
+	// job. The structural checks above ran synchronously (a malformed vote got a 400, an
+	// unknown process a 404); the chain's acceptance of the vote is decided here, async, and
+	// surfaced on the job.
+	jobID, err := apicommon.NewJobID()
+	if err != nil {
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
 		return
+	}
+	// seed the job with what is already known about the envelope, so a caller polling a
+	// pending — or ultimately failed — job still learns which vote it is waiting on.
+	seed := &db.JobResult{ProcessID: vote.processID, Nullifier: vote.nullifier}
+	if err := a.db.CreateTxJobWithResult(jobID, db.JobTypeRelayVote, vote.org, seed); err != nil {
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+	if !a.enqueueTx(txTask{jobID: jobID, run: a.submitRelayVote(vote)}) {
+		// full queue: mark the job failed so it is not orphaned pending.
+		if e := a.db.SetJobStatus(jobID, db.JobStatusFailed, nil, "tx queue full"); e != nil {
+			log.Warnw("could not mark job failed after full queue", "error", e)
+		}
+		errors.ErrTxQueueFull.Write(w)
+		return
+	}
+
+	apicommon.HTTPWriteJSONStatus(w, http.StatusAccepted, &apicommon.EnqueuedResponse{JobID: jobID})
+}
+
+// maxVotesPerBatch bounds a POST /votes call. It matches the cap of the vochain batch
+// transaction endpoint and equals txQueueSize, so the largest accepted batch can at most
+// fill an empty queue.
+const maxVotesPerBatch = 100
+
+// relayVotesHandler godoc
+//
+//	@Summary		Relay a batch of already-signed votes to the Vochain
+//	@Description	Relays several voter transactions, already signed by the voter, in one call. A
+//	@Description	multi-question voting process is one vochain process per question, so a voter casts
+//	@Description	one vote transaction per question; relaying them one by one leaves a window in which
+//	@Description	some are on chain and the rest are not, and the voter ends up half-voted. This
+//	@Description	endpoint closes that window. Public endpoint: no authentication is required.
+//	@Description	The whole batch is checked synchronously and is accepted or rejected as a unit —
+//	@Description	every payload must decode to a Vote envelope (else 400) for a process the backend
+//	@Description	knows (else 404), all of them must belong to the same organization (else 400), and
+//	@Description	the queue must have room for all of them (else 503). A rejected batch enqueues
+//	@Description	nothing. At most 100 votes per call.
+//	@Description	The call returns 202 with a single job id covering the batch. Poll
+//	@Description	GET /jobs/{jobId}: its result carries one entry per vote, index-aligned with the
+//	@Description	request, each with the process id and the nullifier — both known before submission,
+//	@Description	so they are readable while the job is pending — plus the chain-assigned voteID once
+//	@Description	that vote is accepted, or the reason it failed.
+//	@Tags			vote
+//	@Accept			json
+//	@Produce		json
+//	@Param			request	body		apicommon.RelayVotesRequest	true	"Signed vote transaction payloads"
+//	@Success		202		{object}	apicommon.EnqueuedResponse	"Job accepted; poll GET /jobs/{jobId}"
+//	@Failure		400		{object}	errors.Error				"Invalid input data"
+//	@Failure		404		{object}	errors.Error				"Process not found"
+//	@Failure		500		{object}	errors.Error				"Internal server error"
+//	@Failure		503		{object}	errors.Error				"Transaction queue is full"
+//	@Router			/votes [post]
+func (a *API) relayVotesHandler(w http.ResponseWriter, r *http.Request) {
+	var req apicommon.RelayVotesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		errors.ErrMalformedBody.Write(w)
+		return
+	}
+	switch {
+	case len(req.Votes) == 0:
+		errors.ErrVoteBatchEmpty.Write(w)
+		return
+	case len(req.Votes) > maxVotesPerBatch:
+		errors.ErrVoteBatchTooLarge.Withf("%d votes, the maximum is %d", len(req.Votes), maxVotesPerBatch).Write(w)
+		return
+	}
+
+	// validate the whole batch before enqueuing anything: one bad envelope rejects the
+	// batch and leaves the voter with nothing relayed, which is recoverable, rather than
+	// with a relayed prefix, which is not.
+	votes := make([]*parsedVote, len(req.Votes))
+	seenNullifier := make(map[string]int, len(req.Votes))
+	for i, item := range req.Votes {
+		vote, apiErr := a.parseRelayVote(item.TxPayload)
+		if apiErr != nil {
+			apiErr.Withf("at vote index %d", i).Write(w)
+			return
+		}
+		// every vote is metered against, and the job belongs to, a single organization.
+		// The questions of a voting process share one, so a mixed batch is a client bug.
+		if i > 0 && vote.org != votes[0].org {
+			errors.ErrVoteBatchMixedOrganizations.Withf(
+				"vote index %d targets %s, vote index 0 targets %s", i, vote.org, votes[0].org).Write(w)
+			return
+		}
+		if len(vote.nullifier) > 0 {
+			if first, dup := seenNullifier[vote.nullifier.String()]; dup {
+				errors.ErrInvalidTxFormat.Withf(
+					"vote index %d repeats the nullifier of vote index %d", i, first).Write(w)
+				return
+			}
+			seenNullifier[vote.nullifier.String()] = i
+		}
+		votes[i] = vote
+	}
+
+	jobID, err := apicommon.NewJobID()
+	if err != nil {
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+	seed := make([]db.VoteJobResult, len(votes))
+	tasks := make([]txTask, len(votes))
+	for i, vote := range votes {
+		seed[i] = db.VoteJobResult{
+			ProcessID: vote.processID,
+			Nullifier: vote.nullifier,
+			Status:    db.JobStatusPending,
+		}
+		tasks[i] = txTask{
+			jobID:  jobID,
+			run:    a.submitRelayVote(vote),
+			record: a.recordBatchVote(jobID, i),
+		}
+	}
+	if err := a.db.CreateVoteBatchJob(jobID, votes[0].org, seed); err != nil {
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+	// one task per envelope rather than one task submitting them all: each submit blocks
+	// its worker until the tx is mined, so a single task would serialize the batch and hold
+	// one worker for the whole of it. enqueueTxBatch takes all the slots or none.
+	if !a.enqueueTxBatch(tasks) {
+		if e := a.db.SetJobStatus(jobID, db.JobStatusFailed, nil, "tx queue full"); e != nil {
+			log.Warnw("could not mark job failed after full queue", "error", e)
+		}
+		errors.ErrTxQueueFull.Write(w)
+		return
+	}
+
+	apicommon.HTTPWriteJSONStatus(w, http.StatusAccepted, &apicommon.EnqueuedResponse{JobID: jobID})
+}
+
+// parsedVote is one validated vote envelope: the payload to relay plus everything the
+// job needs to describe it before the chain has said anything about it.
+type parsedVote struct {
+	payload   internal.HexBytes
+	processID internal.HexBytes
+	org       common.Address
+	nullifier internal.HexBytes
+}
+
+// parseRelayVote runs the synchronous checks of a vote relay: the payload must decode to
+// a vote envelope naming a process this backend manages. It returns the resolved vote or
+// the API error to write back, never both.
+func (a *API) parseRelayVote(payload internal.HexBytes) (*parsedVote, *errors.Error) {
+	if len(payload) == 0 {
+		return nil, asPtr(errors.ErrMalformedBody.Withf("missing txPayload"))
+	}
+
+	signedTx := &models.SignedTx{}
+	if err := proto.Unmarshal(payload, signedTx); err != nil {
+		return nil, asPtr(errors.ErrInvalidTxFormat.Withf("could not decode signed tx: %v", err))
 	}
 	innerTx := &models.Tx{}
 	if err := proto.Unmarshal(signedTx.Tx, innerTx); err != nil {
-		errors.ErrInvalidTxFormat.Withf("could not decode tx: %v", err).Write(w)
-		return
+		return nil, asPtr(errors.ErrInvalidTxFormat.Withf("could not decode tx: %v", err))
 	}
 
 	vote := innerTx.GetVote()
 	if vote == nil {
-		errors.ErrInvalidTxFormat.With("not a vote tx").Write(w)
-		return
+		return nil, asPtr(errors.ErrInvalidTxFormat.With("not a vote tx"))
 	}
 	// the target process is the one named in the signed vote envelope.
 	pid := internal.HexBytes(vote.ProcessId)
 	if len(pid) == 0 {
-		errors.ErrInvalidTxFormat.With("vote has no process id").Write(w)
-		return
+		return nil, asPtr(errors.ErrInvalidTxFormat.With("vote has no process id"))
 	}
 
 	// ensure we manage this election, resolving its owning organization. Legacy elections
@@ -89,53 +248,88 @@ func (a *API) relayVoteHandler(w http.ResponseWriter, r *http.Request) {
 		case nil:
 			orgAddress = question.OrgAddress
 		case db.ErrNotFound:
-			errors.ErrProcessNotFound.Write(w)
-			return
+			return nil, asPtr(errors.ErrProcessNotFound)
 		default:
-			errors.ErrGenericInternalServerError.WithErr(qErr).Write(w)
-			return
+			return nil, asPtr(errors.ErrGenericInternalServerError.WithErr(qErr))
 		}
 	default:
-		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
-		return
+		return nil, asPtr(errors.ErrGenericInternalServerError.WithErr(err))
 	}
 
-	// submit + confirm on the worker pool; the vote nullifier (voteID) is recorded on the
-	// job. The structural checks above ran synchronously (a malformed vote got a 400, an
-	// unknown process a 404); the chain's acceptance of the vote is decided here, async, and
-	// surfaced on the job.
-	jobID, err := apicommon.NewJobID()
+	return &parsedVote{
+		payload:   payload,
+		processID: pid,
+		org:       orgAddress,
+		nullifier: voteNullifier(signedTx, vote, pid, a.account.ChainID()),
+	}, nil
+}
+
+// voteNullifier works out the nullifier of an envelope without submitting it, so a vote
+// can be identified while its job is still pending and after it failed. An anonymous vote
+// carries its own; otherwise it is hash(voter address + process id), the same value the
+// chain returns as the voteID once it accepts the vote. Best effort: an envelope we
+// cannot recover a signer from yields no nullifier and is relayed anyway — the chain, not
+// this backend, decides whether a signature is valid.
+func voteNullifier(signedTx *models.SignedTx, vote *models.VoteEnvelope, pid internal.HexBytes,
+	chainID string,
+) internal.HexBytes {
+	if len(vote.Nullifier) > 0 {
+		return internal.HexBytes(vote.Nullifier)
+	}
+	msg, _, err := ethereum.BuildVocdoniTransaction(signedTx.Tx, chainID)
 	if err != nil {
-		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
-		return
+		log.Debugw("could not build vote tx message to derive its nullifier", "error", err)
+		return nil
 	}
-	if err := a.db.CreateTxJob(jobID, db.JobTypeRelayVote, orgAddress); err != nil {
-		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
-		return
+	addr, err := ethereum.AddrFromSignature(msg, signedTx.Signature)
+	if err != nil {
+		log.Debugw("could not recover the voter address to derive its nullifier", "error", err)
+		return nil
 	}
-	payload := req.TxPayload
-	if !a.enqueueTx(txTask{jobID: jobID, run: func() (*db.JobResult, error) {
-		voteID, err := a.account.SubmitSignedTx(payload)
+	return internal.HexBytes(state.GenerateNullifier(addr, pid))
+}
+
+// submitRelayVote builds the worker closure that relays one envelope: submit, wait for it
+// to be mined, and meter it. The returned voteID is the vote nullifier as assigned on chain.
+func (a *API) submitRelayVote(vote *parsedVote) func() (*db.JobResult, error) {
+	return func() (*db.JobResult, error) {
+		voteID, err := a.account.SubmitSignedTx(vote.payload)
 		if err != nil {
 			return nil, err
 		}
 		// meter the relayed vote for billing/quota; best-effort, never fail the relay on a
 		// counter error. The quota itself is enforced at election publish, not here.
-		if err := a.db.IncrementOrganizationSentVotesCounter(orgAddress); err != nil {
+		if err := a.db.IncrementOrganizationSentVotesCounter(vote.org); err != nil {
 			log.Errorw(err, "failed to increment org sent votes counter")
 		}
-		return &db.JobResult{VoteID: internal.HexBytes(voteID)}, nil
-	}}) {
-		// full queue: mark the job failed so it is not orphaned pending.
-		if e := a.db.SetJobStatus(jobID, db.JobStatusFailed, nil, "tx queue full"); e != nil {
-			log.Warnw("could not mark job failed after full queue", "error", e)
-		}
-		errors.ErrTxQueueFull.Write(w)
-		return
+		return &db.JobResult{
+			ProcessID: vote.processID,
+			Nullifier: vote.nullifier,
+			VoteID:    internal.HexBytes(voteID),
+		}, nil
 	}
-
-	apicommon.HTTPWriteJSONStatus(w, http.StatusAccepted, &apicommon.EnqueuedResponse{JobID: jobID})
 }
+
+// recordBatchVote builds the outcome recorder for one envelope of a batch job: it writes
+// that envelope's entry instead of closing the shared job, which only the last envelope
+// to report does.
+func (a *API) recordBatchVote(jobID string, index int) func(*db.JobResult, error) {
+	return func(result *db.JobResult, runErr error) {
+		var voteID internal.HexBytes
+		var errMsg string
+		if runErr != nil {
+			errMsg = runErr.Error()
+		} else if result != nil {
+			voteID = result.VoteID
+		}
+		if err := a.db.RecordBatchVoteOutcome(jobID, index, voteID, errMsg); err != nil {
+			log.Warnw("could not record batch vote outcome", "jobId", jobID, "index", index, "error", err)
+		}
+	}
+}
+
+// asPtr lifts an API error to a pointer, so parseRelayVote can signal "no error" with nil.
+func asPtr(e errors.Error) *errors.Error { return &e }
 
 // setProcessStatusHandler godoc
 //

--- a/api/process_vote_test.go
+++ b/api/process_vote_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/csp/handlers"
 	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/errors"
 	"github.com/vocdoni/saas-backend/internal"
+	"go.vocdoni.io/dvote/apiclient"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/types"
 	"go.vocdoni.io/proto/build/go/models"
@@ -122,9 +124,9 @@ func TestProcessStatusLifecycle(t *testing.T) {
 	}
 }
 
-// testRelayVoteRequest signs a vote tx, wraps it as a SignedTx, posts it to
-// POST /vote, and returns the relayed vote nullifier.
-func testRelayVoteRequest(t *testing.T, signer *ethereum.SignKeys, processID internal.HexBytes,
+// testSignVoteTx builds a vote envelope for processID and signs it as the voter would,
+// returning the marshaled models.SignedTx the relay endpoints take as their payload.
+func testSignVoteTx(t *testing.T, signer *ethereum.SignKeys, processID internal.HexBytes,
 	proof *models.Proof, votePackage []byte,
 ) internal.HexBytes {
 	t.Helper()
@@ -139,17 +141,56 @@ func testRelayVoteRequest(t *testing.T, signer *ethereum.SignKeys, processID int
 	c.Assert(err, qt.IsNil)
 	stx, err := proto.Marshal(&models.SignedTx{Tx: txBytes, Signature: signature})
 	c.Assert(err, qt.IsNil)
+	return stx
+}
+
+// testRelayVoteRequest signs a vote tx, wraps it as a SignedTx, posts it to
+// POST /vote, and returns the relayed vote nullifier.
+func testRelayVoteRequest(t *testing.T, signer *ethereum.SignKeys, processID internal.HexBytes,
+	proof *models.Proof, votePackage []byte,
+) internal.HexBytes {
+	t.Helper()
+	c := qt.New(t)
+	stx := testSignVoteTx(t, signer, processID, proof, votePackage)
 	job := enqueueAndPollJob(t, http.MethodPost, "",
 		&apicommon.RelayVoteRequest{TxPayload: stx}, "vote")
 	c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("error: %s", job.Errors))
 	c.Assert(job.Result.VoteID, qt.Not(qt.HasLen), 0)
+	// the nullifier is derived from the envelope before it is submitted, so it is on the
+	// job regardless of what the chain replied, and it must match the chain's voteID.
+	c.Assert(job.Result.Nullifier, qt.DeepEquals, job.Result.VoteID)
+	c.Assert(job.Result.ProcessID, qt.DeepEquals, processID)
 	return job.Result.VoteID
 }
 
-// TestRelayVote builds the full CSP voting setup (org, census, bundle, on-chain
-// process) and casts a vote via the public relay endpoint instead of submitting it
-// directly to the chain, asserting the vote is counted and a nullifier is returned.
-func TestRelayVote(t *testing.T) {
+// relayVotingFixture is a voter authenticated against a CSP bundle covering one or more
+// on-chain processes, i.e. everything the relay endpoints need to accept a real vote.
+type relayVotingFixture struct {
+	token      string
+	client     *apiclient.HTTPclient
+	orgAddress common.Address
+	processIDs []internal.HexBytes
+	bundleID   string
+	authToken  internal.HexBytes
+	voter      *ethereum.SignKeys
+}
+
+// proofFor CSP-signs the voter's address for one of the fixture's processes and builds the
+// vote proof from it. The CSP consumes a process per user, not a bundle, so the same auth
+// token signs once for each process — which is exactly what a multi-question vote does.
+func (f *relayVotingFixture) proofFor(t *testing.T, processID internal.HexBytes) *models.Proof {
+	t.Helper()
+	voterAddr := f.voter.Address().Bytes()
+	signature := testCSPSign(t, f.bundleID, f.authToken, processID, voterAddr)
+	return testGenerateVoteProof(processID, voterAddr, signature, 1)
+}
+
+// setupRelayVoting builds the full CSP voting setup shared by the relay tests: an
+// organization with an on-chain account and a plan, processes many on-chain elections
+// whose census root is the CSP, a published group census bundled with them, and a voter
+// authenticated against that bundle.
+func setupRelayVoting(t *testing.T, processes int) *relayVotingFixture {
+	t.Helper()
 	c := qt.New(t)
 
 	// create a user and organization
@@ -182,32 +223,36 @@ func TestRelayVote(t *testing.T) {
 	}}}
 	signRemoteSignerAndSendVocdoniTx(t, accountTx, token, vocdoniClient, orgAddress)
 
-	// create an on-chain process whose census root is the CSP public key
+	// create the on-chain processes, whose census root is the CSP public key
 	cspPubKey, err := testCSP.PubKey()
 	c.Assert(err, qt.IsNil)
-	processNonce := fetchVocdoniAccountNonce(t, vocdoniClient, orgAddress)
-	processTx := &models.Tx{Payload: &models.Tx_NewProcess{NewProcess: &models.NewProcessTx{
-		Txtype: models.TxType_NEW_PROCESS,
-		Nonce:  processNonce,
-		Process: &models.Process{
-			EntityId:      orgAddress.Bytes(),
-			Duration:      120,
-			Status:        models.ProcessStatus_READY,
-			CensusOrigin:  models.CensusOrigin_OFF_CHAIN_CA,
-			CensusRoot:    cspPubKey,
-			MaxCensusSize: 10,
-			EnvelopeType:  &models.EnvelopeType{Anonymous: false, CostFromWeight: false},
-			VoteOptions:   &models.ProcessVoteOptions{MaxCount: 1, MaxValue: 5},
-			Mode:          &models.ProcessMode{AutoStart: true, Interruptible: true},
-		},
-	}}}
-	processIDBytes := signRemoteSignerAndSendVocdoniTx(t, processTx, token, vocdoniClient, orgAddress)
-	processID := internal.HexBytes(processIDBytes)
-	t.Logf("Created process with ID: %x", processIDBytes)
+	processIDs := make([]internal.HexBytes, processes)
+	rawProcessIDs := make([][]byte, processes)
+	for i := range processIDs {
+		processNonce := fetchVocdoniAccountNonce(t, vocdoniClient, orgAddress)
+		processTx := &models.Tx{Payload: &models.Tx_NewProcess{NewProcess: &models.NewProcessTx{
+			Txtype: models.TxType_NEW_PROCESS,
+			Nonce:  processNonce,
+			Process: &models.Process{
+				EntityId:      orgAddress.Bytes(),
+				Duration:      120,
+				Status:        models.ProcessStatus_READY,
+				CensusOrigin:  models.CensusOrigin_OFF_CHAIN_CA,
+				CensusRoot:    cspPubKey,
+				MaxCensusSize: 10,
+				EnvelopeType:  &models.EnvelopeType{Anonymous: false, CostFromWeight: false},
+				VoteOptions:   &models.ProcessVoteOptions{MaxCount: 1, MaxValue: 5},
+				Mode:          &models.ProcessMode{AutoStart: true, Interruptible: true},
+			},
+		}}}
+		rawProcessIDs[i] = signRemoteSignerAndSendVocdoniTx(t, processTx, token, vocdoniClient, orgAddress)
+		processIDs[i] = internal.HexBytes(rawProcessIDs[i])
+		t.Logf("Created process with ID: %x", rawProcessIDs[i])
 
-	// the relay handler requires the process to be known by its on-chain address
-	_, err = testDB.SetProcess(&db.Process{OrgAddress: orgAddress, Address: processID})
-	c.Assert(err, qt.IsNil)
+		// the relay handler requires the process to be known by its on-chain address
+		_, err = testDB.SetProcess(&db.Process{OrgAddress: orgAddress, Address: processIDs[i]})
+		c.Assert(err, qt.IsNil)
+	}
 
 	// create a census, add members and publish a group-based census
 	authFields := db.OrgMemberAuthFields{
@@ -217,13 +262,14 @@ func TestRelayVote(t *testing.T) {
 	}
 	twoFaFields := db.OrgMemberTwoFaFields{db.OrgMemberTwoFaFieldEmail}
 
+	suffix := internal.RandomInt(1000000)
 	members := []apicommon.OrgMember{{
 		Name:         "Relay",
 		Surname:      "Voter",
-		MemberNumber: "R001",
-		NationalID:   "RELAY0001A",
+		MemberNumber: fmt.Sprintf("R%06d", suffix),
+		NationalID:   fmt.Sprintf("RELAY%05dA", suffix),
 		BirthDate:    "1990-01-01",
-		Email:        "relay.voter@example.com",
+		Email:        fmt.Sprintf("relay.voter.%d@example.com", suffix),
 		Phone:        "+34699000001",
 		Weight:       "1",
 	}}
@@ -244,8 +290,8 @@ func TestRelayVote(t *testing.T) {
 			TwoFaFields: twoFaFields,
 		}, "census", censusID, "group", group.ID, "publish")
 
-	// create a bundle linking the census and process
-	bundleID, _ := postProcessBundle(t, token, censusID, processIDBytes)
+	// create a bundle linking the census and every process
+	bundleID, _ := postProcessBundle(t, token, censusID, rawProcessIDs...)
 
 	// authenticate the voter with the CSP
 	authToken := testCSPAuthenticateWithFields(t, bundleID, &handlers.AuthRequest{
@@ -255,26 +301,181 @@ func TestRelayVote(t *testing.T) {
 		Email:        members[0].Email,
 	})
 
-	// generate the voter key, CSP-sign its address and build the vote proof
-	voter := ethereum.SignKeys{}
+	voter := &ethereum.SignKeys{}
 	c.Assert(voter.Generate(), qt.IsNil)
-	voterAddr := voter.Address().Bytes()
-	signature := testCSPSign(t, bundleID, authToken, processID, voterAddr)
-	proof := testGenerateVoteProof(processID, voterAddr, signature, 1)
+
+	return &relayVotingFixture{
+		token:      token,
+		client:     vocdoniClient,
+		orgAddress: orgAddress,
+		processIDs: processIDs,
+		bundleID:   bundleID,
+		authToken:  authToken,
+		voter:      voter,
+	}
+}
+
+// TestRelayVote casts a vote via the public relay endpoint instead of submitting it
+// directly to the chain, asserting the vote is counted and a nullifier is returned.
+func TestRelayVote(t *testing.T) {
+	c := qt.New(t)
+	f := setupRelayVoting(t, 1)
+	processID := f.processIDs[0]
+	proof := f.proofFor(t, processID)
 
 	// relay the vote and assert the chain counted it
-	votesBefore, err := vocdoniClient.ElectionVoteCount(processID.Bytes())
+	votesBefore, err := f.client.ElectionVoteCount(processID.Bytes())
 	c.Assert(err, qt.IsNil)
 
-	nullifier := testRelayVoteRequest(t, &voter, processID, proof, []byte("[\"1\"]"))
+	nullifier := testRelayVoteRequest(t, f.voter, processID, proof, []byte("[\"1\"]"))
 	c.Assert(nullifier, qt.Not(qt.HasLen), 0)
 
-	votesAfter, err := vocdoniClient.ElectionVoteCount(processID.Bytes())
+	votesAfter, err := f.client.ElectionVoteCount(processID.Bytes())
 	c.Assert(err, qt.IsNil)
 	c.Assert(votesAfter, qt.Equals, votesBefore+1, qt.Commentf("expected 1 more vote, got %d", votesAfter))
 
 	// a chain-accepted relay meters the owning organization's SentVotes counter
-	orgAfter, err := testDB.Organization(orgAddress)
+	orgAfter, err := testDB.Organization(f.orgAddress)
 	c.Assert(err, qt.IsNil)
 	c.Assert(orgAfter.Counters.SentVotes, qt.Equals, 1)
+}
+
+// TestRelayVotesBatch relays the votes of a multi-question process in a single call and
+// asserts the batch lands as one job: every envelope's nullifier is readable from the job
+// before the chain has replied, and each ends up with the voteID the chain assigned it.
+func TestRelayVotesBatch(t *testing.T) {
+	c := qt.New(t)
+	const questions = 3
+	f := setupRelayVoting(t, questions)
+
+	req := &apicommon.RelayVotesRequest{Votes: make([]apicommon.RelayVoteRequest, questions)}
+	votesBefore := make([]uint32, questions)
+	for i, processID := range f.processIDs {
+		var err error
+		votesBefore[i], err = f.client.ElectionVoteCount(processID.Bytes())
+		c.Assert(err, qt.IsNil)
+		proof := f.proofFor(t, processID)
+		req.Votes[i] = apicommon.RelayVoteRequest{
+			TxPayload: testSignVoteTx(t, f.voter, processID, proof, []byte("[\"1\"]")),
+		}
+	}
+
+	enq := requestAndParseWithAssertCode[apicommon.EnqueuedResponse](
+		http.StatusAccepted, t, http.MethodPost, "", req, "votes")
+	c.Assert(enq.JobID, qt.Not(qt.Equals), "")
+
+	// the nullifiers are derived before submission, so they are on the job from the very
+	// first read — whether or not the chain has accepted anything yet.
+	early := requestAndParse[apicommon.JobResponse](t, http.MethodGet, "", nil, "jobs", enq.JobID)
+	c.Assert(early.Type, qt.Equals, db.JobTypeRelayVotes)
+	c.Assert(early.Result.Votes, qt.HasLen, questions)
+	for i, vote := range early.Result.Votes {
+		c.Assert(vote.Nullifier, qt.Not(qt.HasLen), 0, qt.Commentf("vote %d has no nullifier yet", i))
+		c.Assert(vote.ProcessID, qt.DeepEquals, f.processIDs[i])
+	}
+
+	job := pollJob(t, enq.JobID)
+	c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("errors: %s", job.Errors))
+	c.Assert(job.Result.Total, qt.Equals, questions)
+	c.Assert(job.Result.Added, qt.Equals, questions)
+	c.Assert(job.Result.Votes, qt.HasLen, questions)
+	for i, vote := range job.Result.Votes {
+		comment := qt.Commentf("vote %d: %s", i, vote.Error)
+		c.Assert(vote.Status, qt.Equals, db.JobStatusCompleted, comment)
+		c.Assert(vote.ProcessID, qt.DeepEquals, f.processIDs[i], comment)
+		c.Assert(vote.VoteID, qt.Not(qt.HasLen), 0, comment)
+		// the chain assigns the very nullifier the handler derived from the envelope
+		c.Assert(vote.VoteID, qt.DeepEquals, vote.Nullifier, comment)
+	}
+
+	// every question got its vote, and every relayed envelope was metered
+	for i, processID := range f.processIDs {
+		votesAfter, err := f.client.ElectionVoteCount(processID.Bytes())
+		c.Assert(err, qt.IsNil)
+		c.Assert(votesAfter, qt.Equals, votesBefore[i]+1, qt.Commentf("process %d was not voted", i))
+	}
+	orgAfter, err := testDB.Organization(f.orgAddress)
+	c.Assert(err, qt.IsNil)
+	c.Assert(orgAfter.Counters.SentVotes, qt.Equals, questions)
+}
+
+// TestRelayVotesRejectsBatch checks that a batch is validated as a unit: every rejection
+// happens before anything is enqueued, so a voter retries from a clean slate instead of
+// discovering that a prefix of their questions was voted.
+func TestRelayVotesRejectsBatch(t *testing.T) {
+	c := qt.New(t)
+	chainID := fetchVocdoniChainID(t, testNewVocdoniClient(t))
+
+	// two organizations, each owning a process the backend knows about. No chain
+	// interaction is needed: every case below is rejected by the synchronous checks.
+	newOrgProcess := func() (common.Address, internal.HexBytes) {
+		token := testCreateUser(t, "superpassword123")
+		orgAddress := testCreateOrganization(t, token)
+		processID := internal.HexBytes(randomProcessID())
+		_, err := testDB.SetProcess(&db.Process{OrgAddress: orgAddress, Address: processID})
+		c.Assert(err, qt.IsNil)
+		return orgAddress, processID
+	}
+	_, processA := newOrgProcess()
+	_, processB := newOrgProcess()
+
+	voter := &ethereum.SignKeys{}
+	c.Assert(voter.Generate(), qt.IsNil)
+	voteFor := func(processID internal.HexBytes) apicommon.RelayVoteRequest {
+		return apicommon.RelayVoteRequest{
+			TxPayload: testSignVoteTx(t, voter, processID, nil, []byte("[\"1\"]")),
+		}
+	}
+	// a well-formed SignedTx that is not a vote
+	notAVote, err := proto.Marshal(&models.Tx{Payload: &models.Tx_SetAccount{
+		SetAccount: &models.SetAccountTx{Txtype: models.TxType_CREATE_ACCOUNT},
+	}})
+	c.Assert(err, qt.IsNil)
+	signature, err := voter.SignVocdoniTx(notAVote, chainID)
+	c.Assert(err, qt.IsNil)
+	notAVoteTx, err := proto.Marshal(&models.SignedTx{Tx: notAVote, Signature: signature})
+	c.Assert(err, qt.IsNil)
+
+	for _, tc := range []struct {
+		name     string
+		votes    []apicommon.RelayVoteRequest
+		expected errors.Error
+	}{
+		{"empty batch", nil, errors.ErrVoteBatchEmpty},
+		{
+			"over the cap",
+			make([]apicommon.RelayVoteRequest, maxVotesPerBatch+1),
+			errors.ErrVoteBatchTooLarge,
+		},
+		{
+			"one payload missing",
+			[]apicommon.RelayVoteRequest{voteFor(processA), {}},
+			errors.ErrMalformedBody,
+		},
+		{
+			"one payload not a vote",
+			[]apicommon.RelayVoteRequest{voteFor(processA), {TxPayload: notAVoteTx}},
+			errors.ErrInvalidTxFormat,
+		},
+		{
+			"one process unknown",
+			[]apicommon.RelayVoteRequest{voteFor(processA), voteFor(internal.HexBytes(randomProcessID()))},
+			errors.ErrProcessNotFound,
+		},
+		{
+			"votes of two organizations",
+			[]apicommon.RelayVoteRequest{voteFor(processA), voteFor(processB)},
+			errors.ErrVoteBatchMixedOrganizations,
+		},
+		{
+			"the same vote twice",
+			[]apicommon.RelayVoteRequest{voteFor(processA), voteFor(processA)},
+			errors.ErrInvalidTxFormat,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requestAndAssertError(tc.expected, t, http.MethodPost, "",
+				&apicommon.RelayVotesRequest{Votes: tc.votes}, "votes")
+		})
+	}
 }

--- a/api/process_vote_test.go
+++ b/api/process_vote_test.go
@@ -399,6 +399,13 @@ func TestRelayVotesBatch(t *testing.T) {
 	c.Assert(orgAfter.Counters.SentVotes, qt.Equals, questions)
 }
 
+// TestRelayVoteRejectsOversizedBody checks that the single-vote relay, public and
+// unauthenticated like the batch one, also refuses a body it would otherwise buffer whole.
+func TestRelayVoteRejectsOversizedBody(t *testing.T) {
+	requestAndAssertError(errors.ErrRequestBodyTooLarge, t, http.MethodPost, "",
+		&apicommon.RelayVoteRequest{TxPayload: internal.HexBytes(make([]byte, maxVoteBodyBytes))}, "vote")
+}
+
 // TestRelayVotesRejectsBatch checks that a batch is validated as a unit: every rejection
 // happens before anything is enqueued, so a voter retries from a clean slate instead of
 // discovering that a prefix of their questions was voted.
@@ -471,6 +478,12 @@ func TestRelayVotesRejectsBatch(t *testing.T) {
 			"the same vote twice",
 			[]apicommon.RelayVoteRequest{voteFor(processA), voteFor(processA)},
 			errors.ErrInvalidTxFormat,
+		},
+		{
+			// the endpoint is public, so an oversized body is refused before it is buffered
+			"body over the size cap",
+			[]apicommon.RelayVoteRequest{{TxPayload: internal.HexBytes(make([]byte, maxVotesBodyBytes))}},
+			errors.ErrRequestBodyTooLarge,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/api/routes.go
+++ b/api/routes.go
@@ -174,6 +174,11 @@ const (
 	// from the signed vote envelope itself, so no process id appears in the path.
 	voteEndpoint = "/vote"
 
+	// POST /votes to relay several already-signed votes in one call (public), so a voter
+	// casting the questions of a multi-question process cannot end up half-voted. The
+	// whole batch is validated and enqueued all or nothing, under a single job.
+	votesEndpoint = "/votes"
+
 	// GET /process/{processId}/results to get the trimmed on-chain election results (public).
 	// {processId} is the 24-hex ProcessID (not the on-chain election id).
 	processResultsEndpoint = "/process/{processId}/results"

--- a/db/jobs.go
+++ b/db/jobs.go
@@ -119,6 +119,25 @@ func (ms *MongoStorage) CreateVoteBatchJob(jobID string, orgAddress common.Addre
 	})
 }
 
+// TerminalVoteBatchStatus derives the outcome of a batch vote job from its per-envelope entries:
+// completed only when every envelope was, failed otherwise, with one error line per failure.
+//
+// It is exported because two paths must agree on it — the worker that closes the job once the last
+// envelope reports, and the read path, which derives the same answer when it finds a job with every
+// envelope reported but no terminal status stored (a crash between those two writes, or simply a
+// read landing in the moment between them). Sharing the function is what keeps the stored and the
+// derived status from ever disagreeing.
+func TerminalVoteBatchStatus(votes []VoteJobResult) (JobStatus, []string) {
+	status, errs := JobStatusCompleted, []string{}
+	for i, vote := range votes {
+		if vote.Status != JobStatusCompleted {
+			status = JobStatusFailed
+			errs = append(errs, fmt.Sprintf("vote %d: %s", i, vote.Error))
+		}
+	}
+	return status, errs
+}
+
 // RecordBatchVoteOutcome records the terminal outcome of one envelope of a batch vote
 // job: pass the chain-returned voteID and an empty errMsg on success, or a nil voteID
 // and the failure reason. Workers run concurrently, so the per-envelope write and the
@@ -170,15 +189,11 @@ func (ms *MongoStorage) RecordBatchVoteOutcome(jobID string, index int, voteID i
 	}
 
 	// last envelope in: close the job.
-	jobStatus, errs := JobStatusCompleted, []string{}
+	var votes []VoteJobResult
 	if job.Result != nil {
-		for i, vote := range job.Result.Votes {
-			if vote.Status != JobStatusCompleted {
-				jobStatus = JobStatusFailed
-				errs = append(errs, fmt.Sprintf("vote %d: %s", i, vote.Error))
-			}
-		}
+		votes = job.Result.Votes
 	}
+	jobStatus, errs := TerminalVoteBatchStatus(votes)
 	closing := bson.M{"status": jobStatus, "completedAt": time.Now(), "errors": errs}
 	if jobStatus == JobStatusFailed {
 		closing["error"] = fmt.Sprintf("%d of %d votes failed", len(errs), job.Total)

--- a/db/jobs.go
+++ b/db/jobs.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -79,14 +80,105 @@ func (ms *MongoStorage) CreateJob(jobID string, jobType JobType, orgAddress comm
 // (import jobs), it carries no Total/Added counters; the outcome is recorded later
 // via SetJobStatus.
 func (ms *MongoStorage) CreateTxJob(jobID string, jobType JobType, orgAddress common.Address) error {
+	return ms.CreateTxJobWithResult(jobID, jobType, orgAddress, nil)
+}
+
+// CreateTxJobWithResult is CreateTxJob seeding the job with an already-known partial
+// result. A vote relay uses it to record the process id and the nullifier it derived
+// from the signed envelope, so both are readable while the job is still pending and
+// after it failed — SetJobStatus only overwrites `result` when it is handed a non-nil
+// one, so the seeded fields survive the terminal write.
+func (ms *MongoStorage) CreateTxJobWithResult(
+	jobID string, jobType JobType, orgAddress common.Address, result *JobResult,
+) error {
 	return ms.SetJob(&Job{
 		JobID:      jobID,
 		Type:       jobType,
 		OrgAddress: orgAddress,
 		Errors:     []string{},
 		Status:     JobStatusPending,
+		Result:     result,
 		CreatedAt:  time.Now(),
 	})
+}
+
+// CreateVoteBatchJob inserts the single pending job that covers a whole POST /votes
+// batch. votes is index-aligned with the request and already carries each envelope's
+// process id and nullifier; Total is the batch size, so job progress is the number of
+// envelopes that have reported an outcome.
+func (ms *MongoStorage) CreateVoteBatchJob(jobID string, orgAddress common.Address, votes []VoteJobResult) error {
+	return ms.SetJob(&Job{
+		JobID:      jobID,
+		Type:       JobTypeRelayVotes,
+		OrgAddress: orgAddress,
+		Total:      len(votes),
+		Errors:     []string{},
+		Status:     JobStatusPending,
+		Result:     &JobResult{Votes: votes},
+		CreatedAt:  time.Now(),
+	})
+}
+
+// RecordBatchVoteOutcome records the terminal outcome of one envelope of a batch vote
+// job: pass the chain-returned voteID and an empty errMsg on success, or a nil voteID
+// and the failure reason. Workers run concurrently, so the per-envelope write and the
+// progress counter are applied in a single atomic update; the worker that completes the
+// last envelope is the one that closes the job, marking it completed when every envelope
+// succeeded and failed otherwise.
+func (ms *MongoStorage) RecordBatchVoteOutcome(jobID string, index int, voteID internal.HexBytes, errMsg string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+
+	status := JobStatusCompleted
+	if errMsg != "" {
+		status = JobStatusFailed
+	}
+	item := fmt.Sprintf("result.votes.%d.", index)
+	set := bson.M{item + "status": status}
+	if len(voteID) > 0 {
+		set[item+"voteID"] = voteID
+	}
+	if errMsg != "" {
+		set[item+"error"] = errMsg
+	}
+
+	var job Job
+	err := ms.jobs.FindOneAndUpdate(ctx,
+		bson.M{"jobId": jobID},
+		bson.M{"$set": set, "$inc": bson.M{"added": 1}},
+		options.FindOneAndUpdate().SetReturnDocument(options.After),
+	).Decode(&job)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return ErrNotFound
+		}
+		return fmt.Errorf("failed to record batch vote outcome: %w", err)
+	}
+	if job.Added < job.Total {
+		return nil
+	}
+
+	// last envelope in: close the job.
+	jobStatus, errs := JobStatusCompleted, []string{}
+	if job.Result != nil {
+		for i, vote := range job.Result.Votes {
+			if vote.Status != JobStatusCompleted {
+				jobStatus = JobStatusFailed
+				errs = append(errs, fmt.Sprintf("vote %d: %s", i, vote.Error))
+			}
+		}
+	}
+	closing := bson.M{"status": jobStatus, "completedAt": time.Now(), "errors": errs}
+	if jobStatus == JobStatusFailed {
+		closing["error"] = fmt.Sprintf("%d of %d votes failed", len(errs), job.Total)
+	}
+	if _, err := ms.jobs.UpdateOne(ctx, bson.M{"jobId": jobID}, bson.M{"$set": closing}); err != nil {
+		return fmt.Errorf("failed to close batch vote job: %w", err)
+	}
+	return nil
 }
 
 // SetJobStatus records the terminal outcome of a transaction job. On success pass

--- a/db/jobs.go
+++ b/db/jobs.go
@@ -145,14 +145,22 @@ func (ms *MongoStorage) RecordBatchVoteOutcome(jobID string, index int, voteID i
 		set[item+"error"] = errMsg
 	}
 
+	// require the entry to already exist: a $set on an out-of-range array index would pad the array
+	// with nulls up to it, and the $inc would count an envelope that is not part of the batch and
+	// close the job early. Matching on $exists makes an out-of-range write a no-op instead.
 	var job Job
 	err := ms.jobs.FindOneAndUpdate(ctx,
-		bson.M{"jobId": jobID},
+		bson.M{"jobId": jobID, fmt.Sprintf("result.votes.%d", index): bson.M{"$exists": true}},
 		bson.M{"$set": set, "$inc": bson.M{"added": 1}},
 		options.FindOneAndUpdate().SetReturnDocument(options.After),
 	).Decode(&job)
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
+			// tell a missing job apart from a bad index, so an out-of-range write is not reported as
+			// a job that does not exist.
+			if n, cErr := ms.jobs.CountDocuments(ctx, bson.M{"jobId": jobID}); cErr == nil && n > 0 {
+				return fmt.Errorf("vote index %d is not part of batch job %s", index, jobID)
+			}
 			return ErrNotFound
 		}
 		return fmt.Errorf("failed to record batch vote outcome: %w", err)

--- a/db/jobs_test.go
+++ b/db/jobs_test.go
@@ -131,6 +131,12 @@ func TestRecordBatchVoteOutcome(t *testing.T) {
 		c.Assert(job.Result.Votes[1].Nullifier, qt.DeepEquals, internal.HexBytes{0xaa, 1})
 		c.Assert(job.Result.Votes[1].VoteID, qt.HasLen, 0)
 		c.Assert(job.Result.Votes[2].Status, qt.Equals, JobStatusCompleted)
+
+		// the status the worker stored and the one derived from the entries must be the same, or a
+		// job read across the gap between the counter and the closing write would flip its answer
+		derivedStatus, derivedErrs := TerminalVoteBatchStatus(job.Result.Votes)
+		c.Assert(derivedStatus, qt.Equals, job.Status)
+		c.Assert(derivedErrs, qt.DeepEquals, job.Errors)
 	})
 
 	c.Run("unknown job", func(c *qt.C) {

--- a/db/jobs_test.go
+++ b/db/jobs_test.go
@@ -1,11 +1,13 @@
 package db
 
 import (
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -52,6 +54,88 @@ func TestJobOperations(t *testing.T) {
 	// Test non-existent job
 	_, err = testDB.Job("non-existent-job")
 	c.Assert(err, qt.Equals, ErrNotFound)
+}
+
+// TestRecordBatchVoteOutcome checks the bookkeeping of a batch vote relay: the workers
+// report their envelopes concurrently and in no particular order, each entry keeps the
+// process id and nullifier it was seeded with, and the job is closed exactly once, by
+// whichever worker reports last.
+func TestRecordBatchVoteOutcome(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	orgAddress := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	seed := func(n int) []VoteJobResult {
+		votes := make([]VoteJobResult, n)
+		for i := range votes {
+			votes[i] = VoteJobResult{
+				ProcessID: internal.HexBytes{byte(i)},
+				Nullifier: internal.HexBytes{0xaa, byte(i)},
+				Status:    JobStatusPending,
+			}
+		}
+		return votes
+	}
+
+	c.Run("all votes accepted", func(c *qt.C) {
+		jobID := "batch-vote-job-ok"
+		c.Assert(testDB.CreateVoteBatchJob(jobID, orgAddress, seed(4)), qt.IsNil)
+
+		var wg sync.WaitGroup
+		for i := range 4 {
+			wg.Go(func() {
+				c.Check(testDB.RecordBatchVoteOutcome(jobID, i, internal.HexBytes{0xaa, byte(i)}, ""), qt.IsNil)
+			})
+		}
+		wg.Wait()
+
+		job, err := testDB.Job(jobID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(job.Status, qt.Equals, JobStatusCompleted)
+		c.Assert(job.Added, qt.Equals, 4)
+		c.Assert(job.Errors, qt.HasLen, 0)
+		c.Assert(job.CompletedAt.IsZero(), qt.IsFalse)
+		c.Assert(job.Result.Votes, qt.HasLen, 4)
+		for i, vote := range job.Result.Votes {
+			c.Assert(vote.Status, qt.Equals, JobStatusCompleted)
+			c.Assert(vote.ProcessID, qt.DeepEquals, internal.HexBytes{byte(i)})
+			c.Assert(vote.VoteID, qt.DeepEquals, internal.HexBytes{0xaa, byte(i)})
+			c.Assert(vote.Error, qt.Equals, "")
+		}
+	})
+
+	c.Run("one vote rejected", func(c *qt.C) {
+		jobID := "batch-vote-job-partial"
+		c.Assert(testDB.CreateVoteBatchJob(jobID, orgAddress, seed(3)), qt.IsNil)
+
+		c.Assert(testDB.RecordBatchVoteOutcome(jobID, 0, internal.HexBytes{0xaa, 0}, ""), qt.IsNil)
+		c.Assert(testDB.RecordBatchVoteOutcome(jobID, 1, nil, "vote already exists"), qt.IsNil)
+
+		// still open: the last envelope has not reported yet
+		job, err := testDB.Job(jobID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(job.Status, qt.Equals, JobStatusPending)
+
+		c.Assert(testDB.RecordBatchVoteOutcome(jobID, 2, internal.HexBytes{0xaa, 2}, ""), qt.IsNil)
+
+		job, err = testDB.Job(jobID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(job.Status, qt.Equals, JobStatusFailed)
+		c.Assert(job.Added, qt.Equals, 3)
+		c.Assert(job.Errors, qt.DeepEquals, []string{"vote 1: vote already exists"})
+		// the votes that did land keep their outcome, and the one that failed keeps the
+		// nullifier it was seeded with, so the caller can tell which vote to retry
+		c.Assert(job.Result.Votes[0].Status, qt.Equals, JobStatusCompleted)
+		c.Assert(job.Result.Votes[1].Status, qt.Equals, JobStatusFailed)
+		c.Assert(job.Result.Votes[1].Error, qt.Equals, "vote already exists")
+		c.Assert(job.Result.Votes[1].Nullifier, qt.DeepEquals, internal.HexBytes{0xaa, 1})
+		c.Assert(job.Result.Votes[1].VoteID, qt.HasLen, 0)
+		c.Assert(job.Result.Votes[2].Status, qt.Equals, JobStatusCompleted)
+	})
+
+	c.Run("unknown job", func(c *qt.C) {
+		c.Assert(testDB.RecordBatchVoteOutcome("nope", 0, nil, ""), qt.Equals, ErrNotFound)
+	})
 }
 
 func TestSetJob(t *testing.T) {

--- a/db/jobs_test.go
+++ b/db/jobs_test.go
@@ -136,6 +136,25 @@ func TestRecordBatchVoteOutcome(t *testing.T) {
 	c.Run("unknown job", func(c *qt.C) {
 		c.Assert(testDB.RecordBatchVoteOutcome("nope", 0, nil, ""), qt.Equals, ErrNotFound)
 	})
+
+	c.Run("index outside the batch", func(c *qt.C) {
+		jobID := "batch-vote-job-bad-index"
+		c.Assert(testDB.CreateVoteBatchJob(jobID, orgAddress, seed(2)), qt.IsNil)
+
+		// an out-of-range write must not pad result.votes with nulls, must not advance the
+		// progress counter, and must not be mistaken for a job that does not exist
+		for _, index := range []int{2, 7, -1} {
+			err := testDB.RecordBatchVoteOutcome(jobID, index, internal.HexBytes{0xff}, "")
+			c.Assert(err, qt.Not(qt.IsNil), qt.Commentf("index %d", index))
+			c.Assert(err, qt.Not(qt.Equals), ErrNotFound, qt.Commentf("index %d", index))
+		}
+
+		job, err := testDB.Job(jobID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(job.Result.Votes, qt.HasLen, 2)
+		c.Assert(job.Added, qt.Equals, 0)
+		c.Assert(job.Status, qt.Equals, JobStatusPending)
+	})
 }
 
 func TestSetJob(t *testing.T) {

--- a/db/types.go
+++ b/db/types.go
@@ -766,6 +766,9 @@ const (
 	JobTypeSetProcessCensus JobType = "set_process_census"
 	// JobTypeRelayVote represents a vote-relay tx job
 	JobTypeRelayVote JobType = "relay_vote"
+	// JobTypeRelayVotes represents a batch vote-relay tx job: one job covering the
+	// several envelopes of a single POST /votes call, one JobResult.Votes entry each
+	JobTypeRelayVotes JobType = "relay_votes"
 	// JobTypePublishVotingProcess represents a multi-question voting-process publish
 	// (batch of NEW_PROCESS txs) tx job
 	JobTypePublishVotingProcess JobType = "publish_voting_process"
@@ -775,7 +778,7 @@ const (
 func (t JobType) IsValid() bool {
 	switch t {
 	case JobTypeOrgMembers, JobTypeCensusParticipants, JobTypePublishProcess, JobTypeSetProcessStatus,
-		JobTypeSetProcessCensus, JobTypeRelayVote, JobTypePublishVotingProcess:
+		JobTypeSetProcessCensus, JobTypeRelayVote, JobTypeRelayVotes, JobTypePublishVotingProcess:
 		return true
 	default:
 		return false
@@ -794,28 +797,49 @@ const (
 	JobStatusFailed JobStatus = "failed"
 )
 
+// VoteJobResult is the outcome of one relayed vote envelope inside a batch job
+// (JobTypeRelayVotes). ProcessID and Nullifier are known before submission and are
+// therefore set when the job is created, so a caller can tell which envelope an entry
+// belongs to while it is still pending or after it failed. VoteID is the nullifier as
+// returned by the chain and only appears once the vote has been accepted and mined.
+type VoteJobResult struct {
+	ProcessID internal.HexBytes `json:"processId,omitempty" bson:"processId,omitempty" swaggertype:"string" example:"deadbeef"`
+	Nullifier internal.HexBytes `json:"nullifier,omitempty" bson:"nullifier,omitempty" swaggertype:"string" example:"deadbeef"`
+	VoteID    internal.HexBytes `json:"voteID,omitempty" bson:"voteID,omitempty" swaggertype:"string" example:"deadbeef"`
+	Status    JobStatus         `json:"status,omitempty" bson:"status,omitempty"`
+	Error     string            `json:"error,omitempty" bson:"error,omitempty"`
+}
+
 // JobResult carries the public on-chain outcome of a transaction job. Fields are
 // populated depending on the job type (publish → Address+Status; status → Status;
-// vote → VoteID) and are omitted when empty.
+// vote → ProcessID+Nullifier+VoteID; batch vote → Votes) and are omitted when empty.
 type JobResult struct {
-	Address internal.HexBytes `json:"address,omitempty" bson:"address,omitempty" swaggertype:"string" example:"deadbeef"`
-	VoteID  internal.HexBytes `json:"voteID,omitempty" bson:"voteID,omitempty" swaggertype:"string" example:"deadbeef"`
-	Status  string            `json:"status,omitempty" bson:"status,omitempty"`
+	Address   internal.HexBytes `json:"address,omitempty" bson:"address,omitempty" swaggertype:"string" example:"deadbeef"`
+	ProcessID internal.HexBytes `json:"processId,omitempty" bson:"processId,omitempty" swaggertype:"string" example:"deadbeef"`
+	Nullifier internal.HexBytes `json:"nullifier,omitempty" bson:"nullifier,omitempty" swaggertype:"string" example:"deadbeef"`
+	VoteID    internal.HexBytes `json:"voteID,omitempty" bson:"voteID,omitempty" swaggertype:"string" example:"deadbeef"`
+	Status    string            `json:"status,omitempty" bson:"status,omitempty"`
+	// Votes carries the per-envelope outcome of a batch vote relay, index-aligned with
+	// the votes of the POST /votes request that created the job.
+	Votes []VoteJobResult `json:"votes,omitempty" bson:"votes,omitempty"`
 }
 
 // Job represents a persistent import or transaction job with its results and errors.
 // This allows clients to query job status and errors even after server restarts.
 type Job struct {
-	ID          primitive.ObjectID `json:"id" bson:"_id"`
-	JobID       string             `json:"jobId" bson:"jobId"`           // The hex job ID
-	Type        JobType            `json:"type" bson:"type"`             // Job type constant
-	OrgAddress  common.Address     `json:"orgAddress" bson:"orgAddress"` // For authorization
-	Total       int                `json:"total" bson:"total"`           // Total items processed
-	Added       int                `json:"added" bson:"added"`           // Items successfully added
-	Errors      []string           `json:"errors" bson:"errors"`         // All errors encountered
-	CreatedAt   time.Time          `json:"createdAt" bson:"createdAt"`
-	CompletedAt time.Time          `json:"completedAt" bson:"completedAt"`
-	// Transaction-job fields (JobTypePublishProcess/SetProcessStatus/RelayVote)
+	ID         primitive.ObjectID `json:"id" bson:"_id"`
+	JobID      string             `json:"jobId" bson:"jobId"`           // The hex job ID
+	Type       JobType            `json:"type" bson:"type"`             // Job type constant
+	OrgAddress common.Address     `json:"orgAddress" bson:"orgAddress"` // For authorization
+	Total      int                `json:"total" bson:"total"`           // Total items processed
+	// Added counts the items successfully added for import jobs. For a batch vote relay
+	// (JobTypeRelayVotes) it counts the envelopes that have *finished*, successfully or
+	// not, so that the progress reported to the caller advances on every outcome.
+	Added       int       `json:"added" bson:"added"`
+	Errors      []string  `json:"errors" bson:"errors"` // All errors encountered
+	CreatedAt   time.Time `json:"createdAt" bson:"createdAt"`
+	CompletedAt time.Time `json:"completedAt" bson:"completedAt"`
+	// Transaction-job fields (JobTypePublishProcess/SetProcessStatus/RelayVote/RelayVotes)
 	Status JobStatus  `json:"status,omitempty" bson:"status,omitempty"` // pending|completed|failed
 	Result *JobResult `json:"result,omitempty" bson:"result,omitempty"` // on-chain outcome when completed
 	Error  string     `json:"error,omitempty" bson:"error,omitempty"`   // failure reason when failed

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1392,6 +1392,14 @@ definitions:
         format: hex
         type: string
     type: object
+  apicommon.RelayVotesRequest:
+    properties:
+      votes:
+        description: Signed vote transactions, at most 100
+        items:
+          $ref: '#/definitions/apicommon.RelayVoteRequest'
+        type: array
+    type: object
   apicommon.SetProcessStatusRequest:
     properties:
       status:
@@ -1626,6 +1634,12 @@ definitions:
       address:
         example: deadbeef
         type: string
+      nullifier:
+        example: deadbeef
+        type: string
+      processId:
+        example: deadbeef
+        type: string
       progress:
         type: integer
       status:
@@ -1635,6 +1649,12 @@ definitions:
       voteID:
         example: deadbeef
         type: string
+      votes:
+        description: Votes is the per-envelope outcome of a batch vote relay, in request
+          order
+        items:
+          $ref: '#/definitions/db.VoteJobResult'
+        type: array
     type: object
   apicommon.UpdateOrganizationMemberGroupsRequest:
     properties:
@@ -2084,6 +2104,7 @@ definitions:
     - set_process_status
     - set_process_census
     - relay_vote
+    - relay_votes
     - publish_voting_process
     type: string
     x-enum-varnames:
@@ -2093,6 +2114,7 @@ definitions:
     - JobTypeSetProcessStatus
     - JobTypeSetProcessCensus
     - JobTypeRelayVote
+    - JobTypeRelayVotes
     - JobTypePublishVotingProcess
   db.MultiLangString:
     additionalProperties:
@@ -2281,6 +2303,22 @@ definitions:
     - AdminRole
     - ManagerRole
     - ViewerRole
+  db.VoteJobResult:
+    properties:
+      error:
+        type: string
+      nullifier:
+        example: deadbeef
+        type: string
+      processId:
+        example: deadbeef
+        type: string
+      status:
+        $ref: '#/definitions/db.JobStatus'
+      voteID:
+        example: deadbeef
+        type: string
+    type: object
   db.VoteType:
     properties:
       costExponent:
@@ -7368,6 +7406,59 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
       summary: Relay an already-signed vote to the Vochain
+      tags:
+      - vote
+  /votes:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Relays several voter transactions, already signed by the voter, in one call. A
+        multi-question voting process is one vochain process per question, so a voter casts
+        one vote transaction per question; relaying them one by one leaves a window in which
+        some are on chain and the rest are not, and the voter ends up half-voted. This
+        endpoint closes that window. Public endpoint: no authentication is required.
+        The whole batch is checked synchronously and is accepted or rejected as a unit —
+        every payload must decode to a Vote envelope (else 400) for a process the backend
+        knows (else 404), all of them must belong to the same organization (else 400), and
+        the queue must have room for all of them (else 503). A rejected batch enqueues
+        nothing. At most 100 votes per call.
+        The call returns 202 with a single job id covering the batch. Poll
+        GET /jobs/{jobId}: its result carries one entry per vote, index-aligned with the
+        request, each with the process id and the nullifier — both known before submission,
+        so they are readable while the job is pending — plus the chain-assigned voteID once
+        that vote is accepted, or the reason it failed.
+      parameters:
+      - description: Signed vote transaction payloads
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/apicommon.RelayVotesRequest'
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Job accepted; poll GET /jobs/{jobId}
+          schema:
+            $ref: '#/definitions/apicommon.EnqueuedResponse'
+        "400":
+          description: Invalid input data
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "404":
+          description: Process not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "503":
+          description: Transaction queue is full
+          schema:
+            $ref: '#/definitions/errors.Error'
+      summary: Relay a batch of already-signed votes to the Vochain
       tags:
       - vote
 schemes:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -7397,6 +7397,10 @@ paths:
           description: Process not found
           schema:
             $ref: '#/definitions/errors.Error'
+        "413":
+          description: Request body too large
+          schema:
+            $ref: '#/definitions/errors.Error'
         "500":
           description: Internal server error
           schema:
@@ -7448,6 +7452,10 @@ paths:
             $ref: '#/definitions/errors.Error'
         "404":
           description: Process not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "413":
+          description: Request body too large
           schema:
             $ref: '#/definitions/errors.Error'
         "500":

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -111,6 +111,7 @@ var (
 	ErrVoteBatchEmpty                         = Error{Code: 40164, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("vote batch is empty")}
 	ErrVoteBatchTooLarge                      = Error{Code: 40165, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("vote batch is too large")}
 	ErrVoteBatchMixedOrganizations            = Error{Code: 40166, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("vote batch spans several organizations")}
+	ErrRequestBodyTooLarge                    = Error{Code: 40167, HTTPstatus: http.StatusRequestEntityTooLarge, Err: fmt.Errorf("request body is too large")}
 
 	// CSP errors (408)
 	ErrZeroWeightVoter = Error{Code: 40801, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("voter weight cannot be zero")}

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -108,6 +108,9 @@ var (
 	ErrAPIKeyNotFound                         = Error{Code: 40160, HTTPstatus: http.StatusNotFound, Err: fmt.Errorf("API key not found")}
 	ErrManagedOrgHasActiveElections           = Error{Code: 40161, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("managed organization has active elections and cannot be deleted")}
 	ErrVotingTypeNotAllowed                   = Error{Code: 40163, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("voting type not allowed by the subscription plan")}
+	ErrVoteBatchEmpty                         = Error{Code: 40164, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("vote batch is empty")}
+	ErrVoteBatchTooLarge                      = Error{Code: 40165, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("vote batch is too large")}
+	ErrVoteBatchMixedOrganizations            = Error{Code: 40166, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("vote batch spans several organizations")}
 
 	// CSP errors (408)
 	ErrZeroWeightVoter = Error{Code: 40801, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("voter weight cannot be zero")}


### PR DESCRIPTION
Closes #604.

## Problem

A multi-question voting process is one vochain process per question, so a voter casts one
independent vote transaction per question. The only relay today is `POST /vote`, which takes
exactly one signed envelope — so the voter-facing SDK fires N sequential HTTP calls, and there is
a window where some envelopes are relayed and the rest are not (network drop, tab closed,
queue-full 503 midway): the voter ends up **half-voted**. The integrator-sdk has mitigated what it
can client-side; the relay phase itself is the part only the backend can fix.

## What this adds

`POST /votes` (public, like `/vote`):

```
POST /votes
{ "votes": [ { "txPayload": "<hex SignedTx>" }, ... ] }   // at most 100

202 { "jobId": "<hex>" }                                   // + Location: /jobs/<jobId>
```

This is the issue's **Option B** (a new endpoint) rather than Option A (a plural field on
`POST /vote`): the batch form has to return a different body, so growing `/vote` would not have
been backwards compatible for clients reading `{"jobId": …}`.

**Validated as a unit, enqueued all or nothing.** Every payload must decode to a vote envelope
(else 400) for a process the backend knows (else 404); all of them must belong to the same
organization (else 400); no nullifier may repeat within the batch (else 400); and the queue must
have room for the whole batch (else 503). A rejected batch enqueues nothing — a voter retries from
a clean slate instead of discovering that a prefix of their questions was voted.

**Job model — one job per batch.** Deviating from the issue's semantics point 3 (which proposed one
job per vote), the batch lands as a single job of the new type `relay_votes`, so the client polls
once instead of N times. Its result reports every envelope in request order:

```jsonc
GET /jobs/{jobId}
{
  "jobId": "a1b2…", "type": "relay_votes", "status": "failed",
  "errors": ["vote 2: vote already exists"],
  "result": {
    "total": 3, "added": 3, "progress": 100,
    "votes": [
      {"processId": "9d3f…", "nullifier": "7ac1…", "voteID": "7ac1…", "status": "completed"},
      {"processId": "4e77…", "nullifier": "b209…", "voteID": "b209…", "status": "completed"},
      {"processId": "c015…", "nullifier": "33fa…", "status": "failed", "error": "vote already exists"}
    ]
  }
}
```

**Nullifiers are known before submission.** Both relay endpoints now derive the nullifier from the
signed envelope — `ethereum.BuildVocdoniTransaction` + `AddrFromSignature` → `state.GenerateNullifier`,
or the envelope's own `Nullifier` for an anonymous vote — and seed it, with the process id, on the
job at creation. A caller polling a *pending* or *failed* job therefore already knows which vote it
is waiting on, instead of learning the nullifier only from the chain's `voteID` on success. The
derivation is best effort: an envelope whose signer cannot be recovered yields no nullifier and is
relayed anyway, since the chain is the authority on signature validity.

Per-vote billing (`IncrementOrganizationSentVotesCounter`) still runs once per relayed envelope.

## Implementation notes

- **One task per envelope, not one task for the batch.** `SubmitSignedTx` blocks its worker until
  the tx is mined, so a single looping task would serialize the batch and pin one worker for all of
  it. `txTask` gained an optional `record` hook so a batch task writes its own entry instead of
  closing the shared job; the worker that reports last closes it, `completed` only if every vote was
  accepted.
- **`enqueueTxBatch` reserves the slots under a mutex** and sends all or none. `enqueueTx` takes the
  same mutex, so a concurrent single enqueue cannot steal a reserved slot; workers only drain, so a
  check taken under the lock stays valid.
- `RecordBatchVoteOutcome` applies the per-envelope write and the progress counter in one atomic
  `FindOneAndUpdate`, so the job is closed exactly once regardless of worker interleaving.
- New error codes `40164` (empty batch), `40165` (too large), `40166` (mixed organizations).
- `POST /vote` is otherwise untouched and every new job field is additive, so existing clients —
  including `saas-integrator-demo`, which polls `/jobs/{jobId}` — are unaffected.

## Verification

- `go build ./...`, `go vet` clean; `golangci-lint` v2.12.2 0 issues; `scripts/check-qt-patterns.sh` clean.
- `make swagger` regenerated (additive only).
- `go test -run 'TestRelayVote$|TestRelayVotesBatch|TestRelayVotesRejectsBatch' ./api/` — passes.
  `TestRelayVotesBatch` runs a real 3-question batch against voconed and asserts the nullifiers are
  readable while the job is pending and that each chain `voteID` equals the derived `nullifier`;
  `TestRelayVotesRejectsBatch` covers the seven rejection paths.
- `go test -run TestRecordBatchVoteOutcome ./db/` — concurrent workers, exactly-once close, partial failure.
- Re-ran the publish/status/jobs API tests that share the tx queue.