### PR TITLE
feat(processes)!: update a question's eligible members after publish

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -429,6 +429,7 @@ func (a *API) initRouter() http.Handler {
 		handle(r, http.MethodDelete, processesEndpoint, a.deleteVotingProcessHandler)
 		handle(r, http.MethodGet, processesParticipantsEndpoint, a.votingProcessParticipantsHandler)
 		handle(r, http.MethodPut, processesCensusEndpoint, a.updateVotingProcessCensusHandler)
+		handle(r, http.MethodPut, processesQuestionCensusEndpoint, a.updateVotingProcessQuestionCensusHandler)
 	})
 
 	// Public routes

--- a/api/apicommon/voting_processes.go
+++ b/api/apicommon/voting_processes.go
@@ -82,6 +82,26 @@ type UpdateProcessCensusResponse struct {
 	Errors []string `json:"errors,omitempty"`
 }
 
+// UpdateQuestionCensusRequest is the body of PUT /processes/{processId}/questions/{questionId}/census:
+// the complete list of members eligible to vote that question, not a delta. An empty list means every
+// census member is eligible. Once the process is published the list may only grow — it must still
+// contain every member it already had — so a retry of the same body is a no-op rather than an error.
+type UpdateQuestionCensusRequest struct {
+	// Member ids eligible for this question; each must be a participant of the process census
+	MemberIDs []string `json:"memberIds"`
+}
+
+// UpdateQuestionCensusResponse is the result of PUT /processes/{processId}/questions/{questionId}/census:
+// how the eligible list changed, plus the async job that raises the question's on-chain maxCensusSize
+// when it grew (empty for a draft, or when the list did not change).
+type UpdateQuestionCensusResponse struct {
+	JobID string `json:"jobId,omitempty"`
+	// Eligible is the number of members eligible after the update
+	Eligible int `json:"eligible"`
+	Added    int `json:"added"`
+	Removed  int `json:"removed,omitempty"`
+}
+
 // CreateVotingProcessResponse is returned by POST /processes.
 type CreateVotingProcessResponse struct {
 	ProcessID string `json:"processId"`
@@ -170,10 +190,11 @@ type QuestionStatusID struct {
 	ID string `json:"id"`
 }
 
-// PublicQuestionResponse is the voter-facing single-question read: the voter-safe question
-// fields plus the parent process's census config (the auth policy a voter must satisfy). It is
-// an explicit allow-list, NOT the raw db.VotingProcessQuestion — the census member list and the
-// per-question eligibility subset (member ids) are never exposed on this public endpoint.
+// PublicQuestionResponse is the voter-facing single-question read. It is an explicit allow-list,
+// NOT the raw db.VotingProcessQuestion. The parent process's census config is not repeated here —
+// read it from GET /processes/{parentProcessId} — and EligibleMemberIDs, which names the members
+// allowed to vote this question, is filled in only for a manager of the owning organization; an
+// anonymous voter never sees who the electorate is.
 type PublicQuestionResponse struct {
 	ID                primitive.ObjectID   `json:"id"`
 	ParentProcessID   primitive.ObjectID   `json:"parentProcessId"`
@@ -187,7 +208,9 @@ type PublicQuestionResponse struct {
 	Metadata          map[string]any       `json:"metadata,omitempty"`
 	UpstreamID        internal.HexBytes    `json:"upstreamId,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`
 	Status            string               `json:"status,omitempty"`
-	Census            CensusSpec           `json:"census"`
+	// EligibleMemberIDs are the members allowed to vote this question; absent when the question is
+	// open to the whole census, and always absent for a caller who is not a manager of the org.
+	EligibleMemberIDs []string `json:"eligibleMemberIds,omitempty"`
 	// EncryptionKeys are the on-chain vote-encryption public keys (only for secretUntilTheEnd
 	// questions). Because of omitempty the field is absent (not an empty array) until the keykeepers
 	// publish the keys, so clients treat its absence as "not yet published" and poll. Voters seal
@@ -201,9 +224,10 @@ type PublicQuestionResponse struct {
 	Results *db.QuestionResults `json:"results,omitempty"`
 }
 
-// PublicQuestionResponseFromDB builds the public question read from a question and its parent
-// process's census (config only). It copies only the voter-safe fields (no eligibility member ids).
-func PublicQuestionResponseFromDB(q *db.VotingProcessQuestion, census *db.Census) *PublicQuestionResponse {
+// PublicQuestionResponseFromDB builds the public question read from a question. It copies only the
+// voter-safe fields and never the eligible member ids: a caller entitled to those adds them
+// afterwards (see WithEligibility), so the default stays safe for the voter-facing route.
+func PublicQuestionResponseFromDB(q *db.VotingProcessQuestion) *PublicQuestionResponse {
 	resp := &PublicQuestionResponse{
 		ID:                q.ID,
 		ParentProcessID:   q.ProcessID,
@@ -220,14 +244,14 @@ func PublicQuestionResponseFromDB(q *db.VotingProcessQuestion, census *db.Census
 		EncryptionKeys:    q.EncryptionKeys,
 		Results:           q.Results,
 	}
-	if census != nil {
-		resp.Census = CensusSpec{
-			Weighted:    census.Weighted,
-			AuthFields:  census.AuthFields,
-			TwoFaFields: census.TwoFaFields,
-		}
-	}
 	return resp
+}
+
+// WithEligibility discloses which members may vote the question. Reserved for a manager of the
+// owning organization — a voter is told the question, not the electorate.
+func (r *PublicQuestionResponse) WithEligibility(q *db.VotingProcessQuestion) *PublicQuestionResponse {
+	r.EligibleMemberIDs = q.EligibleMemberIDs
+	return r
 }
 
 // VotingProcessResponseFromDB builds the read response from a process, its (hydrated)

--- a/api/apicommon/voting_processes.go
+++ b/api/apicommon/voting_processes.go
@@ -84,8 +84,11 @@ type UpdateProcessCensusResponse struct {
 
 // UpdateQuestionCensusRequest is the body of PUT /processes/{processId}/questions/{questionId}/census:
 // the complete list of members eligible to vote that question, not a delta. An empty list means every
-// census member is eligible. Once the process is published the list may only grow — it must still
-// contain every member it already had — so a retry of the same body is a no-op rather than an error.
+// census member is eligible. Sending the list a question already has is a no-op rather than an error.
+//
+// While the process is a draft the list is applied as given. Once it is published members may still
+// be added and removed, with one restriction: a member who has already voted the question cannot
+// lose eligibility, and a request that would drop one is refused with 409.
 type UpdateQuestionCensusRequest struct {
 	// Member ids eligible for this question; each must be a participant of the process census
 	MemberIDs []string `json:"memberIds"`
@@ -96,10 +99,13 @@ type UpdateQuestionCensusRequest struct {
 // when it grew (empty for a draft, or when the list did not change).
 type UpdateQuestionCensusResponse struct {
 	JobID string `json:"jobId,omitempty"`
-	// Eligible is the number of members eligible after the update
+	// Eligible is the length of the stored eligible list after the update, so zero means the
+	// question is open to the WHOLE census rather than to nobody — an empty list is "no
+	// restriction", the same convention the request body uses.
 	Eligible int `json:"eligible"`
-	Added    int `json:"added"`
-	Removed  int `json:"removed,omitempty"`
+	// Added and Removed count the members whose eligibility changed with this request
+	Added   int `json:"added"`
+	Removed int `json:"removed,omitempty"`
 }
 
 // CreateVotingProcessResponse is returned by POST /processes.

--- a/api/apicommon/voting_processes.go
+++ b/api/apicommon/voting_processes.go
@@ -87,8 +87,9 @@ type UpdateProcessCensusResponse struct {
 // census member is eligible. Sending the list a question already has is a no-op rather than an error.
 //
 // While the process is a draft the list is applied as given. Once it is published members may still
-// be added and removed, with one restriction: a member who has already voted the question cannot
-// lose eligibility, and a request that would drop one is refused with 409.
+// be added and removed, with one restriction: a member the CSP has already signed for on the
+// question cannot lose eligibility, and a request that would drop one is refused with 409. Note that
+// is "signed for", not "voted on chain" — they hold a valid signature either way.
 type UpdateQuestionCensusRequest struct {
 	// Member ids eligible for this question; each must be a participant of the process census
 	MemberIDs []string `json:"memberIds"`
@@ -103,9 +104,11 @@ type UpdateQuestionCensusResponse struct {
 	// question is open to the WHOLE census rather than to nobody — an empty list is "no
 	// restriction", the same convention the request body uses.
 	Eligible int `json:"eligible"`
-	// Added and Removed count the members whose eligibility changed with this request
+	// Added and Removed count the members whose eligibility changed with this request. Both are
+	// always present: omitting a zero would leave a client unable to tell "removed nobody" from
+	// "this response does not report removals".
 	Added   int `json:"added"`
-	Removed int `json:"removed,omitempty"`
+	Removed int `json:"removed"`
 }
 
 // CreateVotingProcessResponse is returned by POST /processes.

--- a/api/apikeys.go
+++ b/api/apikeys.go
@@ -90,6 +90,7 @@ var apiKeyAllowlist = map[string]string{
 	"POST " + processesPublishEndpoint:        ScopeVotingWrite,
 	"PUT " + processesQuestionsStatusEndpoint: ScopeVotingWrite,
 	"PUT " + processesQuestionStatusEndpoint:  ScopeVotingWrite,
+	"PUT " + processesQuestionCensusEndpoint:  ScopeVotingWrite,
 }
 
 // requiredScopeForRoute returns the scope required to call (method, pattern) with an API key and

--- a/api/processes.go
+++ b/api/processes.go
@@ -511,7 +511,11 @@ func (a *API) validateVotingProcessHandler(w http.ResponseWriter, r *http.Reques
 // votingProcessQuestionHandler godoc
 //
 //	@Summary		Get a voting process question
-//	@Description	Public voter read of a single question, including its synced status and eligibility.
+//	@Description	Public voter read of a single question, including its synced status. The parent
+//	@Description	process's census config is not repeated here — read it from GET /processes/{parentProcessId},
+//	@Description	using the parentProcessId this response carries. A Manager/Admin of the owning organization
+//	@Description	(or a voting:write API key) additionally gets eligibleMemberIds, the members allowed to
+//	@Description	vote this question; it is never disclosed to a voter.
 //	@Tags			processes
 //	@Produce		json
 //	@Param			processId	path		string	true	"Process ID"
@@ -538,8 +542,8 @@ func (a *API) votingProcessQuestionHandler(w http.ResponseWriter, r *http.Reques
 		errors.ErrProcessNotFound.Withf("question not found").Write(w)
 		return
 	}
-	// hydrate the parent process's census config (the auth policy the voter must satisfy); the
-	// member list and per-question eligibility subset are never exposed on this public endpoint.
+	// the parent process is needed to gate the read and to resolve the caller's role; its census
+	// config is not repeated here — clients read it from GET /processes/{parentProcessId}.
 	vp, err := a.db.VotingProcess(oid)
 	if err != nil {
 		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
@@ -551,7 +555,6 @@ func (a *API) votingProcessQuestionHandler(w http.ResponseWriter, r *http.Reques
 		errors.ErrProcessNotFound.Withf("question not found").Write(w)
 		return
 	}
-	census, _ := a.db.Census(vp.CensusID.Hex())
 	// serve the stored status now; refresh it from the chain in the background so a status change
 	// made directly on-chain (outside this API) is picked up.
 	a.enqueueReconcileIfStale(question)
@@ -559,7 +562,13 @@ func (a *API) votingProcessQuestionHandler(w http.ResponseWriter, r *http.Reques
 	question.EncryptionKeys = a.resolveQuestionEncryptionKeys(question)
 	// surface the on-chain tally once the question is in RESULTS status (nil/no chain call otherwise).
 	question.Results = a.resolveQuestionResults(question)
-	apicommon.HTTPWriteJSON(w, apicommon.PublicQuestionResponseFromDB(question, census))
+	// who may vote this question is management information: a voter gets the question, a manager
+	// (or a voting:write API key) also gets the eligible member ids.
+	resp := apicommon.PublicQuestionResponseFromDB(question)
+	if a.optionalManager(r, vp.OrgAddress) {
+		resp = resp.WithEligibility(question)
+	}
+	apicommon.HTTPWriteJSON(w, resp)
 }
 
 // parallelForEach runs fn(0..n-1) concurrently with a bounded worker pool and waits for all to

--- a/api/processes.go
+++ b/api/processes.go
@@ -217,7 +217,9 @@ func (a *API) writeQuestions(vp *db.VotingProcess, built []*db.VotingProcessQues
 // updateVotingProcessHandler godoc
 //
 //	@Summary		Update a voting process draft
-//	@Description	Update a voting process while it is still a draft (not published). 409 if already published.
+//	@Description	Update a voting process while it is still a draft (not published). 409 if already
+//	@Description	published, and also while a publish is in flight: the worker is already building
+//	@Description	elections from the draft, so it cannot be rewritten until that finishes.
 //	@Tags			processes
 //	@Accept			json
 //	@Produce		json
@@ -253,6 +255,13 @@ func (a *API) updateVotingProcessHandler(w http.ResponseWriter, r *http.Request)
 		errors.ErrDuplicateConflict.Withf("process already published and not in draft mode").Write(w)
 		return
 	}
+	// The other half of the same rule: a process whose publish is in flight is not published yet,
+	// but it is no longer editable either. This rewrite replaces the whole document and recreates
+	// every question with new ids, so a worker mid-publish would be left stamping UpstreamIDs onto
+	// questions that no longer exist, against a census this call already deleted.
+	if refuseWhilePublishing(w, vp) {
+		return
+	}
 	if !user.HasRoleFor(vp.OrgAddress, db.ManagerRole) && !user.HasRoleFor(vp.OrgAddress, db.AdminRole) {
 		errors.ErrUnauthorized.Withf("user is not admin or manager of the organization").Write(w)
 		return
@@ -284,6 +293,10 @@ func (a *API) updateVotingProcessHandler(w http.ResponseWriter, r *http.Request)
 	}
 	vp.Title, vp.Description, vp.Header, vp.StreamURI = req.Title, req.Description, req.Header, req.StreamURI
 	vp.StartDate, vp.EndDate, vp.CensusID = start, end, census.ID
+	// The only marker that survives the guard above is a stale one, left by a worker that died.
+	// Editing the draft is what releases it — writing it back through this whole-document replace
+	// would leave the process reported as stale forever, reconciled on every startup.
+	vp.Publishing = time.Time{}
 	if _, err := a.db.SetVotingProcess(vp); err != nil {
 		_ = a.db.DelCensus(census.ID.Hex())
 		errors.ErrGenericInternalServerError.WithErr(err).Write(w)

--- a/api/processes_admin.go
+++ b/api/processes_admin.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	stderrors "errors"
 	"net/http"
-	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/vocdoni/saas-backend/account"
@@ -287,15 +286,17 @@ func (a *API) updateVotingProcessCensusHandler(w http.ResponseWriter, r *http.Re
 //	@Summary		Set the members eligible to vote one question
 //	@Description	Replace the list of organization members eligible to vote a single question. The body
 //	@Description	carries the complete list, not a delta, and every id must already be a participant of the
-//	@Description	process census — add them with PUT /processes/{processId}/census first.
-//	@Description	While the process is a draft the list is applied as given, so members can be added,
-//	@Description	removed or replaced. Once the process is published the list may only grow: it must still
-//	@Description	contain every member it already had (409 otherwise), a question that was open to the whole
-//	@Description	census cannot be narrowed to a subset, and a subset cannot be widened back to the whole
-//	@Description	census. Sending the list a question already has is a no-op.
-//	@Description	Growing a published question's list raises its on-chain election maxCensusSize as an
-//	@Description	async job (poll GET /jobs/{jobId}); without that the new members would be signed by the
-//	@Description	CSP only for the chain to reject their vote. Requires Manager/Admin role.
+//	@Description	process census — add them with PUT /processes/{processId}/census first. An empty list
+//	@Description	opens the question to the whole census. Sending the list a question already has is a no-op.
+//	@Description	While the process is a draft the list is applied as given. Once it is published members
+//	@Description	may still be added and removed, with one restriction: a member who has already voted the
+//	@Description	question cannot lose eligibility. Such a request is refused with 409 and the offending
+//	@Description	ids in the error's data.votedMemberIds.
+//	@Description	Adding members raises the question's on-chain election maxCensusSize as an async job
+//	@Description	(poll GET /jobs/{jobId}) when the election is too small for them; without that the new
+//	@Description	members would be signed by the CSP only for the chain to reject their vote. Removing
+//	@Description	members never touches the chain — maxCensusSize is left as headroom, since eligibility
+//	@Description	is enforced by the CSP, not by that number. Requires Manager/Admin role.
 //	@Tags			processes
 //	@Accept			json
 //	@Produce		json
@@ -308,7 +309,7 @@ func (a *API) updateVotingProcessCensusHandler(w http.ResponseWriter, r *http.Re
 //	@Failure		400			{object}	errors.Error							"Invalid input data"
 //	@Failure		401			{object}	errors.Error							"Unauthorized"
 //	@Failure		404			{object}	errors.Error							"Process or question not found"
-//	@Failure		409			{object}	errors.Error							"Would restrict a published question"
+//	@Failure		409			{object}	errors.Error							"A member that already voted would lose eligibility"
 //	@Failure		500			{object}	errors.Error							"Internal server error"
 //	@Router			/processes/{processId}/questions/{questionId}/census [put]
 func (a *API) updateVotingProcessQuestionCensusHandler(w http.ResponseWriter, r *http.Request) {
@@ -356,9 +357,18 @@ func (a *API) updateVotingProcessQuestionCensusHandler(w http.ResponseWriter, r 
 		writeSubscriptionError(w, err)
 		return
 	}
-	if vp.Published {
-		if apiErr, valid := checkEligibilityGrows(question.EligibleMemberIDs, eligible); !valid {
-			apiErr.Write(w)
+	// a member who already voted must keep the right they exercised. Only an on-chain question can
+	// have votes, so a draft skips the check entirely.
+	if len(question.UpstreamID) > 0 {
+		voters, err := a.db.CSPProcessVoters(question.UpstreamID)
+		if err != nil {
+			errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+			return
+		}
+		if blocked := votedMembersLosingEligibility(eligible, voters); len(blocked) > 0 {
+			errors.ErrQuestionEligibilityVoted.
+				Withf("%d member(s) losing eligibility already voted", len(blocked)).
+				WithData(map[string]any{"votedMemberIds": blocked}).Write(w)
 			return
 		}
 	}
@@ -384,14 +394,35 @@ func (a *API) updateVotingProcessQuestionCensusHandler(w http.ResponseWriter, r 
 		return
 	}
 
-	// a published question's election was sized for its old eligible count, so it has no room for
-	// the members just added: raise its on-chain maxCensusSize to match.
+	// a published question's election was sized for its old eligible count, so it may have no room
+	// for the members just added. Only additions can require more room, so a removal never goes on
+	// chain — which is just as well, since the chain refuses to shrink maxCensusSize.
 	if len(question.UpstreamID) == 0 || added == 0 {
 		apicommon.HTTPWriteJSON(w, resp)
 		return
 	}
+	// an empty list means the whole census is eligible, so the election has to fit all of it.
+	needed := uint64(len(eligible))
+	if len(eligible) == 0 {
+		needed = uint64(census.Size)
+	}
+	// compare against what the election actually carries rather than against the list we replaced:
+	// an earlier update may have raised it above the old list's length, and re-submitting a smaller
+	// size would simply be rejected by the chain.
+	elec, err := a.account.Election(question.UpstreamID)
+	if err != nil {
+		errors.ErrVochainRequestFailed.WithErr(err).Write(w)
+		return
+	}
+	// when the election does not report a census at all, attempt the resize rather than skip it:
+	// a tx the chain rejects is visible on the job, whereas silently leaving the election too small
+	// would strand the members just added with no way to tell.
+	if elec.Census != nil && needed <= elec.Census.MaxCensusSize {
+		apicommon.HTTPWriteJSON(w, resp)
+		return
+	}
 	jobID, ok := a.enqueueSetProcessCensus(w, vp, census,
-		[]censusSizeTarget{{upstreamID: question.UpstreamID, size: uint64(len(eligible))}})
+		[]censusSizeTarget{{upstreamID: question.UpstreamID, size: needed}})
 	if !ok {
 		return
 	}
@@ -399,37 +430,30 @@ func (a *API) updateVotingProcessQuestionCensusHandler(w http.ResponseWriter, r 
 	apicommon.HTTPWriteJSONStatus(w, http.StatusAccepted, resp)
 }
 
-// checkEligibilityGrows enforces the append-only rule of a published question: the new eligible set
-// must keep every member the stored one had. The two whole-census edges are not implied by that
-// containment check and are rejected explicitly — an empty stored list means "everyone", so
-// narrowing it to a subset restricts the electorate, and widening a subset back to everyone would
-// need the election resized to the full census, which is a different operation.
-// It reports the error to write back and false when the change is not allowed.
-func checkEligibilityGrows(stored, requested []string) (errors.Error, bool) {
-	switch {
-	case len(stored) == 0 && len(requested) > 0:
-		return errors.ErrQuestionEligibilityRestricted.Withf(
-			"question is open to the whole census; restricting it to %d members is not allowed once published",
-			len(requested)), false
-	case len(stored) > 0 && len(requested) == 0:
-		return errors.ErrQuestionEligibilityRestricted.With(
-			"opening a published question to the whole census is not allowed"), false
+// votedMembersLosingEligibility returns the members that requested would strip of a vote they have
+// already cast. voters are the members who consumed the question's election, so they were eligible
+// when they voted; any of them left out of requested is losing that eligibility retroactively.
+//
+// An empty requested list opens the question to the whole census, which takes eligibility from
+// nobody — that is the one case where a shorter list is not a removal at all.
+func votedMembersLosingEligibility(requested, voters []string) []string {
+	if len(requested) == 0 || len(voters) == 0 {
+		return nil
 	}
-	have := make(map[string]bool, len(requested))
+	stays := make(map[string]bool, len(requested))
 	for _, id := range requested {
-		have[id] = true
+		stays[id] = true
 	}
-	missing := make([]string, 0, len(stored))
-	for _, id := range stored {
-		if !have[id] {
-			missing = append(missing, id)
+	blocked := make([]string, 0, len(voters))
+	for _, id := range voters {
+		if !stays[id] {
+			blocked = append(blocked, id)
 		}
 	}
-	if len(missing) > 0 {
-		return errors.ErrQuestionEligibilityRestricted.Withf(
-			"would drop %d already-eligible member(s): %s", len(missing), strings.Join(missing, ", ")), false
+	if len(blocked) == 0 {
+		return nil
 	}
-	return errors.Error{}, true
+	return blocked
 }
 
 // diffEligibility counts the members added and removed between the stored and the new eligible list.

--- a/api/processes_admin.go
+++ b/api/processes_admin.go
@@ -289,8 +289,8 @@ func (a *API) updateVotingProcessCensusHandler(w http.ResponseWriter, r *http.Re
 //	@Description	process census — add them with PUT /processes/{processId}/census first. An empty list
 //	@Description	opens the question to the whole census. Sending the list a question already has is a no-op.
 //	@Description	While the process is a draft the list is applied as given. Once it is published members
-//	@Description	may still be added and removed, with one restriction: a member who has already voted the
-//	@Description	question cannot lose eligibility. Such a request is refused with 409 and the offending
+//	@Description	may still be added and removed, with one restriction: a member the CSP has already signed
+//	@Description	for on the question cannot lose eligibility. Such a request is refused with 409 and the offending
 //	@Description	ids in the error's data.votedMemberIds.
 //	@Description	Adding members raises the question's on-chain election maxCensusSize as an async job
 //	@Description	(poll GET /jobs/{jobId}) when the election is too small for them; without that the new
@@ -309,7 +309,7 @@ func (a *API) updateVotingProcessCensusHandler(w http.ResponseWriter, r *http.Re
 //	@Failure		400			{object}	errors.Error							"Invalid input data"
 //	@Failure		401			{object}	errors.Error							"Unauthorized"
 //	@Failure		404			{object}	errors.Error							"Process or question not found"
-//	@Failure		409			{object}	errors.Error							"A member that already voted would lose eligibility"
+//	@Failure		409			{object}	errors.Error							"A member already signed for would lose eligibility"
 //	@Failure		500			{object}	errors.Error							"Internal server error"
 //	@Router			/processes/{processId}/questions/{questionId}/census [put]
 func (a *API) updateVotingProcessQuestionCensusHandler(w http.ResponseWriter, r *http.Request) {
@@ -322,14 +322,15 @@ func (a *API) updateVotingProcessQuestionCensusHandler(w http.ResponseWriter, r 
 		errors.ErrMalformedURLParam.Withf("invalid question ID").Write(w)
 		return
 	}
+	// loads the process + questions and gates on Manager/Admin of the owning org. Authorize before
+	// touching the body, matching the sibling handler: an unauthorized caller's input is not parsed.
+	vp, questions, ok := a.authorizeStatusChange(w, r, oid)
+	if !ok {
+		return
+	}
 	var req apicommon.UpdateQuestionCensusRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		errors.ErrMalformedBody.Write(w)
-		return
-	}
-	// loads the process + questions and gates on Manager/Admin of the owning org.
-	vp, questions, ok := a.authorizeStatusChange(w, r, oid)
-	if !ok {
 		return
 	}
 	var question *db.VotingProcessQuestion
@@ -359,6 +360,12 @@ func (a *API) updateVotingProcessQuestionCensusHandler(w http.ResponseWriter, r 
 	}
 	// a member who already voted must keep the right they exercised. Only an on-chain question can
 	// have votes, so a draft skips the check entirely.
+	//
+	// This read and the write below are not atomic: a vote landing in between is stored against a
+	// member the write has just made ineligible. The compare-and-set guards concurrent eligibility
+	// writes, not this — closing it would need a transaction spanning two collections for a window
+	// that closes itself, and the outcome is a stored list that briefly contradicts the invariant
+	// rather than a vote lost or double-counted.
 	if len(question.UpstreamID) > 0 {
 		voters, err := a.db.CSPProcessVoters(question.UpstreamID)
 		if err != nil {
@@ -367,7 +374,7 @@ func (a *API) updateVotingProcessQuestionCensusHandler(w http.ResponseWriter, r 
 		}
 		if blocked := votedMembersLosingEligibility(eligible, voters); len(blocked) > 0 {
 			errors.ErrQuestionEligibilityVoted.
-				Withf("%d member(s) losing eligibility already voted", len(blocked)).
+				Withf("%d member(s) losing eligibility have already been signed for", len(blocked)).
 				WithData(map[string]any{"votedMemberIds": blocked}).Write(w)
 			return
 		}
@@ -394,30 +401,36 @@ func (a *API) updateVotingProcessQuestionCensusHandler(w http.ResponseWriter, r 
 		return
 	}
 
-	// a published question's election was sized for its old eligible count, so it may have no room
-	// for the members just added. Only additions can require more room, so a removal never goes on
-	// chain — which is just as well, since the chain refuses to shrink maxCensusSize.
-	if len(question.UpstreamID) == 0 || added == 0 {
-		apicommon.HTTPWriteJSON(w, resp)
-		return
+	// a published question's election was sized for its old eligible list, so it may have no room
+	// for whoever is eligible now. An empty list means the whole census is eligible, on both sides
+	// of the comparison — which is the case that matters here: reopening a restricted question adds
+	// nobody by name yet can multiply the electorate, so keying this off `added` would skip the
+	// resize exactly when it is most needed and leave the new voters signable but unable to vote.
+	previous := uint64(len(question.EligibleMemberIDs))
+	if len(question.EligibleMemberIDs) == 0 {
+		previous = uint64(census.Size)
 	}
-	// an empty list means the whole census is eligible, so the election has to fit all of it.
 	needed := uint64(len(eligible))
 	if len(eligible) == 0 {
 		needed = uint64(census.Size)
 	}
-	// compare against what the election actually carries rather than against the list we replaced:
-	// an earlier update may have raised it above the old list's length, and re-submitting a smaller
-	// size would simply be rejected by the chain.
-	elec, err := a.account.Election(question.UpstreamID)
-	if err != nil {
-		errors.ErrVochainRequestFailed.WithErr(err).Write(w)
+	if len(question.UpstreamID) == 0 || needed <= previous {
+		// a draft, or a change that cannot need more room than the election already has. Removals
+		// land here and never reach the chain, which is just as well: it refuses to shrink
+		// maxCensusSize anyway.
+		apicommon.HTTPWriteJSON(w, resp)
 		return
 	}
-	// when the election does not report a census at all, attempt the resize rather than skip it:
-	// a tx the chain rejects is visible on the job, whereas silently leaving the election too small
-	// would strand the members just added with no way to tell.
-	if elec.Census != nil && needed <= elec.Census.MaxCensusSize {
+	// the stored list is only a lower bound on what the election carries — an earlier update may
+	// have raised it further — so ask the chain before submitting a size it would reject.
+	elec, err := a.account.Election(question.UpstreamID)
+	if err != nil {
+		// the eligibility write has already committed, so failing the request here would report
+		// failure for work that was done. Enqueue instead: growth is genuinely required to reach
+		// this point, so the tx cannot be a shrink, and a chain problem surfaces on the job.
+		log.Warnw("could not read election size, enqueuing the resize anyway",
+			"upstreamId", question.UpstreamID.String(), "error", err)
+	} else if elec.Census != nil && needed <= elec.Census.MaxCensusSize {
 		apicommon.HTTPWriteJSON(w, resp)
 		return
 	}

--- a/api/processes_admin.go
+++ b/api/processes_admin.go
@@ -4,11 +4,15 @@ import (
 	"encoding/json"
 	stderrors "errors"
 	"net/http"
+	"strings"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/vocdoni/saas-backend/account"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
+	"github.com/vocdoni/saas-backend/internal"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.vocdoni.io/dvote/log"
 )
 
@@ -278,21 +282,212 @@ func (a *API) updateVotingProcessCensusHandler(w http.ResponseWriter, r *http.Re
 	apicommon.HTTPWriteJSONStatus(w, http.StatusAccepted, resp)
 }
 
+// updateVotingProcessQuestionCensusHandler godoc
+//
+//	@Summary		Set the members eligible to vote one question
+//	@Description	Replace the list of organization members eligible to vote a single question. The body
+//	@Description	carries the complete list, not a delta, and every id must already be a participant of the
+//	@Description	process census — add them with PUT /processes/{processId}/census first.
+//	@Description	While the process is a draft the list is applied as given, so members can be added,
+//	@Description	removed or replaced. Once the process is published the list may only grow: it must still
+//	@Description	contain every member it already had (409 otherwise), a question that was open to the whole
+//	@Description	census cannot be narrowed to a subset, and a subset cannot be widened back to the whole
+//	@Description	census. Sending the list a question already has is a no-op.
+//	@Description	Growing a published question's list raises its on-chain election maxCensusSize as an
+//	@Description	async job (poll GET /jobs/{jobId}); without that the new members would be signed by the
+//	@Description	CSP only for the chain to reject their vote. Requires Manager/Admin role.
+//	@Tags			processes
+//	@Accept			json
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			processId	path		string									true	"Process ID"
+//	@Param			questionId	path		string									true	"Question ID"
+//	@Param			request		body		apicommon.UpdateQuestionCensusRequest	true	"Eligible member IDs"
+//	@Success		200			{object}	apicommon.UpdateQuestionCensusResponse	"Applied; no on-chain resize needed"
+//	@Success		202			{object}	apicommon.UpdateQuestionCensusResponse	"Applied; maxCensusSize update enqueued"
+//	@Failure		400			{object}	errors.Error							"Invalid input data"
+//	@Failure		401			{object}	errors.Error							"Unauthorized"
+//	@Failure		404			{object}	errors.Error							"Process or question not found"
+//	@Failure		409			{object}	errors.Error							"Would restrict a published question"
+//	@Failure		500			{object}	errors.Error							"Internal server error"
+//	@Router			/processes/{processId}/questions/{questionId}/census [put]
+func (a *API) updateVotingProcessQuestionCensusHandler(w http.ResponseWriter, r *http.Request) {
+	oid, ok := a.votingProcessID(w, r)
+	if !ok {
+		return
+	}
+	qid, err := primitive.ObjectIDFromHex(chi.URLParam(r, "questionId"))
+	if err != nil {
+		errors.ErrMalformedURLParam.Withf("invalid question ID").Write(w)
+		return
+	}
+	var req apicommon.UpdateQuestionCensusRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		errors.ErrMalformedBody.Write(w)
+		return
+	}
+	// loads the process + questions and gates on Manager/Admin of the owning org.
+	vp, questions, ok := a.authorizeStatusChange(w, r, oid)
+	if !ok {
+		return
+	}
+	var question *db.VotingProcessQuestion
+	for i := range questions {
+		if questions[i].ID == qid {
+			question = &questions[i]
+			break
+		}
+	}
+	if question == nil {
+		errors.ErrProcessNotFound.Withf("question not found").Write(w)
+		return
+	}
+	census, err := a.db.Census(vp.CensusID.Hex())
+	if err != nil {
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+	// resolve and validate against the census: eligibility is a subset of the process census, so an
+	// id that is not a participant is rejected rather than silently stored.
+	eligible, err := a.resolveEligibleMemberIDs(
+		&apicommon.EligibilitySpec{MemberIDs: req.MemberIDs}, census, vp.OrgAddress)
+	if err != nil {
+		// passes the resolver's own 400 through (e.g. "member X is not part of the process census")
+		writeSubscriptionError(w, err)
+		return
+	}
+	if vp.Published {
+		if apiErr, valid := checkEligibilityGrows(question.EligibleMemberIDs, eligible); !valid {
+			apiErr.Write(w)
+			return
+		}
+	}
+
+	added, removed := diffEligibility(question.EligibleMemberIDs, eligible)
+	resp := &apicommon.UpdateQuestionCensusResponse{Eligible: len(eligible), Added: added, Removed: removed}
+	if added == 0 && removed == 0 {
+		// idempotent replay: nothing stored, nothing to resize on chain.
+		apicommon.HTTPWriteJSON(w, resp)
+		return
+	}
+	switch err := a.db.SetQuestionEligibleMemberIDs(qid, question.EligibleMemberIDs, eligible); {
+	case err == nil:
+	case stderrors.Is(err, db.ErrStaleWrite):
+		errors.ErrDuplicateConflict.
+			Withf("question eligibility changed concurrently; re-read the question and retry").Write(w)
+		return
+	case stderrors.Is(err, db.ErrNotFound):
+		errors.ErrProcessNotFound.Withf("question not found").Write(w)
+		return
+	default:
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+
+	// a published question's election was sized for its old eligible count, so it has no room for
+	// the members just added: raise its on-chain maxCensusSize to match.
+	if len(question.UpstreamID) == 0 || added == 0 {
+		apicommon.HTTPWriteJSON(w, resp)
+		return
+	}
+	jobID, ok := a.enqueueSetProcessCensus(w, vp, census,
+		[]censusSizeTarget{{upstreamID: question.UpstreamID, size: uint64(len(eligible))}})
+	if !ok {
+		return
+	}
+	resp.JobID = jobID
+	apicommon.HTTPWriteJSONStatus(w, http.StatusAccepted, resp)
+}
+
+// checkEligibilityGrows enforces the append-only rule of a published question: the new eligible set
+// must keep every member the stored one had. The two whole-census edges are not implied by that
+// containment check and are rejected explicitly — an empty stored list means "everyone", so
+// narrowing it to a subset restricts the electorate, and widening a subset back to everyone would
+// need the election resized to the full census, which is a different operation.
+// It reports the error to write back and false when the change is not allowed.
+func checkEligibilityGrows(stored, requested []string) (errors.Error, bool) {
+	switch {
+	case len(stored) == 0 && len(requested) > 0:
+		return errors.ErrQuestionEligibilityRestricted.Withf(
+			"question is open to the whole census; restricting it to %d members is not allowed once published",
+			len(requested)), false
+	case len(stored) > 0 && len(requested) == 0:
+		return errors.ErrQuestionEligibilityRestricted.With(
+			"opening a published question to the whole census is not allowed"), false
+	}
+	have := make(map[string]bool, len(requested))
+	for _, id := range requested {
+		have[id] = true
+	}
+	missing := make([]string, 0, len(stored))
+	for _, id := range stored {
+		if !have[id] {
+			missing = append(missing, id)
+		}
+	}
+	if len(missing) > 0 {
+		return errors.ErrQuestionEligibilityRestricted.Withf(
+			"would drop %d already-eligible member(s): %s", len(missing), strings.Join(missing, ", ")), false
+	}
+	return errors.Error{}, true
+}
+
+// diffEligibility counts the members added and removed between the stored and the new eligible list.
+func diffEligibility(stored, updated []string) (added, removed int) {
+	was := make(map[string]bool, len(stored))
+	for _, id := range stored {
+		was[id] = true
+	}
+	now := make(map[string]bool, len(updated))
+	for _, id := range updated {
+		now[id] = true
+		if !was[id] {
+			added++
+		}
+	}
+	for _, id := range stored {
+		if !now[id] {
+			removed++
+		}
+	}
+	return added, removed
+}
+
 // enqueueCensusSizeUpdate submits a SET_PROCESS_CENSUS tx per published whole-census question to raise
-// its on-chain maxCensusSize to the census's new size. Questions with an eligibility subset keep their
-// fixed size and are skipped. Returns the job id (empty when nothing on-chain needs updating) and false
-// on failure (after writing the error response).
+// its on-chain maxCensusSize to the census's new size. A question with an eligibility subset is sized
+// by that subset, not by the census, so growing the census leaves it alone; it is resized instead when
+// its own eligible list grows, through PUT /processes/{processId}/questions/{questionId}/census.
+// Returns the job id (empty when nothing on-chain needs updating) and false on failure (after writing
+// the error response).
 func (a *API) enqueueCensusSizeUpdate(
 	w http.ResponseWriter, vp *db.VotingProcess, census *db.Census, questions []db.VotingProcessQuestion,
 ) (string, bool) {
-	published := make([]db.VotingProcessQuestion, 0, len(questions))
+	targets := make([]censusSizeTarget, 0, len(questions))
 	for i := range questions {
 		if len(questions[i].UpstreamID) > 0 && len(questions[i].EligibleMemberIDs) == 0 {
-			published = append(published, questions[i])
+			targets = append(targets, censusSizeTarget{upstreamID: questions[i].UpstreamID, size: uint64(census.Size)})
 		}
 	}
-	if len(published) == 0 {
-		return "", true // no whole-census election on chain: nothing to resize
+	return a.enqueueSetProcessCensus(w, vp, census, targets)
+}
+
+// censusSizeTarget is one published election whose on-chain maxCensusSize must be raised, and the
+// size to raise it to. A whole-census question takes the census size; a question restricted to an
+// eligibility subset takes the size of that subset.
+type censusSizeTarget struct {
+	upstreamID internal.HexBytes
+	size       uint64
+}
+
+// enqueueSetProcessCensus submits a SET_PROCESS_CENSUS tx per target, on a background worker, to
+// raise each election's on-chain maxCensusSize while keeping its census root and URI. Returns the
+// job id (empty when there is nothing to resize) and false on failure (after writing the error
+// response).
+func (a *API) enqueueSetProcessCensus(
+	w http.ResponseWriter, vp *db.VotingProcess, census *db.Census, targets []censusSizeTarget,
+) (string, bool) {
+	if len(targets) == 0 {
+		return "", true // nothing on chain to resize
 	}
 	org, err := a.db.Organization(vp.OrgAddress)
 	if err != nil {
@@ -315,12 +510,12 @@ func (a *API) enqueueCensusSizeUpdate(
 	}
 	root := census.Published.Root
 	uri := census.Published.URI
-	size := uint64(census.Size)
 	orgLock := a.orgTxLocks.lock(org.Address)
 	if !a.enqueueTx(txTask{jobID: jobID, run: func() (*db.JobResult, error) {
 		defer orgLock.Unlock()
-		for i := range published {
-			tx, err := a.account.BuildSetProcessCensusTx(orgSigner.Address(), published[i].UpstreamID, root, uri, size)
+		for _, target := range targets {
+			tx, err := a.account.BuildSetProcessCensusTx(
+				orgSigner.Address(), target.upstreamID, root, uri, target.size)
 			if err != nil {
 				return nil, err
 			}

--- a/api/processes_admin.go
+++ b/api/processes_admin.go
@@ -28,7 +28,7 @@ import (
 //	@Success		200			{string}	string			"OK"
 //	@Failure		401			{object}	errors.Error	"Unauthorized"
 //	@Failure		404			{object}	errors.Error	"Process not found"
-//	@Failure		409			{object}	errors.Error	"Process already published"
+//	@Failure		409			{object}	errors.Error	"Process already published, or its publish is in flight"
 //	@Failure		500			{object}	errors.Error	"Internal server error"
 //	@Router			/processes/{processId} [delete]
 func (a *API) deleteVotingProcessHandler(w http.ResponseWriter, r *http.Request) {
@@ -44,6 +44,12 @@ func (a *API) deleteVotingProcessHandler(w http.ResponseWriter, r *http.Request)
 	// only a draft can be deleted; a published process lives on-chain and is immutable.
 	if vp.Published {
 		errors.ErrDuplicateConflict.Withf("process already published and not in draft mode").Write(w)
+		return
+	}
+	// a process being published is not a draft either, whatever its published flag says: deleting
+	// it would take the questions and the census out from under the worker and leave the elections
+	// it already mined on chain with nothing pointing at them.
+	if refuseWhilePublishing(w, vp) {
 		return
 	}
 	if err := a.db.DeleteVotingProcess(oid); err != nil {
@@ -221,6 +227,14 @@ func (a *API) updateVotingProcessCensusHandler(w http.ResponseWriter, r *http.Re
 		errors.ErrDuplicateConflict.Withf("process is not published; edit the draft via PUT /processes/{processId}").Write(w)
 		return
 	}
+	// Unreachable today, and deliberately kept: a process being published is unpublished, so the
+	// check above already refuses it — but only as a side effect of a rule about drafts, and only
+	// while publishing and published stay mutually exclusive (SetVotingProcessPublished sets one
+	// and unsets the other in a single update). This states the real reason, and answers with the
+	// error that names it, if that ever stops holding.
+	if refuseWhilePublishing(w, vp) {
+		return
+	}
 	census, err := a.db.Census(vp.CensusID.Hex())
 	if err != nil {
 		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
@@ -309,7 +323,7 @@ func (a *API) updateVotingProcessCensusHandler(w http.ResponseWriter, r *http.Re
 //	@Failure		400			{object}	errors.Error							"Invalid input data"
 //	@Failure		401			{object}	errors.Error							"Unauthorized"
 //	@Failure		404			{object}	errors.Error							"Process or question not found"
-//	@Failure		409			{object}	errors.Error							"A member already signed for would lose eligibility"
+//	@Failure		409			{object}	errors.Error							"A member already signed for would lose eligibility, or the publish is in flight"
 //	@Failure		500			{object}	errors.Error							"Internal server error"
 //	@Router			/processes/{processId}/questions/{questionId}/census [put]
 func (a *API) updateVotingProcessQuestionCensusHandler(w http.ResponseWriter, r *http.Request) {
@@ -326,6 +340,14 @@ func (a *API) updateVotingProcessQuestionCensusHandler(w http.ResponseWriter, r 
 	// touching the body, matching the sibling handler: an unauthorized caller's input is not parsed.
 	vp, questions, ok := a.authorizeStatusChange(w, r, oid)
 	if !ok {
+		return
+	}
+	// While a publish is in flight the questions still carry no UpstreamID, so this would take the
+	// draft path: it would store the new list and skip the resize, and the worker would then
+	// publish an election sized from the list it snapshotted before the claim. The members added
+	// here would be signed by the CSP and rejected by the chain — the exact failure this endpoint
+	// exists to prevent, and one a replay cannot repair, since an unchanged list is a no-op.
+	if refuseWhilePublishing(w, vp) {
 		return
 	}
 	var req apicommon.UpdateQuestionCensusRequest

--- a/api/processes_admin.go
+++ b/api/processes_admin.go
@@ -448,8 +448,12 @@ func (a *API) updateVotingProcessQuestionCensusHandler(w http.ResponseWriter, r 
 	elec, err := a.account.Election(question.UpstreamID)
 	if err != nil {
 		// the eligibility write has already committed, so failing the request here would report
-		// failure for work that was done. Enqueue instead: growth is genuinely required to reach
-		// this point, so the tx cannot be a shrink, and a chain problem surfaces on the job.
+		// failure for work that was done. Enqueue instead and let the chain judge the size: it
+		// may well already be larger than what is being asked for, since `previous` is only the
+		// stored list — narrow a resized question and widen it again and `needed` exceeds
+		// `previous` while sitting below the election. The chain refuses to shrink, so such a tx
+		// is rejected and the job says so, which is a better outcome than reporting a failed
+		// request for an eligibility change that did land.
 		log.Warnw("could not read election size, enqueuing the resize anyway",
 			"upstreamId", question.UpstreamID.String(), "error", err)
 	} else if elec.Census != nil && needed <= elec.Census.MaxCensusSize {

--- a/api/processes_census.go
+++ b/api/processes_census.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -93,7 +94,8 @@ func (a *API) resolveEligibleMemberIDs(
 	if len(memberIDs) == 0 {
 		return nil, nil
 	}
-	// validate each id is a participant of the census (subset ⊆ default invariant)
+	// dedup, keeping the caller's order: the resolved list is stored verbatim, read back by
+	// clients, and compared against the next request to decide what changed.
 	out := make([]string, 0, len(memberIDs))
 	seen := make(map[string]bool, len(memberIDs))
 	for _, id := range memberIDs {
@@ -101,10 +103,36 @@ func (a *API) resolveEligibleMemberIDs(
 			continue
 		}
 		seen[id] = true
-		if _, err := a.db.CensusParticipant(census.ID.Hex(), id); err != nil {
-			return nil, errors.ErrInvalidData.Withf("member %s is not part of the process census", id)
-		}
 		out = append(out, id)
 	}
-	return out, nil
+	// validate the subset ⊆ census invariant with one indexed query rather than one per id.
+	// PUT /processes/{processId}/questions/{questionId}/census takes the complete list every
+	// time, so the cost here follows the size of the electorate, not the size of the change — a
+	// per-id loop meant thousands of sequential round trips inside the request, on a live
+	// endpoint, for adding one member.
+	participants, err := a.db.CensusParticipantsByMemberIDs(census.ID.Hex(), out)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load census participants: %w", err)
+	}
+	inCensus := make(map[string]bool, len(participants))
+	for i := range participants {
+		inCensus[participants[i].ParticipantID] = true
+	}
+	// report every offending id, in the caller's order, so a bad list can be fixed in one pass
+	// instead of one id per request.
+	var missing []string
+	for _, id := range out {
+		if !inCensus[id] {
+			missing = append(missing, id)
+		}
+	}
+	switch len(missing) {
+	case 0:
+		return out, nil
+	case 1:
+		return nil, errors.ErrInvalidData.Withf("member %s is not part of the process census", missing[0])
+	default:
+		return nil, errors.ErrInvalidData.Withf("%d members are not part of the process census: %s",
+			len(missing), strings.Join(missing, ", "))
+	}
 }

--- a/api/processes_census_test.go
+++ b/api/processes_census_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/csp/handlers"
 	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 )
@@ -189,4 +190,203 @@ func TestProcessesCensusGroupID(t *testing.T) {
 	c.Assert(groups, qt.Contains, group.ID)
 	c.Assert(groups, qt.Contains, "")
 	c.Assert(groups, qt.Not(qt.Contains), primitive.NilObjectID.Hex())
+}
+
+// TestUpdateQuestionCensus adds a member to a published question's eligibility subset and verifies
+// the member really can vote afterwards: the CSP signs for them AND the question's on-chain
+// maxCensusSize grew to fit them. Without the size bump the CSP would sign a ballot the chain then
+// rejects, so both halves matter.
+func TestUpdateQuestionCensus(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateProvisionedOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	// question 1 is restricted to ids[0]; question 0 is open to the whole census.
+	req := newVotingProcessRequest(orgAddress, ids)
+	req.StartDate = ""
+	req.Census.AuthFields = db.OrgMemberAuthFields{db.OrgMemberAuthFieldsName, db.OrgMemberAuthFieldsSurname}
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, req, processesCreateEndpoint)
+	pid := created.ProcessID
+
+	job := enqueueAndPollJob(t, http.MethodPost, token, nil, "processes", pid, "publish")
+	c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("job error: %s", job.Errors))
+
+	got := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	qid := got.Questions[1].ID.Hex()
+	election := got.Questions[1].UpstreamID
+	c.Assert(len(election) > 0, qt.IsTrue)
+	c.Assert(got.Questions[1].EligibleMemberIDs, qt.DeepEquals, ids[:1])
+
+	// the subset question's election was sized for exactly its one eligible member.
+	elec, err := testAPI.account.Election(election)
+	c.Assert(err, qt.IsNil)
+	c.Assert(elec.Census, qt.Not(qt.IsNil))
+	c.Assert(elec.Census.MaxCensusSize, qt.Equals, uint64(1))
+
+	// members[1] is already a census participant, so it only has to become eligible.
+	upd := requestAndParseWithAssertCode[apicommon.UpdateQuestionCensusResponse](
+		http.StatusAccepted, t, http.MethodPut, token,
+		&apicommon.UpdateQuestionCensusRequest{MemberIDs: ids},
+		"processes", pid, "questions", qid, "census")
+	c.Assert(upd.Added, qt.Equals, 1)
+	c.Assert(upd.Removed, qt.Equals, 0)
+	c.Assert(upd.Eligible, qt.Equals, 2)
+	c.Assert(upd.JobID, qt.Not(qt.Equals), "")
+
+	sizeJob := pollJob(t, upd.JobID)
+	c.Assert(sizeJob.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("size job error: %s", sizeJob.Errors))
+	elec, err = testAPI.account.Election(election)
+	c.Assert(err, qt.IsNil)
+	c.Assert(elec.Census.MaxCensusSize, qt.Equals, uint64(2),
+		qt.Commentf("the question's maxCensusSize should have grown to fit the new member"))
+
+	got = requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	c.Assert(got.Questions[1].EligibleMemberIDs, qt.DeepEquals, ids)
+
+	// replaying the same list changes nothing and enqueues no job.
+	replay := requestAndParseWithAssertCode[apicommon.UpdateQuestionCensusResponse](
+		http.StatusOK, t, http.MethodPut, token,
+		&apicommon.UpdateQuestionCensusRequest{MemberIDs: ids},
+		"processes", pid, "questions", qid, "census")
+	c.Assert(replay.Added, qt.Equals, 0)
+	c.Assert(replay.Eligible, qt.Equals, 2)
+	c.Assert(replay.JobID, qt.Equals, "")
+
+	// the newly eligible member can now authenticate and sign that question's election.
+	voter := ethereum.SignKeys{}
+	c.Assert(voter.Generate(), qt.IsNil)
+	tok := authProcessCSP(t, pid, &handlers.AuthRequest{
+		Name: members[1].Name, Surname: members[1].Surname, Email: members[1].Email,
+	})
+	sign := requestAndParse[handlers.AuthResponse](t, http.MethodPost, "",
+		&handlers.SignRequest{
+			AuthToken: tok, ProcessID: election, Payload: hex.EncodeToString(voter.Address().Bytes()),
+		}, "processes", pid, "sign")
+	c.Assert(sign.Signature, qt.Not(qt.HasLen), 0)
+}
+
+// TestUpdateQuestionCensusDraft verifies that while the process is still a draft the eligible list
+// is simply replaced — members may be removed and swapped, and nothing goes on chain.
+func TestUpdateQuestionCensusDraft(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateProvisionedOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	req := newVotingProcessRequest(orgAddress, ids)
+	req.StartDate = ""
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, req, processesCreateEndpoint)
+	pid := created.ProcessID
+	got := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	subsetQID := got.Questions[1].ID.Hex()
+	openQID := got.Questions[0].ID.Hex()
+
+	// swap the eligible member for the other one: one added, one removed, no job.
+	upd := requestAndParseWithAssertCode[apicommon.UpdateQuestionCensusResponse](
+		http.StatusOK, t, http.MethodPut, token,
+		&apicommon.UpdateQuestionCensusRequest{MemberIDs: ids[1:]},
+		"processes", pid, "questions", subsetQID, "census")
+	c.Assert(upd.Added, qt.Equals, 1)
+	c.Assert(upd.Removed, qt.Equals, 1)
+	c.Assert(upd.Eligible, qt.Equals, 1)
+	c.Assert(upd.JobID, qt.Equals, "")
+
+	// a draft may also be opened back up to the whole census, and restricted from it.
+	requestAndParseWithAssertCode[apicommon.UpdateQuestionCensusResponse](
+		http.StatusOK, t, http.MethodPut, token,
+		&apicommon.UpdateQuestionCensusRequest{MemberIDs: nil},
+		"processes", pid, "questions", subsetQID, "census")
+	requestAndParseWithAssertCode[apicommon.UpdateQuestionCensusResponse](
+		http.StatusOK, t, http.MethodPut, token,
+		&apicommon.UpdateQuestionCensusRequest{MemberIDs: ids[:1]},
+		"processes", pid, "questions", openQID, "census")
+
+	got = requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	c.Assert(got.Questions[0].EligibleMemberIDs, qt.DeepEquals, ids[:1])
+	c.Assert(got.Questions[1].EligibleMemberIDs, qt.HasLen, 0)
+}
+
+// TestUpdateQuestionCensusRejects covers the guards: a published question's electorate may only
+// grow, ids must already be census participants, and the caller must manage the organization.
+func TestUpdateQuestionCensusRejects(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateProvisionedOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(3)...)
+	ids := memberIDs(members)
+
+	// census = the first two members; members[2] is an org member outside the census.
+	req := newVotingProcessRequest(orgAddress, ids[:2])
+	req.StartDate = ""
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, req, processesCreateEndpoint)
+	pid := created.ProcessID
+	job := enqueueAndPollJob(t, http.MethodPost, token, nil, "processes", pid, "publish")
+	c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("job error: %s", job.Errors))
+
+	got := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	openQID := got.Questions[0].ID.Hex()   // whole census
+	subsetQID := got.Questions[1].ID.Hex() // restricted to ids[0]
+
+	for _, tc := range []struct {
+		name     string
+		qid      string
+		jwt      string
+		body     *apicommon.UpdateQuestionCensusRequest
+		expected errors.Error
+	}{
+		{
+			"drops an already-eligible member", subsetQID, token,
+			&apicommon.UpdateQuestionCensusRequest{MemberIDs: ids[1:2]},
+			errors.ErrQuestionEligibilityRestricted,
+		},
+		{
+			"restricts a whole-census question", openQID, token,
+			&apicommon.UpdateQuestionCensusRequest{MemberIDs: ids[:1]},
+			errors.ErrQuestionEligibilityRestricted,
+		},
+		{
+			"opens a restricted question to everyone", subsetQID, token,
+			&apicommon.UpdateQuestionCensusRequest{MemberIDs: nil},
+			errors.ErrQuestionEligibilityRestricted,
+		},
+		{
+			"member is not in the process census", subsetQID, token,
+			&apicommon.UpdateQuestionCensusRequest{MemberIDs: []string{ids[0], ids[2]}},
+			errors.ErrInvalidData,
+		},
+		{
+			"question belongs to another process", primitive.NewObjectID().Hex(), token,
+			&apicommon.UpdateQuestionCensusRequest{MemberIDs: ids[:1]},
+			errors.ErrProcessNotFound,
+		},
+		{
+			"caller does not manage the organization", subsetQID, testCreateUser(t, "otherpassword123"),
+			&apicommon.UpdateQuestionCensusRequest{MemberIDs: ids[:2]},
+			errors.ErrUnauthorized,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requestAndAssertError(tc.expected, t, http.MethodPut, tc.jwt, tc.body,
+				"processes", pid, "questions", tc.qid, "census")
+		})
+	}
+
+	// a malformed question id is a 400, not a 404
+	requestAndAssertError(errors.ErrMalformedURLParam, t, http.MethodPut, token,
+		&apicommon.UpdateQuestionCensusRequest{MemberIDs: ids[:1]},
+		"processes", pid, "questions", "not-an-objectid", "census")
+
+	// none of the rejections changed the stored eligibility
+	got = requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	c.Assert(got.Questions[0].EligibleMemberIDs, qt.HasLen, 0)
+	c.Assert(got.Questions[1].EligibleMemberIDs, qt.DeepEquals, ids[:1])
 }

--- a/api/processes_census_test.go
+++ b/api/processes_census_test.go
@@ -421,3 +421,69 @@ func TestUpdateQuestionCensusRejects(t *testing.T) {
 	c.Assert(got.Questions[0].EligibleMemberIDs, qt.HasLen, 0)
 	c.Assert(got.Questions[1].EligibleMemberIDs, qt.DeepEquals, ids[:1])
 }
+
+// TestUpdateQuestionCensusReopen covers the transition that adds nobody by name yet can multiply the
+// electorate: a published question restricted to a subset, reopened to the whole census. Its election
+// was sized for the subset, so it must be resized — keying the resize off the count of added members
+// would skip it here, and the newly eligible members would be signed by the CSP only for the chain to
+// reject their ballots.
+func TestUpdateQuestionCensusReopen(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateProvisionedOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(3)...)
+	ids := memberIDs(members)
+
+	// a census of three; question 1 is restricted to a single member, so its election is published
+	// with room for exactly one voter while the census has three.
+	req := newVotingProcessRequest(orgAddress, ids)
+	req.StartDate = ""
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, req, processesCreateEndpoint)
+	pid := created.ProcessID
+
+	job := enqueueAndPollJob(t, http.MethodPost, token, nil, "processes", pid, "publish")
+	c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("job error: %s", job.Errors))
+
+	got := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	c.Assert(got.Census.Size, qt.Equals, int64(3))
+	qid := got.Questions[1].ID.Hex()
+	election := got.Questions[1].UpstreamID
+	c.Assert(got.Questions[1].EligibleMemberIDs, qt.DeepEquals, ids[:1])
+
+	elec, err := testAPI.account.Election(election)
+	c.Assert(err, qt.IsNil)
+	c.Assert(elec.Census.MaxCensusSize, qt.Equals, uint64(1),
+		qt.Commentf("a subset question is published sized for its subset"))
+
+	// reopening it to the whole census: nobody is named, so nothing is "added", but two more members
+	// become eligible and the election has no room for them.
+	reopen := requestAndParseWithAssertCode[apicommon.UpdateQuestionCensusResponse](
+		http.StatusAccepted, t, http.MethodPut, token,
+		&apicommon.UpdateQuestionCensusRequest{MemberIDs: nil},
+		"processes", pid, "questions", qid, "census")
+	c.Assert(reopen.Eligible, qt.Equals, 0)
+	c.Assert(reopen.Added, qt.Equals, 0)
+	c.Assert(reopen.Removed, qt.Equals, 1)
+	c.Assert(reopen.JobID, qt.Not(qt.Equals), "")
+
+	sizeJob := pollJob(t, reopen.JobID)
+	c.Assert(sizeJob.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("size job error: %s", sizeJob.Errors))
+	elec, err = testAPI.account.Election(election)
+	c.Assert(err, qt.IsNil)
+	c.Assert(elec.Census.MaxCensusSize, qt.Equals, uint64(3),
+		qt.Commentf("reopening to the whole census must resize the election to fit it"))
+
+	// a member who was never in the subset can now authenticate and be signed for the question
+	voter := ethereum.SignKeys{}
+	c.Assert(voter.Generate(), qt.IsNil)
+	tok := authProcessCSP(t, pid, &handlers.AuthRequest{
+		Name: members[2].Name, Surname: members[2].Surname, Email: members[2].Email,
+	})
+	sign := requestAndParse[handlers.AuthResponse](t, http.MethodPost, "",
+		&handlers.SignRequest{
+			AuthToken: tok, ProcessID: election, Payload: hex.EncodeToString(voter.Address().Bytes()),
+		}, "processes", pid, "sign")
+	c.Assert(sign.Signature, qt.Not(qt.HasLen), 0)
+}

--- a/api/processes_census_test.go
+++ b/api/processes_census_test.go
@@ -267,6 +267,53 @@ func TestUpdateQuestionCensus(t *testing.T) {
 			AuthToken: tok, ProcessID: election, Payload: hex.EncodeToString(voter.Address().Bytes()),
 		}, "processes", pid, "sign")
 	c.Assert(sign.Signature, qt.Not(qt.HasLen), 0)
+
+	// members[1] has now voted this question, so they can no longer be dropped from it. The error
+	// names them so the caller knows which ids to put back.
+	apiErr := requestAndExpectError(t, http.MethodPut, token,
+		&apicommon.UpdateQuestionCensusRequest{MemberIDs: ids[:1]},
+		"processes", pid, "questions", qid, "census")
+	c.Assert(apiErr.Code, qt.Equals, errors.ErrQuestionEligibilityVoted.Code)
+	data, isMap := apiErr.Data.(map[string]any)
+	c.Assert(isMap, qt.IsTrue, qt.Commentf("error data: %#v", apiErr.Data))
+	c.Assert(data["votedMemberIds"], qt.DeepEquals, []any{ids[1]})
+
+	// and the refusal changed nothing
+	got = requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	c.Assert(got.Questions[1].EligibleMemberIDs, qt.DeepEquals, ids)
+
+	// the member who never voted can be dropped, and that alone never goes on chain — the election
+	// keeps the headroom it already has.
+	drop := requestAndParseWithAssertCode[apicommon.UpdateQuestionCensusResponse](
+		http.StatusOK, t, http.MethodPut, token,
+		&apicommon.UpdateQuestionCensusRequest{MemberIDs: ids[1:]},
+		"processes", pid, "questions", qid, "census")
+	c.Assert(drop.Removed, qt.Equals, 1)
+	c.Assert(drop.Added, qt.Equals, 0)
+	c.Assert(drop.Eligible, qt.Equals, 1)
+	c.Assert(drop.JobID, qt.Equals, "")
+	elec, err = testAPI.account.Election(election)
+	c.Assert(err, qt.IsNil)
+	c.Assert(elec.Census.MaxCensusSize, qt.Equals, uint64(2), qt.Commentf("a removal must not resize the election"))
+
+	// question 0 is open to the whole census: narrowing it is a removal for everyone left out, and
+	// is allowed here because nobody has voted it. Reopening it takes eligibility from nobody.
+	openQID := got.Questions[0].ID.Hex()
+	narrow := requestAndParseWithAssertCode[apicommon.UpdateQuestionCensusResponse](
+		http.StatusOK, t, http.MethodPut, token,
+		&apicommon.UpdateQuestionCensusRequest{MemberIDs: ids[:1]},
+		"processes", pid, "questions", openQID, "census")
+	c.Assert(narrow.Eligible, qt.Equals, 1)
+	reopen := requestAndParseWithAssertCode[apicommon.UpdateQuestionCensusResponse](
+		http.StatusOK, t, http.MethodPut, token,
+		&apicommon.UpdateQuestionCensusRequest{MemberIDs: nil},
+		"processes", pid, "questions", openQID, "census")
+	c.Assert(reopen.Eligible, qt.Equals, 0)
+	c.Assert(reopen.Removed, qt.Equals, 1)
+
+	got = requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	c.Assert(got.Questions[0].EligibleMemberIDs, qt.HasLen, 0)
+	c.Assert(got.Questions[1].EligibleMemberIDs, qt.DeepEquals, ids[1:])
 }
 
 // TestUpdateQuestionCensusDraft verifies that while the process is still a draft the eligible list
@@ -333,7 +380,6 @@ func TestUpdateQuestionCensusRejects(t *testing.T) {
 	c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("job error: %s", job.Errors))
 
 	got := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
-	openQID := got.Questions[0].ID.Hex()   // whole census
 	subsetQID := got.Questions[1].ID.Hex() // restricted to ids[0]
 
 	for _, tc := range []struct {
@@ -343,21 +389,6 @@ func TestUpdateQuestionCensusRejects(t *testing.T) {
 		body     *apicommon.UpdateQuestionCensusRequest
 		expected errors.Error
 	}{
-		{
-			"drops an already-eligible member", subsetQID, token,
-			&apicommon.UpdateQuestionCensusRequest{MemberIDs: ids[1:2]},
-			errors.ErrQuestionEligibilityRestricted,
-		},
-		{
-			"restricts a whole-census question", openQID, token,
-			&apicommon.UpdateQuestionCensusRequest{MemberIDs: ids[:1]},
-			errors.ErrQuestionEligibilityRestricted,
-		},
-		{
-			"opens a restricted question to everyone", subsetQID, token,
-			&apicommon.UpdateQuestionCensusRequest{MemberIDs: nil},
-			errors.ErrQuestionEligibilityRestricted,
-		},
 		{
 			"member is not in the process census", subsetQID, token,
 			&apicommon.UpdateQuestionCensusRequest{MemberIDs: []string{ids[0], ids[2]}},

--- a/api/processes_census_test.go
+++ b/api/processes_census_test.go
@@ -411,6 +411,16 @@ func TestUpdateQuestionCensusRejects(t *testing.T) {
 		})
 	}
 
+	// several bad ids are reported together: the whole list is validated in one query, so there
+	// is no reason to make a client discover them one request at a time.
+	outsider := primitive.NewObjectID().Hex()
+	apiErr := requestAndExpectError(t, http.MethodPut, token,
+		&apicommon.UpdateQuestionCensusRequest{MemberIDs: []string{ids[0], ids[2], outsider}},
+		"processes", pid, "questions", subsetQID, "census")
+	c.Assert(apiErr.Code, qt.Equals, errors.ErrInvalidData.Code)
+	c.Assert(apiErr.Error(), qt.Contains, ids[2])
+	c.Assert(apiErr.Error(), qt.Contains, outsider)
+
 	// a malformed question id is a 400, not a 404
 	requestAndAssertError(errors.ErrMalformedURLParam, t, http.MethodPut, token,
 		&apicommon.UpdateQuestionCensusRequest{MemberIDs: ids[:1]},
@@ -486,4 +496,34 @@ func TestUpdateQuestionCensusReopen(t *testing.T) {
 			AuthToken: tok, ProcessID: election, Payload: hex.EncodeToString(voter.Address().Bytes()),
 		}, "processes", pid, "sign")
 	c.Assert(sign.Signature, qt.Not(qt.HasLen), 0)
+}
+
+// TestUpdateQuestionCensusDedupsAndPreservesOrder pins the two properties the stored eligible list
+// has to keep now that it is validated with one bulk query instead of a per-id loop: a repeated id
+// counts once, and the list comes back in the order the caller sent it. The order is not cosmetic —
+// it is what the next request is diffed against to decide what was added and removed.
+func TestUpdateQuestionCensusDedupsAndPreservesOrder(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateProvisionedOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	req := newVotingProcessRequest(orgAddress, ids)
+	req.StartDate = ""
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, req, processesCreateEndpoint)
+	pid := created.ProcessID
+	got := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	subsetQID := got.Questions[1].ID.Hex()
+
+	upd := requestAndParseWithAssertCode[apicommon.UpdateQuestionCensusResponse](
+		http.StatusOK, t, http.MethodPut, token,
+		&apicommon.UpdateQuestionCensusRequest{MemberIDs: []string{ids[1], ids[0], ids[1]}},
+		"processes", pid, "questions", subsetQID, "census")
+	c.Assert(upd.Eligible, qt.Equals, 2, qt.Commentf("the repeated id must be counted once"))
+
+	got = requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	c.Assert(got.Questions[1].EligibleMemberIDs, qt.DeepEquals, []string{ids[1], ids[0]})
 }

--- a/api/processes_publish.go
+++ b/api/processes_publish.go
@@ -654,6 +654,25 @@ func (a *API) authorizeStatusChange(
 	return vp, questions, true
 }
 
+// refuseWhilePublishing writes a 409 and reports true when a publish worker already owns the
+// process, so the caller must return without touching it.
+//
+// The worker builds its elections from a snapshot taken before it claimed the process, and sizes
+// each one from the eligible list in that snapshot. Anything editing the process behind it is
+// therefore either lost or actively harmful: a census or eligibility change is not carried onto the
+// chain (the questions still have no UpstreamID, so the resize is skipped, and the members end up
+// signable by the CSP but rejected by the chain), while a draft rewrite or a delete pulls the
+// documents out from under the worker entirely. It is the same condition the publish handler itself
+// refuses a second publish with, refused here for the same reason.
+func refuseWhilePublishing(w http.ResponseWriter, vp *db.VotingProcess) bool {
+	if !vp.PublishInProgress() {
+		return false
+	}
+	errors.ErrPublishInProgress.
+		Withf("the process is being published; retry once the publish job finishes").Write(w)
+	return true
+}
+
 // selectStatusTargets returns the published questions matching the requested ids, or every
 // published question when no ids are given.
 func selectStatusTargets(

--- a/api/processes_publish_guard_test.go
+++ b/api/processes_publish_guard_test.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/api/apicommon"
+	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/errors"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// claimedDraft is a process sitting in the publish window, with what a test needs to poke at it.
+type claimedDraft struct {
+	pid string
+	oid primitive.ObjectID
+	qid string // the second (subset-restricted) question
+	ids []string
+}
+
+// newClaimedDraft creates a draft and claims it for publishing the way the publish handler does,
+// without running the worker: the process is then in the state the guard exists for — unpublished,
+// questions still carrying no UpstreamID, and a live worker (as far as anything stored can tell)
+// building elections from the snapshot it took.
+func newClaimedDraft(t *testing.T, token string, orgAddress common.Address) claimedDraft {
+	t.Helper()
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, newVotingProcessRequest(orgAddress, ids), processesCreateEndpoint)
+	got := requestAndParse[apicommon.VotingProcessResponse](
+		t, http.MethodGet, token, nil, "processes", created.ProcessID)
+	oid, err := primitive.ObjectIDFromHex(created.ProcessID)
+	qt.Assert(t, err, qt.IsNil)
+	claimed, err := testDB.ClaimVotingProcessForPublish(oid)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, claimed, qt.IsTrue)
+	return claimedDraft{pid: created.ProcessID, oid: oid, qid: got.Questions[1].ID.Hex(), ids: ids}
+}
+
+// TestVotingProcessMutationsRefusedWhilePublishing covers the window between a publish being
+// claimed and the elections being mined. Nothing in the stored state says "draft" any less during
+// it — published is false and no question has an UpstreamID yet — so every mutating handler used to
+// take its draft path and edit the process behind the worker's back.
+func TestVotingProcessMutationsRefusedWhilePublishing(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	draft := newClaimedDraft(t, token, orgAddress)
+	pid, oid, qid, ids := draft.pid, draft.oid, draft.qid, draft.ids
+
+	// rewriting the draft would replace the document and recreate the questions with new ids
+	upd := newVotingProcessRequest(orgAddress, ids)
+	upd.Title = db.MultiLangString{"default": "Updated title"}
+	requestAndAssertError(errors.ErrPublishInProgress, t, http.MethodPut, token, upd, "processes", pid)
+
+	// changing eligibility would store a list the election being minted knows nothing about
+	requestAndAssertError(errors.ErrPublishInProgress, t, http.MethodPut, token,
+		&apicommon.UpdateQuestionCensusRequest{MemberIDs: ids},
+		"processes", pid, "questions", qid, "census")
+
+	// deleting would leave whatever the worker already mined on chain with no process at all
+	requestAndAssertError(errors.ErrPublishInProgress, t, http.MethodDelete, token, nil, "processes", pid)
+
+	// none of the refusals changed anything
+	got := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	c.Assert(got.Title["default"], qt.Equals, "Test process")
+	c.Assert(got.Questions[1].EligibleMemberIDs, qt.DeepEquals, ids[:1])
+
+	// and the guard is a gate, not a wall: releasing the claim makes the process editable again
+	c.Assert(testDB.ClearVotingProcessPublishing(oid), qt.IsNil)
+	requestAndAssertCode(http.StatusOK, t, http.MethodPut, token, upd, "processes", pid)
+	got = requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	c.Assert(got.Title["default"], qt.Equals, "Updated title")
+}
+
+// TestVotingProcessMutationsAllowedAfterStalePublishMarker covers the other side of the rule: a
+// marker left by a crashed worker must not lock the process out of editing, since it does not lock
+// it out of publishing either. Editing then has to clear it — the draft rewrite replaces the whole
+// document, so writing a stale marker back would leave the process reported as stale forever.
+func TestVotingProcessMutationsAllowedAfterStalePublishMarker(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	draft := newClaimedDraft(t, token, orgAddress)
+	pid, oid, qid, ids := draft.pid, draft.oid, draft.qid, draft.ids
+
+	restore := db.PublishStaleAfter
+	db.PublishStaleAfter = -time.Minute
+	defer func() { db.PublishStaleAfter = restore }()
+
+	requestAndAssertCode(http.StatusOK, t, http.MethodPut, token,
+		&apicommon.UpdateQuestionCensusRequest{MemberIDs: ids},
+		"processes", pid, "questions", qid, "census")
+
+	upd := newVotingProcessRequest(orgAddress, ids)
+	upd.Title = db.MultiLangString{"default": "Updated title"}
+	requestAndAssertCode(http.StatusOK, t, http.MethodPut, token, upd, "processes", pid)
+
+	vp, err := testDB.VotingProcess(oid)
+	c.Assert(err, qt.IsNil)
+	c.Assert(vp.Publishing.IsZero(), qt.IsTrue,
+		qt.Commentf("editing a draft must release a stale marker, not write it back"))
+	stale, err := testDB.StaleVotingProcesses()
+	c.Assert(err, qt.IsNil)
+	c.Assert(stale, qt.Not(qt.Contains), oid)
+}

--- a/api/processes_test.go
+++ b/api/processes_test.go
@@ -551,9 +551,9 @@ func TestVotingProcessPublicReads(t *testing.T) {
 		"processes?orgAddress=0x0000000000000000000000000000000000000000")
 }
 
-// TestVotingProcessPublicQuestionCensus verifies the public single-question read of a PUBLISHED
-// process includes the parent census config (the auth policy) but never the eligibility member
-// list, and that a restricted question's eligibleMemberIds is not serialized.
+// TestVotingProcessPublicQuestionCensus verifies the single-question read no longer repeats the
+// parent process's census config, and that its eligibility member list is management information:
+// present for a manager, never serialized for an anonymous voter.
 func TestVotingProcessPublicQuestionCensus(t *testing.T) {
 	c := qt.New(t)
 	token := testCreateUser(t, "adminpassword123")
@@ -571,7 +571,7 @@ func TestVotingProcessPublicQuestionCensus(t *testing.T) {
 	job := enqueueAndPollJob(t, http.MethodPost, token, nil, "processes", created.ProcessID, "publish")
 	c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("job error: %s", job.Errors))
 
-	// public read (no token) of question 2 (the eligibility-restricted one): census config present,
+	// public read (no token) of question 2 (the eligibility-restricted one): no census block, and
 	// eligibleMemberIds NOT exposed. Assert against the raw JSON so a re-added field can't slip in.
 	raw, code := testRequest(t, http.MethodGet, "", nil,
 		"processes", created.ProcessID, "questions", got.Questions[1].ID.Hex())
@@ -579,9 +579,23 @@ func TestVotingProcessPublicQuestionCensus(t *testing.T) {
 	var q apicommon.PublicQuestionResponse
 	c.Assert(json.Unmarshal(raw, &q), qt.IsNil)
 	c.Assert(q.ID, qt.Equals, got.Questions[1].ID)
-	c.Assert(q.Census.TwoFaFields, qt.Contains, db.OrgMemberTwoFaFieldEmail)
+	c.Assert(q.ParentProcessID.Hex(), qt.Equals, created.ProcessID)
+	c.Assert(q.EligibleMemberIDs, qt.HasLen, 0)
 	c.Assert(strings.Contains(string(raw), "eligibleMemberIds"), qt.IsFalse,
 		qt.Commentf("public read leaked eligibleMemberIds: %s", raw))
+	// the parent census config lives on the parent process, reachable via parentProcessId
+	c.Assert(strings.Contains(string(raw), `"census"`), qt.IsFalse,
+		qt.Commentf("question read still carries the parent census: %s", raw))
+
+	// the same read as a manager carries the eligibility list
+	mgr := requestAndParse[apicommon.PublicQuestionResponse](t, http.MethodGet, token, nil,
+		"processes", created.ProcessID, "questions", got.Questions[1].ID.Hex())
+	c.Assert(mgr.EligibleMemberIDs, qt.DeepEquals, ids[:1])
+
+	// a whole-census question has no eligibility list to show, even to a manager
+	mgrOpen := requestAndParse[apicommon.PublicQuestionResponse](t, http.MethodGet, token, nil,
+		"processes", created.ProcessID, "questions", got.Questions[0].ID.Hex())
+	c.Assert(mgrOpen.EligibleMemberIDs, qt.HasLen, 0)
 }
 
 // TestVotingProcessParticipant verifies the participant endpoint validates the process and

--- a/api/routes.go
+++ b/api/routes.go
@@ -225,7 +225,8 @@ const (
 	// PUT /processes/{processId}/questions/{questionId}/status to change one question's status
 	processesQuestionStatusEndpoint = "/processes/{processId}/questions/{questionId}/status"
 	// PUT /processes/{processId}/questions/{questionId}/census sets one question's eligible members.
-	// Append-only once the process is published; unrestricted while it is still a draft.
+	// Unrestricted while the process is a draft; once published, members may still be added and
+	// removed, except that a member who already voted the question cannot lose eligibility.
 	processesQuestionCensusEndpoint = "/processes/{processId}/questions/{questionId}/census"
 	// GET /processes/{processId}/questions/{questionId} to read one question (public voter read)
 	processesQuestionEndpoint = "/processes/{processId}/questions/{questionId}"

--- a/api/routes.go
+++ b/api/routes.go
@@ -224,6 +224,9 @@ const (
 	processesQuestionsStatusEndpoint = "/processes/{processId}/questions/status"
 	// PUT /processes/{processId}/questions/{questionId}/status to change one question's status
 	processesQuestionStatusEndpoint = "/processes/{processId}/questions/{questionId}/status"
+	// PUT /processes/{processId}/questions/{questionId}/census sets one question's eligible members.
+	// Append-only once the process is published; unrestricted while it is still a draft.
+	processesQuestionCensusEndpoint = "/processes/{processId}/questions/{questionId}/census"
 	// GET /processes/{processId}/questions/{questionId} to read one question (public voter read)
 	processesQuestionEndpoint = "/processes/{processId}/questions/{questionId}"
 	// GET /processes/{processId}/participants/{participantId} for a single participant's info (public)

--- a/db/csp.go
+++ b/db/csp.go
@@ -411,6 +411,19 @@ func (ms *MongoStorage) GetOrgMembersByProcess(orgAddress common.Address, proces
 	return orgMembers, nil
 }
 
+// CSPProcessVoters returns the id of every member that has already cast a ballot in the given
+// process, as one query, without needing the candidate ids up front. Use it when the question is
+// "who has voted"; use MembersWithUsedCSPProcess when a specific handful of members must be
+// checked, since that one costs a round-trip per id.
+//
+// "Voted" is the same signal both use: a CSPProcess exists for (member, process) and was consumed.
+func (ms *MongoStorage) CSPProcessVoters(processID internal.HexBytes) ([]string, error) {
+	if processID == nil {
+		return nil, ErrBadInputs
+	}
+	return ms.distinctCSPProcessVotersByProcess(processID)
+}
+
 // MembersWithUsedCSPProcess returns the subset of the given memberIDs (each the
 // hex of an OrgMember ObjectID) that have already cast a ballot in the given
 // process. The returned map is keyed by the memberID hex string and only

--- a/db/errors.go
+++ b/db/errors.go
@@ -27,6 +27,10 @@ var (
 	// ErrManagedQuotaReached is returned when an atomic integrator-quota reservation would
 	// exceed the integrator's managed-orgs, managed-processes or managed-census-size limit.
 	ErrManagedQuotaReached = fmt.Errorf("integrator managed quota reached")
+	// ErrStaleWrite is returned by a compare-and-set update whose document still exists but no
+	// longer holds the value the caller read: someone else changed it in between, so the caller
+	// must re-read and decide again rather than overwrite blindly.
+	ErrStaleWrite = fmt.Errorf("document changed since it was read")
 )
 
 // errorsAsStrings converts a slice of errors to a slice of strings

--- a/db/processes_questions.go
+++ b/db/processes_questions.go
@@ -148,6 +148,47 @@ func (ms *MongoStorage) SetQuestionEncryptionKeys(id primitive.ObjectID, keys []
 	return nil
 }
 
+// SetQuestionEligibleMemberIDs sets only the eligibleMemberIds field of a question (targeted
+// update), leaving the fields the publish path owns — upstreamId, status, metadataURL, syncedAt —
+// untouched. An empty list means every census member is eligible.
+//
+// The write is a compare-and-set: expected is the list the caller read before deciding what the
+// new one should be, and it is part of the filter, so two concurrent updates cannot silently drop
+// each other's members. A question that still exists but no longer matches expected yields
+// ErrStaleWrite, telling the caller to re-read and decide again.
+func (ms *MongoStorage) SetQuestionEligibleMemberIDs(id primitive.ObjectID, expected, ids []string) error {
+	if id == primitive.NilObjectID {
+		return ErrInvalidData
+	}
+	if ids == nil {
+		ids = []string{}
+	}
+	// "no restriction" reaches the database as null (a nil slice), as a missing field, or as an
+	// empty array depending on which write stored it, and all three mean the same thing — so match
+	// any of them rather than only the shape this caller happens to hold.
+	match := any(expected)
+	if len(expected) == 0 {
+		match = bson.M{"$in": bson.A{nil, bson.A{}}}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	res, err := ms.processesQuestions.UpdateOne(ctx,
+		bson.M{"_id": id, "eligibleMemberIds": match},
+		bson.M{"$set": bson.M{"eligibleMemberIds": ids}})
+	if err != nil {
+		return fmt.Errorf("failed to set question eligible member ids: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		// tell "there is no such question" apart from "someone else changed it first".
+		n, cErr := ms.processesQuestions.CountDocuments(ctx, bson.M{"_id": id})
+		if cErr == nil && n > 0 {
+			return ErrStaleWrite
+		}
+		return ErrNotFound
+	}
+	return nil
+}
+
 // DeleteQuestion removes a single question document (used when replacing a draft's
 // questions on update).
 func (ms *MongoStorage) DeleteQuestion(id primitive.ObjectID) error {

--- a/db/types.go
+++ b/db/types.go
@@ -667,9 +667,14 @@ type BallotProtocol struct {
 // independent on-chain election) by id in the processesQuestions collection. It is a
 // draft while Published is false. It is unrelated to the single-election Process type.
 type VotingProcess struct {
-	ID          primitive.ObjectID   `json:"id" bson:"_id"`
-	OrgAddress  common.Address       `json:"orgAddress" bson:"orgAddress"`
-	Published   bool                 `json:"published" bson:"published"`
+	ID         primitive.ObjectID `json:"id" bson:"_id"`
+	OrgAddress common.Address     `json:"orgAddress" bson:"orgAddress"`
+	Published  bool               `json:"published" bson:"published"`
+	// Publishing is when a publish worker claimed this process, and is unset again the moment it
+	// finishes (see ClaimVotingProcessForPublish / PublishInProgress). It must stay omitempty: the
+	// duplicate-publish guard and the stale sweep both key off the field being absent, so writing a
+	// zero date would make every draft look like a crashed publish.
+	Publishing  time.Time            `json:"-" bson:"publishing,omitempty"`
 	Title       MultiLangString      `json:"title" bson:"title"`
 	Description MultiLangString      `json:"description,omitempty" bson:"description,omitempty"`
 	Header      string               `json:"header,omitempty" bson:"header,omitempty"`

--- a/db/voting_processes.go
+++ b/db/voting_processes.go
@@ -154,6 +154,22 @@ func (ms *MongoStorage) CountVotingProcesses(orgAddress common.Address, draft Dr
 // worker — and becomes reclaimable by a new publish. It is a var so tests can shorten it.
 var PublishStaleAfter = 15 * time.Minute
 
+// PublishInProgress reports whether a publish worker currently owns this process: it has been
+// claimed, has not finished, and the claim has not gone stale. While that is true the process is
+// unpublished and its questions still carry no UpstreamID, so every "is this a draft?" test reads
+// true even though a worker is already building elections from its own snapshot of it — which is
+// why mutating handlers have to ask this instead.
+//
+// The staleness rule has to agree with ClaimVotingProcessForPublish's own $lt cutoff: a marker it
+// would reclaim must not block anything here either, or a crashed worker would leave the process
+// uneditable for as long as it leaves it unpublishable.
+func (vp *VotingProcess) PublishInProgress() bool {
+	if vp.Published || vp.Publishing.IsZero() {
+		return false
+	}
+	return time.Since(vp.Publishing) <= PublishStaleAfter
+}
+
 // ClaimVotingProcessForPublish atomically transitions an unpublished process into the
 // publishing state (published stays false, but a "publishing" timestamp marker is set) so two
 // concurrent publish requests cannot both proceed. It returns true when this call won the

--- a/db/voting_processes_test.go
+++ b/db/voting_processes_test.go
@@ -1,12 +1,14 @@
 package db
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/saas-backend/internal"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -219,4 +221,89 @@ func TestSetQuestionEligibleMemberIDs(t *testing.T) {
 	// unknown question
 	c.Assert(testDB.SetQuestionEligibleMemberIDs(primitive.NewObjectID(), nil, []string{"a"}), qt.Equals, ErrNotFound)
 	c.Assert(testDB.SetQuestionEligibleMemberIDs(primitive.NilObjectID, nil, nil), qt.Equals, ErrInvalidData)
+}
+
+// TestSetVotingProcessKeepsPublishingMarker pins that editing a process does not release the claim
+// a publish worker holds on it. SetVotingProcess replaces the whole document, so before the marker
+// was a field on the struct any draft edit silently wiped it — and a second publish could then be
+// claimed while the first was still running.
+func TestSetVotingProcessKeepsPublishingMarker(t *testing.T) {
+	c := qt.New(t)
+	org := common.Address{0x13}
+	setupVotingProcessOrg(c, org)
+	id, err := testDB.SetVotingProcess(&VotingProcess{OrgAddress: org, Title: MultiLangString{"default": "P"}})
+	c.Assert(err, qt.IsNil)
+
+	claimed, err := testDB.ClaimVotingProcessForPublish(id)
+	c.Assert(err, qt.IsNil)
+	c.Assert(claimed, qt.IsTrue)
+
+	vp, err := testDB.VotingProcess(id)
+	c.Assert(err, qt.IsNil)
+	c.Assert(vp.Publishing.IsZero(), qt.IsFalse, qt.Commentf("the claim must be readable through the struct"))
+	c.Assert(vp.PublishInProgress(), qt.IsTrue)
+
+	vp.Title = MultiLangString{"default": "edited"}
+	_, err = testDB.SetVotingProcess(vp)
+	c.Assert(err, qt.IsNil)
+
+	got, err := testDB.VotingProcess(id)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.Title["default"], qt.Equals, "edited")
+	c.Assert(got.Publishing.IsZero(), qt.IsFalse)
+	claimed, err = testDB.ClaimVotingProcessForPublish(id)
+	c.Assert(err, qt.IsNil)
+	c.Assert(claimed, qt.IsFalse, qt.Commentf("an edit must not release the publish claim"))
+}
+
+// TestVotingProcessOmitsZeroPublishingMarker pins the omitempty contract the duplicate-publish
+// guard rests on: it matches processes whose publishing field is ABSENT, and the stale sweep
+// matches those whose field is old. A zero date written into the document would satisfy the second
+// and make every draft ever created look like a crashed publish.
+func TestVotingProcessOmitsZeroPublishingMarker(t *testing.T) {
+	c := qt.New(t)
+	org := common.Address{0x14}
+	setupVotingProcessOrg(c, org)
+	id, err := testDB.SetVotingProcess(&VotingProcess{OrgAddress: org, Title: MultiLangString{"default": "P"}})
+	c.Assert(err, qt.IsNil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	var doc bson.M
+	c.Assert(testDB.votingProcesses.FindOne(ctx, bson.M{"_id": id}).Decode(&doc), qt.IsNil)
+	_, present := doc["publishing"]
+	c.Assert(present, qt.IsFalse, qt.Commentf("a never-claimed process must carry no publishing key"))
+
+	stale, err := testDB.StaleVotingProcesses()
+	c.Assert(err, qt.IsNil)
+	c.Assert(stale, qt.Not(qt.Contains), id, qt.Commentf("a fresh draft is not a crashed publish"))
+
+	claimed, err := testDB.ClaimVotingProcessForPublish(id)
+	c.Assert(err, qt.IsNil)
+	c.Assert(claimed, qt.IsTrue)
+}
+
+// TestPublishInProgress covers the predicate the mutating handlers gate on. The staleness boundary
+// has to agree with ClaimVotingProcessForPublish's own cutoff, or a process could be unpublishable
+// and uneditable at the same time — or claimable and editable at once.
+func TestPublishInProgress(t *testing.T) {
+	c := qt.New(t)
+	now := time.Now()
+	for name, tc := range map[string]struct {
+		vp   VotingProcess
+		want bool
+	}{
+		"never claimed":    {VotingProcess{}, false},
+		"claimed just now": {VotingProcess{Publishing: now}, true},
+		// the boundary itself is `<=`, matching the strict `$lt` the claim reclaims with, but a
+		// marker exactly on the cutoff cannot be asserted: time.Since moves past it between
+		// building this table and reading it. These bracket it instead.
+		"claim still inside the window": {VotingProcess{Publishing: now.Add(-PublishStaleAfter + time.Minute)}, true},
+		"claim just past the window":    {VotingProcess{Publishing: now.Add(-PublishStaleAfter - time.Minute)}, false},
+		"claim long since stale":        {VotingProcess{Publishing: now.Add(-2 * PublishStaleAfter)}, false},
+		"published, marker unset":       {VotingProcess{Published: true}, false},
+		"published, marker lagged":      {VotingProcess{Published: true, Publishing: now}, false},
+	} {
+		c.Assert(tc.vp.PublishInProgress(), qt.Equals, tc.want, qt.Commentf("%s", name))
+	}
 }

--- a/db/voting_processes_test.go
+++ b/db/voting_processes_test.go
@@ -175,3 +175,48 @@ func TestQuestionStatusSyncMethods(t *testing.T) {
 	_, err = testDB.SetQuestionStatusSynced(nil, QuestionStatusReady, QuestionStatusEnded)
 	c.Assert(err, qt.ErrorIs, ErrInvalidData)
 }
+
+// TestSetQuestionEligibleMemberIDs covers the targeted eligibility write: it leaves the fields the
+// publish path owns alone, treats "no restriction" the same however it was stored, and refuses a
+// write whose expected value is stale.
+func TestSetQuestionEligibleMemberIDs(t *testing.T) {
+	c := qt.New(t)
+	org := common.Address{0x33}
+	setupVotingProcessOrg(c, org)
+
+	vpID, err := testDB.SetVotingProcess(&VotingProcess{OrgAddress: org, Title: MultiLangString{"default": "P"}})
+	c.Assert(err, qt.IsNil)
+
+	// a question stored with no restriction: EligibleMemberIDs is nil, i.e. null in the database.
+	qID, err := testDB.SetQuestion(&VotingProcessQuestion{
+		ProcessID: vpID, OrgAddress: org, Type: VotingTypeSingleChoice,
+		UpstreamID: internal.HexBytes{0xab}, Status: "READY",
+	})
+	c.Assert(err, qt.IsNil)
+
+	// restricting it matches the stored null, and does not disturb the publish-owned fields
+	c.Assert(testDB.SetQuestionEligibleMemberIDs(qID, nil, []string{"a", "b"}), qt.IsNil)
+	got, err := testDB.Question(qID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.EligibleMemberIDs, qt.DeepEquals, []string{"a", "b"})
+	c.Assert(got.UpstreamID, qt.DeepEquals, internal.HexBytes{0xab})
+	c.Assert(got.Status, qt.Equals, "READY")
+
+	// appending against the value we just read succeeds
+	c.Assert(testDB.SetQuestionEligibleMemberIDs(qID, []string{"a", "b"}, []string{"a", "b", "c"}), qt.IsNil)
+
+	// a stale expected value loses instead of clobbering the concurrent write
+	err = testDB.SetQuestionEligibleMemberIDs(qID, []string{"a", "b"}, []string{"a", "b", "d"})
+	c.Assert(err, qt.Equals, ErrStaleWrite)
+	got, err = testDB.Question(qID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.EligibleMemberIDs, qt.DeepEquals, []string{"a", "b", "c"})
+
+	// clearing it back to "everyone", then matching that empty list however it is stored
+	c.Assert(testDB.SetQuestionEligibleMemberIDs(qID, []string{"a", "b", "c"}, nil), qt.IsNil)
+	c.Assert(testDB.SetQuestionEligibleMemberIDs(qID, nil, []string{"e"}), qt.IsNil)
+
+	// unknown question
+	c.Assert(testDB.SetQuestionEligibleMemberIDs(primitive.NewObjectID(), nil, []string{"a"}), qt.Equals, ErrNotFound)
+	c.Assert(testDB.SetQuestionEligibleMemberIDs(primitive.NilObjectID, nil, nil), qt.Equals, ErrInvalidData)
+}

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1721,9 +1721,14 @@ definitions:
   apicommon.UpdateQuestionCensusResponse:
     properties:
       added:
+        description: Added and Removed count the members whose eligibility changed
+          with this request
         type: integer
       eligible:
-        description: Eligible is the number of members eligible after the update
+        description: |-
+          Eligible is the length of the stored eligible list after the update, so zero means the
+          question is open to the WHOLE census rather than to nobody — an empty list is "no
+          restriction", the same convention the request body uses.
         type: integer
       jobId:
         type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -6449,15 +6449,17 @@ paths:
       description: |-
         Replace the list of organization members eligible to vote a single question. The body
         carries the complete list, not a delta, and every id must already be a participant of the
-        process census — add them with PUT /processes/{processId}/census first.
-        While the process is a draft the list is applied as given, so members can be added,
-        removed or replaced. Once the process is published the list may only grow: it must still
-        contain every member it already had (409 otherwise), a question that was open to the whole
-        census cannot be narrowed to a subset, and a subset cannot be widened back to the whole
-        census. Sending the list a question already has is a no-op.
-        Growing a published question's list raises its on-chain election maxCensusSize as an
-        async job (poll GET /jobs/{jobId}); without that the new members would be signed by the
-        CSP only for the chain to reject their vote. Requires Manager/Admin role.
+        process census — add them with PUT /processes/{processId}/census first. An empty list
+        opens the question to the whole census. Sending the list a question already has is a no-op.
+        While the process is a draft the list is applied as given. Once it is published members
+        may still be added and removed, with one restriction: a member who has already voted the
+        question cannot lose eligibility. Such a request is refused with 409 and the offending
+        ids in the error's data.votedMemberIds.
+        Adding members raises the question's on-chain election maxCensusSize as an async job
+        (poll GET /jobs/{jobId}) when the election is too small for them; without that the new
+        members would be signed by the CSP only for the chain to reject their vote. Removing
+        members never touches the chain — maxCensusSize is left as headroom, since eligibility
+        is enforced by the CSP, not by that number. Requires Manager/Admin role.
       parameters:
       - description: Process ID
         in: path
@@ -6499,7 +6501,7 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
         "409":
-          description: Would restrict a published question
+          description: A member that already voted would lose eligibility
           schema:
             $ref: '#/definitions/errors.Error'
         "500":

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1721,8 +1721,10 @@ definitions:
   apicommon.UpdateQuestionCensusResponse:
     properties:
       added:
-        description: Added and Removed count the members whose eligibility changed
-          with this request
+        description: |-
+          Added and Removed count the members whose eligibility changed with this request. Both are
+          always present: omitting a zero would leave a client unable to tell "removed nobody" from
+          "this response does not report removals".
         type: integer
       eligible:
         description: |-
@@ -6457,8 +6459,8 @@ paths:
         process census — add them with PUT /processes/{processId}/census first. An empty list
         opens the question to the whole census. Sending the list a question already has is a no-op.
         While the process is a draft the list is applied as given. Once it is published members
-        may still be added and removed, with one restriction: a member who has already voted the
-        question cannot lose eligibility. Such a request is refused with 409 and the offending
+        may still be added and removed, with one restriction: a member the CSP has already signed
+        for on the question cannot lose eligibility. Such a request is refused with 409 and the offending
         ids in the error's data.votedMemberIds.
         Adding members raises the question's on-chain election maxCensusSize as an async job
         (poll GET /jobs/{jobId}) when the election is too small for them; without that the new
@@ -6506,7 +6508,7 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
         "409":
-          description: A member that already voted would lose eligibility
+          description: A member already signed for would lose eligibility
           schema:
             $ref: '#/definitions/errors.Error'
         "500":

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -6029,7 +6029,7 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
         "409":
-          description: Process already published
+          description: Process already published, or its publish is in flight
           schema:
             $ref: '#/definitions/errors.Error'
         "500":
@@ -6070,8 +6070,10 @@ paths:
     put:
       consumes:
       - application/json
-      description: Update a voting process while it is still a draft (not published).
-        409 if already published.
+      description: |-
+        Update a voting process while it is still a draft (not published). 409 if already
+        published, and also while a publish is in flight: the worker is already building
+        elections from the draft, so it cannot be rewritten until that finishes.
       parameters:
       - description: Process ID
         in: path
@@ -6546,7 +6548,8 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
         "409":
-          description: A member already signed for would lose eligibility
+          description: A member already signed for would lose eligibility, or the
+            publish is in flight
           schema:
             $ref: '#/definitions/errors.Error'
         "500":

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1293,14 +1293,19 @@ definitions:
     properties:
       ballotProtocol:
         $ref: '#/definitions/db.BallotProtocol'
-      census:
-        $ref: '#/definitions/apicommon.CensusSpec'
       choices:
         items:
           $ref: '#/definitions/db.Choice'
         type: array
       description:
         $ref: '#/definitions/db.MultiLangString'
+      eligibleMemberIds:
+        description: |-
+          EligibleMemberIDs are the members allowed to vote this question; absent when the question is
+          open to the whole census, and always absent for a caller who is not a manager of the org.
+        items:
+          type: string
+        type: array
       encryptionKeys:
         description: |-
           EncryptionKeys are the on-chain vote-encryption public keys (only for secretUntilTheEnd
@@ -1703,6 +1708,27 @@ definitions:
           Additional metadata for the process
           Can be any key-value pairs
         type: object
+    type: object
+  apicommon.UpdateQuestionCensusRequest:
+    properties:
+      memberIds:
+        description: Member ids eligible for this question; each must be a participant
+          of the process census
+        items:
+          type: string
+        type: array
+    type: object
+  apicommon.UpdateQuestionCensusResponse:
+    properties:
+      added:
+        type: integer
+      eligible:
+        description: Eligible is the number of members eligible after the update
+        type: integer
+      jobId:
+        type: string
+      removed:
+        type: integer
     type: object
   apicommon.UserInfo:
     properties:
@@ -6385,8 +6411,12 @@ paths:
       - processes
   /processes/{processId}/questions/{questionId}:
     get:
-      description: Public voter read of a single question, including its synced status
-        and eligibility.
+      description: |-
+        Public voter read of a single question, including its synced status. The parent
+        process's census config is not repeated here — read it from GET /processes/{parentProcessId},
+        using the parentProcessId this response carries. A Manager/Admin of the owning organization
+        (or a voting:write API key) additionally gets eligibleMemberIds, the members allowed to
+        vote this question; it is never disclosed to a voter.
       parameters:
       - description: Process ID
         in: path
@@ -6410,6 +6440,75 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
       summary: Get a voting process question
+      tags:
+      - processes
+  /processes/{processId}/questions/{questionId}/census:
+    put:
+      consumes:
+      - application/json
+      description: |-
+        Replace the list of organization members eligible to vote a single question. The body
+        carries the complete list, not a delta, and every id must already be a participant of the
+        process census — add them with PUT /processes/{processId}/census first.
+        While the process is a draft the list is applied as given, so members can be added,
+        removed or replaced. Once the process is published the list may only grow: it must still
+        contain every member it already had (409 otherwise), a question that was open to the whole
+        census cannot be narrowed to a subset, and a subset cannot be widened back to the whole
+        census. Sending the list a question already has is a no-op.
+        Growing a published question's list raises its on-chain election maxCensusSize as an
+        async job (poll GET /jobs/{jobId}); without that the new members would be signed by the
+        CSP only for the chain to reject their vote. Requires Manager/Admin role.
+      parameters:
+      - description: Process ID
+        in: path
+        name: processId
+        required: true
+        type: string
+      - description: Question ID
+        in: path
+        name: questionId
+        required: true
+        type: string
+      - description: Eligible member IDs
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/apicommon.UpdateQuestionCensusRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Applied; no on-chain resize needed
+          schema:
+            $ref: '#/definitions/apicommon.UpdateQuestionCensusResponse'
+        "202":
+          description: Applied; maxCensusSize update enqueued
+          schema:
+            $ref: '#/definitions/apicommon.UpdateQuestionCensusResponse'
+        "400":
+          description: Invalid input data
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "404":
+          description: Process or question not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "409":
+          description: Would restrict a published question
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+      security:
+      - BearerAuth: []
+      summary: Set the members eligible to vote one question
       tags:
       - processes
   /processes/{processId}/questions/{questionId}/status:

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -108,6 +108,7 @@ var (
 	ErrAPIKeyNotFound                         = Error{Code: 40160, HTTPstatus: http.StatusNotFound, Err: fmt.Errorf("API key not found")}
 	ErrManagedOrgHasActiveElections           = Error{Code: 40161, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("managed organization has active elections and cannot be deleted")}
 	ErrVotingTypeNotAllowed                   = Error{Code: 40163, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("voting type not allowed by the subscription plan")}
+	ErrQuestionEligibilityRestricted          = Error{Code: 40168, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("a published question's eligible members can only be added to")}
 
 	// CSP errors (408)
 	ErrZeroWeightVoter = Error{Code: 40801, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("voter weight cannot be zero")}

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -108,7 +108,7 @@ var (
 	ErrAPIKeyNotFound                         = Error{Code: 40160, HTTPstatus: http.StatusNotFound, Err: fmt.Errorf("API key not found")}
 	ErrManagedOrgHasActiveElections           = Error{Code: 40161, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("managed organization has active elections and cannot be deleted")}
 	ErrVotingTypeNotAllowed                   = Error{Code: 40163, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("voting type not allowed by the subscription plan")}
-	ErrQuestionEligibilityRestricted          = Error{Code: 40168, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("a published question's eligible members can only be added to")}
+	ErrQuestionEligibilityVoted               = Error{Code: 40168, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("members that already voted cannot lose eligibility")}
 
 	// CSP errors (408)
 	ErrZeroWeightVoter = Error{Code: 40801, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("voter weight cannot be zero")}

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -108,7 +108,7 @@ var (
 	ErrAPIKeyNotFound                         = Error{Code: 40160, HTTPstatus: http.StatusNotFound, Err: fmt.Errorf("API key not found")}
 	ErrManagedOrgHasActiveElections           = Error{Code: 40161, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("managed organization has active elections and cannot be deleted")}
 	ErrVotingTypeNotAllowed                   = Error{Code: 40163, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("voting type not allowed by the subscription plan")}
-	ErrQuestionEligibilityVoted               = Error{Code: 40168, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("members that already voted cannot lose eligibility")}
+	ErrQuestionEligibilityVoted               = Error{Code: 40168, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("members already signed for cannot lose eligibility")}
 
 	// CSP errors (408)
 	ErrZeroWeightVoter = Error{Code: 40801, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("voter weight cannot be zero")}


### PR DESCRIPTION
Closes #611.

## Problem

A question's electorate lives in `EligibleMemberIDs`, a subset of the process census, and could only
be set while authoring. `PUT /processes/{processId}` rejects a published process outright and
rebuilds census and questions from scratch, so once a process was published its per-question
electorate was frozen — letting one more member vote one question meant recreating the process.

## What this adds

`PUT /processes/{processId}/questions/{questionId}/census` (protected, Manager/Admin, `voting:write`
for API keys):

```
PUT /processes/{processId}/questions/{questionId}/census
{ "memberIds": ["66f…a1", "66f…b2"] }

200 { "eligible": 2, "added": 1, "removed": 0 }                    // draft, or nothing to resize
202 { "jobId": "…", "eligible": 2, "added": 1, "removed": 0 }      // maxCensusSize bump enqueued
```

The body is the **complete desired list, not a delta**, so the request is idempotent. Every id must
already be a participant of the process census; one that is not gets the resolver's own `400`. That
keeps `PUT /processes/{processId}/census` the single owner of census growth and its plan quota, at
the cost of two calls when adding a brand-new member. An empty list means the whole census is
eligible — so `eligible: 0` in a response means the question is open to **everyone**, not to nobody.

## The one restriction: a cast ballot cannot be taken away

While the process is a draft the list is applied as given. Once published, members may still be
added **and removed** — with the single restriction that **a member who has already been signed for
cannot lose eligibility**:

```
409  code 40168
{
  "error": "members already signed for cannot lose eligibility: 1 member(s) losing eligibility have already been signed for",
  "data": { "votedMemberIds": ["66f…b2"] }
}
```

The three cases that might look separate collapse into one check, because only an eligible member
can ever have obtained a signature — so the members losing a vote they already cast are exactly the
voters absent from the new list:

| stored | requested | outcome |
|---|---|---|
| `[a,b,c]` | `[a,b]` | allowed unless `c` voted |
| `[]` (whole census) | `[a,b]` | allowed unless any voter is outside `[a,b]` |
| `[a,b]` | `[]` | always allowed — opening to everyone removes nobody |

No diff against the stored list is needed, and the narrowing case needs no enumeration of the
census. "Voted" is `CSPProcess.Used`, the same signal `GET /processes/{processId}/participants`
reports as `hasVoted`. It means *the CSP signed for them*, not *the vote reached the chain*, so a
member who took a signature and never relayed it still counts — the conservative direction, since
the alternative is silently disenfranchising someone mid-vote.

The voter set comes from the existing per-election `Distinct` query, exported as `CSPProcessVoters`.
`MembersWithUsedCSPProcess` costs a round-trip per id, which is fine for the handful the
participants endpoint looks up but not for a whole census.

## Why the on-chain resize is part of this, not a follow-up

Eligibility is a live Mongo read at CSP sign time (`memberEligibleForQuestion`), and the chain never
sees a member list — the published census root is the CSP public key with `OFF_CHAIN_CA`. So an
appended id is authorized on the voter's very next request with no census rebuild.

Their vote would still be rejected, though. `ComputeMaxCensusSize` stamps a subset question's
election at *exactly* its eligible count — zero headroom — and `enqueueCensusSizeUpdate`
deliberately skips subset questions. Without raising that one election's `maxCensusSize`, the CSP
would happily sign a ballot the chain then refuses. So a change that grows the electorate enqueues a
`SET_PROCESS_CENSUS` for that election. `enqueueCensusSizeUpdate` is refactored onto a shared
`enqueueSetProcessCensus(targets []censusSizeTarget)`; its own filter and behaviour are unchanged.

The gate compares **what the election needs against what it needed before**, with an empty list
meaning the whole census on *both* sides:

```go
previous := uint64(len(question.EligibleMemberIDs))
if len(question.EligibleMemberIDs) == 0 {
	previous = uint64(census.Size)
}
needed := uint64(len(eligible))
if len(eligible) == 0 {
	needed = uint64(census.Size)
}
if len(question.UpstreamID) == 0 || needed <= previous {
```

Keying it off "members were added" would have skipped the resize exactly where it matters most:
**reopening** a restricted question adds nobody by name yet can multiply the electorate, and the
election was sized for the subset. Removals short-circuit here without paying for a chain read.

Only when growth is genuinely required is the election read, because the stored list is a lower
bound on what the chain carries — an earlier update may have raised it further. If that read fails
the resize is enqueued anyway: the eligibility write has already committed, so failing the request
would report failure for work that landed, and a tx the chain refuses surfaces on the job with its
real reason. After a removal the on-chain number stays as headroom, which is harmless: the CSP is
what gates eligibility, not that number.

## Breaking change on the question read

`GET /processes/{processId}/questions/{questionId}` **no longer returns `census`**. Clients read the
parent census config from `GET /processes/{parentProcessId}` using the `parentProcessId` the
question already carries. `saas-integrator-demo` does not consume this endpoint (grepped), but
external clients may.

In its place the question carries `eligibleMemberIds` — **only for a Manager/Admin of the owning org
or a `voting:write` key**. That route is public, and `api/processes_test.go` deliberately asserts the
ids never appear in an anonymous response; returning who may vote to any caller would have undone a
privacy guard, so that assertion is kept rather than inverted. `PublicQuestionResponseFromDB` never
copies the ids and a caller entitled to them opts in via `WithEligibility`, so the default stays safe.

## Review follow-ups

Three commits added after the first round of review.

**`9a316d2` — a process being published can no longer be mutated behind the worker's back.**
`publishVotingProcessHandler` snapshots the questions, claims the process and hands the snapshot to
a worker that can run for minutes. Throughout that window the process is unpublished and its
questions carry no `upstreamId`, so every "is this a draft?" test read true:

- this endpoint stored the new list and skipped the resize, and the worker then minted an election
  sized from the older snapshot — the CSP signs, the chain rejects, and a replay cannot repair it
  because an unchanged list is a no-op;
- `PUT /processes/{id}` replaced the whole document and recreated every question with new ids, so
  the worker stamped `upstreamId` onto questions that no longer existed — and wiped the publish
  claim marker, letting a second publish be claimed while the first ran;
- `DELETE /processes/{id}` removed the process, its questions and its census outright, leaving
  whatever the worker had already mined on chain with nothing pointing at it.

All three now answer `409 ErrPublishInProgress` (40903 — the error the publish handler already
returns for a duplicate publish; no new code). Reading the claim required `publishing` to become a
field on `db.VotingProcess`, which also stops `SetVotingProcess`'s whole-document `ReplaceOne` from
wiping it. A marker older than `PublishStaleAfter` is treated as released, matching what
`ClaimVotingProcessForPublish` reclaims, and editing a draft clears it rather than writing it back.

**`d5abc7b` — the eligible list is validated with one query instead of one per member.** The
per-id `FindOne` loop cost was proportional to the electorate rather than to the change, on an
endpoint whose contract is to resend the whole list: adding one member to a 10k-member question
meant 10k sequential round trips, every call. It is now one `$in` served by the existing unique
`(censusId, participantID)` index plus a set difference. Order and dedup are preserved — the list is
read back by clients and diffed against the next request. A single missing id keeps its message
verbatim; several are now reported together, and a Mongo failure surfaces as a 500 instead of being
laundered into "member X is not part of the census".

**`a5384d0`** corrects a comment that claimed the enqueued tx could never be a shrink. It can, when
an earlier resize left the chain above the stored list.

## Known limitation

**An election left too small by a failed resize job has no repair path through this endpoint.** The
gate trusts the stored list rather than the chain, and an idempotent replay returns before any
resize check, so re-sending the same list will not retry it — recovery means removing and re-adding
a member. Fixing it properly is a design decision (reconcile against the chain on every update, or a
dedicated resync endpoint) rather than a patch, so it is recorded here rather than bolted on.

## Notes

- New error code **40168**. It skips 40164–40167, which the open PR #610 claims, so the two branches
  cannot collide; the file's own rule is to append rather than fill gaps.
- `SetQuestionEligibleMemberIDs` is a targeted `$set`, not `SetQuestion` (a full `ReplaceOne` that
  would clobber `upstreamId`/`status`/`metadataURL`/`syncedAt`). It is a compare-and-set — the list
  the caller read is part of the filter — so two concurrent updates cannot silently drop each other's
  members; a lost race returns `ErrStaleWrite` → `409`. The filter matches `null`, a missing field and
  `[]` alike, since "no restriction" reaches the database as any of the three.
- The `publishing` marker must stay `omitempty`: the duplicate-publish guard matches on the field
  being *absent* and the stale sweep on it being *old*, so a zero date would make every draft ever
  created look like a crashed publish. `TestVotingProcessOmitsZeroPublishingMarker` pins it.
- Residual race not closed: `updateVotingProcessHandler` reads the process and replaces it later, so
  a claim landing between the two is still wiped. The window drops from 15 minutes to microseconds;
  closing it needs a conditional replace filtered on `{published: false, publishing: {$exists: false}}`.

## Verification

- `go build ./...`, `go vet` clean; `golangci-lint` **0 issues** (re-checked with a cleaned cache —
  it served a stale clean result at first); `scripts/check-qt-patterns.sh` clean.
- `make swagger` regenerated, no drift.
- Full `./api/` passes (583 s). `./db/` passes without `-race`.
- `TestUpdateQuestionCensus` runs against the real chain: asserts the subset question's
  `MaxCensusSize` is 1, adds a member, polls the job, asserts it grew to 2, and proves the newly
  eligible member can authenticate and sign — then, now that they have voted, that removing them is
  refused with the ids in `data.votedMemberIds` and nothing stored changes, that removing the member
  who never voted succeeds without resizing the election, and that narrowing and reopening the
  whole-census question both work. `TestUpdateQuestionCensusReopen` covers the reopen case on its own.
- `TestVotingProcessMutationsRefusedWhilePublishing` claims the process directly, asserts all three
  refusals and that nothing changed, then releases the claim and asserts the same PUT succeeds.
  `TestVotingProcessMutationsAllowedAfterStalePublishMarker` covers the stale side.
- `TestUpdateQuestionCensusDedupsAndPreservesOrder` pins the order and dedup of the stored list.
- `TestSetVotingProcessKeepsPublishingMarker`, `TestVotingProcessOmitsZeroPublishingMarker`,
  `TestPublishInProgress` in `./db/`.
- `TestUpdateProcessCensus` passes untouched, confirming the enqueue refactor is behaviour-preserving.

> **Unrelated `-race` failure, pre-existing on `main`:** `go test -race ./db/` fails in
> `TestOrgMembers/AddBulkOrgMembersLineErrors` — `addOrgMemberBatches` reassigns the job struct while
> `startOrgMemberProgressReporter` reads it (`db/org_members.go:329/350`). Reproduced on a clean
> checkout of `f23f1d3`; that file is not in this diff. Fixed on the #613 branch as `8a3678a`.
>
> **Unrelated heads-up for CI:** `TestVotingProcessStalePublishReclaim` is flaky on `main` as well as
> here. `ClaimVotingProcessForPublish` returns `res.ModifiedCount == 1`, but a reclaim landing on the
> same millisecond as the original claim writes an identical `publishing` timestamp, so Mongo reports
> `MatchedCount=1, ModifiedCount=0` and the claim is wrongly reported as lost. Not touched in this PR.