### PR TITLE
fix(csp): make census removal actually revoke a voter mid-election

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -429,6 +429,7 @@ func (a *API) initRouter() http.Handler {
 		handle(r, http.MethodDelete, processesEndpoint, a.deleteVotingProcessHandler)
 		handle(r, http.MethodGet, processesParticipantsEndpoint, a.votingProcessParticipantsHandler)
 		handle(r, http.MethodPut, processesCensusEndpoint, a.updateVotingProcessCensusHandler)
+		handle(r, http.MethodDelete, processesCensusEndpoint, a.removeVotingProcessCensusHandler)
 	})
 
 	// Public routes

--- a/api/apicommon/voting_processes.go
+++ b/api/apicommon/voting_processes.go
@@ -82,6 +82,14 @@ type UpdateProcessCensusResponse struct {
 	Errors []string `json:"errors,omitempty"`
 }
 
+// RemoveCensusParticipantsRequest is the body of DELETE /processes/{processId}/census: the members
+// to take off the census. It mirrors AddCensusParticipantsRequest but is its own type so the
+// generated docs do not describe a removal with an "add" schema.
+type RemoveCensusParticipantsRequest struct {
+	// Member ids to remove from the census
+	MemberIDs []string `json:"memberIds"`
+}
+
 // RemoveProcessCensusResponse is the result of DELETE /processes/{processId}/census: how many
 // participants were taken off the census. Nothing is sent on chain — an election's maxCensusSize
 // can only grow, and the leftover headroom is harmless because the CSP decides who may vote.

--- a/api/apicommon/voting_processes.go
+++ b/api/apicommon/voting_processes.go
@@ -82,6 +82,13 @@ type UpdateProcessCensusResponse struct {
 	Errors []string `json:"errors,omitempty"`
 }
 
+// RemoveProcessCensusResponse is the result of DELETE /processes/{processId}/census: how many
+// participants were taken off the census. Nothing is sent on chain — an election's maxCensusSize
+// can only grow, and the leftover headroom is harmless because the CSP decides who may vote.
+type RemoveProcessCensusResponse struct {
+	Removed int `json:"removed"`
+}
+
 // CreateVotingProcessResponse is returned by POST /processes.
 type CreateVotingProcessResponse struct {
 	ProcessID string `json:"processId"`

--- a/api/organization_groups.go
+++ b/api/organization_groups.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	stderrors "errors"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -308,6 +309,15 @@ func (a *API) updateOrganizationMemberGroupHandler(w http.ResponseWriter, r *htt
 		toUpdate.RemoveMembers,
 	)
 	if err != nil {
+		// removing a member from a group takes their eligibility away, so it answers to the same
+		// rule as DELETE /processes/{processId}/census and reports it the same way.
+		var voted *db.MembersAlreadyVotedError
+		if stderrors.As(err, &voted) {
+			errors.ErrCensusMemberAlreadyVoted.
+				Withf("%d of the members being removed already voted", len(voted.MemberIDs)).
+				WithData(map[string]any{"votedMemberIds": voted.MemberIDs}).Write(w)
+			return
+		}
 		switch err {
 		case db.ErrNotFound, db.ErrInvalidData:
 			errors.ErrInvalidData.Withf("group not found").Write(w)
@@ -365,6 +375,17 @@ func (a *API) deleteOrganizationMemberGroupHandler(w http.ResponseWriter, r *htt
 		return
 	}
 	if err := a.db.DeleteOrganizationMemberGroup(groupID, org.Address); err != nil {
+		// deleting the group would take its members off the censuses built from it, which for a
+		// published process means wiping a live electorate. Name the processes in the way.
+		var inUse *db.CensusInUseByPublishedProcessError
+		if stderrors.As(err, &inUse) {
+			errors.ErrCensusInUseByPublishedProc.
+				Withf("the group census is voted by %d published process(es); "+
+					"remove members with DELETE /processes/{processId}/census instead",
+					len(inUse.ProcessIDs)).
+				WithData(map[string]any{"processIds": inUse.ProcessIDs}).Write(w)
+			return
+		}
 		switch err {
 		case db.ErrNotFound:
 			errors.ErrInvalidData.Withf("group not found").Write(w)

--- a/api/organization_groups.go
+++ b/api/organization_groups.go
@@ -314,7 +314,7 @@ func (a *API) updateOrganizationMemberGroupHandler(w http.ResponseWriter, r *htt
 		var voted *db.MembersAlreadyVotedError
 		if stderrors.As(err, &voted) {
 			errors.ErrCensusMemberAlreadyVoted.
-				Withf("%d of the members being removed already voted", len(voted.MemberIDs)).
+				Withf("%d of the members being removed have already been signed for", len(voted.MemberIDs)).
 				WithData(map[string]any{"votedMemberIds": voted.MemberIDs}).Write(w)
 			return
 		}

--- a/api/processes_admin.go
+++ b/api/processes_admin.go
@@ -9,6 +9,7 @@ import (
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.vocdoni.io/dvote/log"
 )
 
@@ -303,7 +304,7 @@ func (a *API) updateVotingProcessCensusHandler(w http.ResponseWriter, r *http.Re
 //	@Failure		400			{object}	errors.Error							"Invalid input data"
 //	@Failure		401			{object}	errors.Error							"Unauthorized"
 //	@Failure		404			{object}	errors.Error							"Process not found"
-//	@Failure		409			{object}	errors.Error							"A member has already voted"
+//	@Failure		409			{object}	errors.Error							"Process is not published, or a member has already voted"
 //	@Failure		500			{object}	errors.Error							"Internal server error"
 //	@Router			/processes/{processId}/census [delete]
 func (a *API) removeVotingProcessCensusHandler(w http.ResponseWriter, r *http.Request) {
@@ -331,6 +332,14 @@ func (a *API) removeVotingProcessCensusHandler(w http.ResponseWriter, r *http.Re
 	if len(req.MemberIDs) == 0 {
 		apicommon.HTTPWriteJSON(w, &apicommon.RemoveProcessCensusResponse{Removed: 0})
 		return
+	}
+	// member ids reach code that decodes them as hex, so reject a malformed one here with a 400
+	// rather than let it surface as an opaque failure deeper down.
+	for _, id := range req.MemberIDs {
+		if _, err := primitive.ObjectIDFromHex(id); err != nil {
+			errors.ErrInvalidData.Withf("invalid member id %q", id).Write(w)
+			return
+		}
 	}
 	// a ballot already cast cannot be taken back, so refuse rather than pretend the removal undid it
 	voted, apiErr := a.votedAmong(questions, req.MemberIDs)

--- a/api/processes_admin.go
+++ b/api/processes_admin.go
@@ -293,9 +293,10 @@ const maxCensusRemovalBatch = 1000
 //	@Description	are deleted, they are pruned from every question's eligibility subset, and their CSP
 //	@Description	sessions are invalidated, so a token minted while they were still in the census cannot
 //	@Description	be spent afterwards.
-//	@Description	A member who has already voted any of the process's questions cannot be removed: the
-//	@Description	request is refused with 409 and the offending ids in the error's data.votedMemberIds.
-//	@Description	Their ballot is already on chain and removing them would only hide that, not undo it.
+//	@Description	A member the CSP has already signed for, on any of the process's questions, cannot be
+//	@Description	removed: the request is refused with 409 and the offending ids in the error's
+//	@Description	data.votedMemberIds. They hold a valid signature whether or not the ballot has reached
+//	@Description	the chain yet, so removing them would only hide that, not undo it.
 //	@Description	Nothing is sent on chain — an election's maxCensusSize can only grow, and the leftover
 //	@Description	headroom is harmless because the CSP, not that number, decides who may vote. Note that a
 //	@Description	CSP signature already handed out stays valid until the election closes; removal closes
@@ -313,7 +314,7 @@ const maxCensusRemovalBatch = 1000
 //	@Failure		400			{object}	errors.Error								"Invalid input data"
 //	@Failure		401			{object}	errors.Error								"Unauthorized"
 //	@Failure		404			{object}	errors.Error								"Process not found"
-//	@Failure		409			{object}	errors.Error								"Process is not published, or a member has already voted"
+//	@Failure		409			{object}	errors.Error								"Process is not published, or a member was already signed for"
 //	@Failure		500			{object}	errors.Error								"Internal server error"
 //	@Router			/processes/{processId}/census [delete]
 func (a *API) removeVotingProcessCensusHandler(w http.ResponseWriter, r *http.Request) {
@@ -363,7 +364,7 @@ func (a *API) removeVotingProcessCensusHandler(w http.ResponseWriter, r *http.Re
 	}
 	if len(voted) > 0 {
 		errors.ErrCensusMemberAlreadyVoted.
-			Withf("%d of the %d members to remove already voted", len(voted), len(req.MemberIDs)).
+			Withf("%d of the %d members to remove have already been signed for", len(voted), len(req.MemberIDs)).
 			WithData(map[string]any{"votedMemberIds": voted}).Write(w)
 		return
 	}

--- a/api/processes_admin.go
+++ b/api/processes_admin.go
@@ -278,6 +278,111 @@ func (a *API) updateVotingProcessCensusHandler(w http.ResponseWriter, r *http.Re
 	apicommon.HTTPWriteJSONStatus(w, http.StatusAccepted, resp)
 }
 
+// removeVotingProcessCensusHandler godoc
+//
+//	@Summary		Remove members from a published process's census
+//	@Description	Take organization members off the census of an already-published voting process, so
+//	@Description	they can no longer authenticate or be signed for by the CSP. Their participant rows
+//	@Description	are deleted, they are pruned from every question's eligibility subset, and their CSP
+//	@Description	sessions are invalidated, so a token minted while they were still in the census cannot
+//	@Description	be spent afterwards.
+//	@Description	A member who has already voted any of the process's questions cannot be removed: the
+//	@Description	request is refused with 409 and the offending ids in the error's data.votedMemberIds.
+//	@Description	Their ballot is already on chain and removing them would only hide that, not undo it.
+//	@Description	Nothing is sent on chain — an election's maxCensusSize can only grow, and the leftover
+//	@Description	headroom is harmless because the CSP, not that number, decides who may vote. Note that a
+//	@Description	CSP signature already handed out stays valid until the election closes; removal closes
+//	@Description	the door on new signatures, it cannot recall one. Requires Manager/Admin role.
+//	@Tags			processes
+//	@Accept			json
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			processId	path		string									true	"Process ID"
+//	@Param			request		body		apicommon.AddCensusParticipantsRequest	true	"Member IDs to remove"
+//	@Success		200			{object}	apicommon.RemoveProcessCensusResponse	"Members removed"
+//	@Failure		400			{object}	errors.Error							"Invalid input data"
+//	@Failure		401			{object}	errors.Error							"Unauthorized"
+//	@Failure		404			{object}	errors.Error							"Process not found"
+//	@Failure		409			{object}	errors.Error							"A member has already voted"
+//	@Failure		500			{object}	errors.Error							"Internal server error"
+//	@Router			/processes/{processId}/census [delete]
+func (a *API) removeVotingProcessCensusHandler(w http.ResponseWriter, r *http.Request) {
+	oid, ok := a.votingProcessID(w, r)
+	if !ok {
+		return
+	}
+	// loads the process + questions and gates on Manager/Admin of the owning org.
+	vp, questions, ok := a.authorizeStatusChange(w, r, oid)
+	if !ok {
+		return
+	}
+	// a draft's census is rebuilt wholesale by PUT /processes/{processId}; this endpoint exists for
+	// the published case, where that is not possible.
+	if !vp.Published {
+		errors.ErrDuplicateConflict.
+			Withf("process is not published; edit the draft via PUT /processes/{processId}").Write(w)
+		return
+	}
+	var req apicommon.AddCensusParticipantsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		errors.ErrMalformedBody.Withf("couldn't decode participant IDs").Write(w)
+		return
+	}
+	if len(req.MemberIDs) == 0 {
+		apicommon.HTTPWriteJSON(w, &apicommon.RemoveProcessCensusResponse{Removed: 0})
+		return
+	}
+	// a ballot already cast cannot be taken back, so refuse rather than pretend the removal undid it
+	voted, apiErr := a.votedAmong(questions, req.MemberIDs)
+	if apiErr != nil {
+		apiErr.Write(w)
+		return
+	}
+	if len(voted) > 0 {
+		errors.ErrCensusMemberAlreadyVoted.
+			Withf("%d of the %d members to remove already voted", len(voted), len(req.MemberIDs)).
+			WithData(map[string]any{"votedMemberIds": voted}).Write(w)
+		return
+	}
+
+	removed, err := a.db.RemoveCensusParticipantsByMemberIDs(vp.CensusID.Hex(), req.MemberIDs)
+	if err != nil {
+		if stderrors.Is(err, db.ErrNotFound) {
+			errors.ErrCensusNotFound.Write(w)
+			return
+		}
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+	apicommon.HTTPWriteJSON(w, &apicommon.RemoveProcessCensusResponse{Removed: removed})
+}
+
+// votedAmong returns which of the given members have already voted any of the process's on-chain
+// questions, sorted so the response is stable. It reports the API error to write back on failure.
+func (a *API) votedAmong(questions []db.VotingProcessQuestion, memberIDs []string) ([]string, *errors.Error) {
+	seen := make(map[string]bool)
+	for i := range questions {
+		if len(questions[i].UpstreamID) == 0 {
+			continue // not on chain, so nothing can have been voted
+		}
+		votedInQuestion, err := a.db.MembersWithUsedCSPProcess(questions[i].UpstreamID, memberIDs)
+		if err != nil {
+			e := errors.ErrGenericInternalServerError.WithErr(err)
+			return nil, &e
+		}
+		for id := range votedInQuestion {
+			seen[id] = true
+		}
+	}
+	voted := make([]string, 0, len(seen))
+	for _, id := range memberIDs {
+		if seen[id] {
+			voted = append(voted, id)
+		}
+	}
+	return voted, nil
+}
+
 // enqueueCensusSizeUpdate submits a SET_PROCESS_CENSUS tx per published whole-census question to raise
 // its on-chain maxCensusSize to the census's new size. Questions with an eligibility subset keep their
 // fixed size and are skipped. Returns the job id (empty when nothing on-chain needs updating) and false
@@ -285,14 +390,27 @@ func (a *API) updateVotingProcessCensusHandler(w http.ResponseWriter, r *http.Re
 func (a *API) enqueueCensusSizeUpdate(
 	w http.ResponseWriter, vp *db.VotingProcess, census *db.Census, questions []db.VotingProcessQuestion,
 ) (string, bool) {
+	size := uint64(census.Size)
 	published := make([]db.VotingProcessQuestion, 0, len(questions))
 	for i := range questions {
-		if len(questions[i].UpstreamID) > 0 && len(questions[i].EligibleMemberIDs) == 0 {
-			published = append(published, questions[i])
+		if len(questions[i].UpstreamID) == 0 || len(questions[i].EligibleMemberIDs) > 0 {
+			continue
 		}
+		// the chain only accepts a maxCensusSize increase, and the census can now shrink (a removed
+		// member, a group edit), so compare against what the election actually carries instead of
+		// submitting census.Size blindly and having the tx rejected.
+		elec, err := a.account.Election(questions[i].UpstreamID)
+		if err != nil {
+			errors.ErrVochainRequestFailed.WithErr(err).Write(w)
+			return "", false
+		}
+		if elec.Census != nil && size <= elec.Census.MaxCensusSize {
+			continue
+		}
+		published = append(published, questions[i])
 	}
 	if len(published) == 0 {
-		return "", true // no whole-census election on chain: nothing to resize
+		return "", true // no whole-census election on chain needs a bigger size
 	}
 	org, err := a.db.Organization(vp.OrgAddress)
 	if err != nil {
@@ -315,7 +433,6 @@ func (a *API) enqueueCensusSizeUpdate(
 	}
 	root := census.Published.Root
 	uri := census.Published.URI
-	size := uint64(census.Size)
 	orgLock := a.orgTxLocks.lock(org.Address)
 	if !a.enqueueTx(txTask{jobID: jobID, run: func() (*db.JobResult, error) {
 		defer orgLock.Unlock()

--- a/api/processes_admin.go
+++ b/api/processes_admin.go
@@ -9,6 +9,7 @@ import (
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
+	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.vocdoni.io/dvote/log"
 )
@@ -279,6 +280,11 @@ func (a *API) updateVotingProcessCensusHandler(w http.ResponseWriter, r *http.Re
 	apicommon.HTTPWriteJSONStatus(w, http.StatusAccepted, resp)
 }
 
+// maxCensusRemovalBatch bounds how many members one removal request may name. Each one is checked
+// against the process's elections and then deleted, so an unbounded body would let a single request
+// hold the census lock for an arbitrarily long write. Well above any realistic manual removal.
+const maxCensusRemovalBatch = 1000
+
 // removeVotingProcessCensusHandler godoc
 //
 //	@Summary		Remove members from a published process's census
@@ -293,19 +299,22 @@ func (a *API) updateVotingProcessCensusHandler(w http.ResponseWriter, r *http.Re
 //	@Description	Nothing is sent on chain — an election's maxCensusSize can only grow, and the leftover
 //	@Description	headroom is harmless because the CSP, not that number, decides who may vote. Note that a
 //	@Description	CSP signature already handed out stays valid until the election closes; removal closes
-//	@Description	the door on new signatures, it cannot recall one. Requires Manager/Admin role.
+//	@Description	the door on new signatures, it cannot recall one.
+//	@Description	Removal invalidates the member's CSP sessions across every process, not just this one,
+//	@Description	so they will have to authenticate again elsewhere. Note also that this request carries a
+//	@Description	body, which some proxies and HTTP clients drop on DELETE. Requires Manager/Admin role.
 //	@Tags			processes
 //	@Accept			json
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			processId	path		string									true	"Process ID"
-//	@Param			request		body		apicommon.AddCensusParticipantsRequest	true	"Member IDs to remove"
-//	@Success		200			{object}	apicommon.RemoveProcessCensusResponse	"Members removed"
-//	@Failure		400			{object}	errors.Error							"Invalid input data"
-//	@Failure		401			{object}	errors.Error							"Unauthorized"
-//	@Failure		404			{object}	errors.Error							"Process not found"
-//	@Failure		409			{object}	errors.Error							"Process is not published, or a member has already voted"
-//	@Failure		500			{object}	errors.Error							"Internal server error"
+//	@Param			processId	path		string										true	"Process ID"
+//	@Param			request		body		apicommon.RemoveCensusParticipantsRequest	true	"Member IDs to remove"
+//	@Success		200			{object}	apicommon.RemoveProcessCensusResponse		"Members removed"
+//	@Failure		400			{object}	errors.Error								"Invalid input data"
+//	@Failure		401			{object}	errors.Error								"Unauthorized"
+//	@Failure		404			{object}	errors.Error								"Process not found"
+//	@Failure		409			{object}	errors.Error								"Process is not published, or a member has already voted"
+//	@Failure		500			{object}	errors.Error								"Internal server error"
 //	@Router			/processes/{processId}/census [delete]
 func (a *API) removeVotingProcessCensusHandler(w http.ResponseWriter, r *http.Request) {
 	oid, ok := a.votingProcessID(w, r)
@@ -324,13 +333,18 @@ func (a *API) removeVotingProcessCensusHandler(w http.ResponseWriter, r *http.Re
 			Withf("process is not published; edit the draft via PUT /processes/{processId}").Write(w)
 		return
 	}
-	var req apicommon.AddCensusParticipantsRequest
+	var req apicommon.RemoveCensusParticipantsRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		errors.ErrMalformedBody.Withf("couldn't decode participant IDs").Write(w)
 		return
 	}
 	if len(req.MemberIDs) == 0 {
 		apicommon.HTTPWriteJSON(w, &apicommon.RemoveProcessCensusResponse{Removed: 0})
+		return
+	}
+	if len(req.MemberIDs) > maxCensusRemovalBatch {
+		errors.ErrInvalidData.Withf("%d members, the maximum per request is %d",
+			len(req.MemberIDs), maxCensusRemovalBatch).Write(w)
 		return
 	}
 	// member ids reach code that decodes them as hex, so reject a malformed one here with a 400
@@ -356,8 +370,10 @@ func (a *API) removeVotingProcessCensusHandler(w http.ResponseWriter, r *http.Re
 
 	removed, err := a.db.RemoveCensusParticipantsByMemberIDs(vp.CensusID.Hex(), req.MemberIDs)
 	if err != nil {
-		if stderrors.Is(err, db.ErrNotFound) {
-			errors.ErrCensusNotFound.Write(w)
+		// the removal never reports a missing document — DeleteMany matching nothing is a no-op —
+		// so the only caller-visible failure is a rejected argument.
+		if stderrors.Is(err, db.ErrInvalidData) {
+			errors.ErrInvalidData.WithErr(err).Write(w)
 			return
 		}
 		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
@@ -369,19 +385,17 @@ func (a *API) removeVotingProcessCensusHandler(w http.ResponseWriter, r *http.Re
 // votedAmong returns which of the given members have already voted any of the process's on-chain
 // questions, sorted so the response is stable. It reports the API error to write back on failure.
 func (a *API) votedAmong(questions []db.VotingProcessQuestion, memberIDs []string) ([]string, *errors.Error) {
-	seen := make(map[string]bool)
+	elections := make([]internal.HexBytes, 0, len(questions))
 	for i := range questions {
 		if len(questions[i].UpstreamID) == 0 {
 			continue // not on chain, so nothing can have been voted
 		}
-		votedInQuestion, err := a.db.MembersWithUsedCSPProcess(questions[i].UpstreamID, memberIDs)
-		if err != nil {
-			e := errors.ErrGenericInternalServerError.WithErr(err)
-			return nil, &e
-		}
-		for id := range votedInQuestion {
-			seen[id] = true
-		}
+		elections = append(elections, questions[i].UpstreamID)
+	}
+	seen, err := a.db.MembersWithUsedCSPProcesses(elections, memberIDs)
+	if err != nil {
+		e := errors.ErrGenericInternalServerError.WithErr(err)
+		return nil, &e
 	}
 	voted := make([]string, 0, len(seen))
 	for _, id := range memberIDs {
@@ -408,12 +422,17 @@ func (a *API) enqueueCensusSizeUpdate(
 		// the chain only accepts a maxCensusSize increase, and the census can now shrink (a removed
 		// member, a group edit), so compare against what the election actually carries instead of
 		// submitting census.Size blindly and having the tx rejected.
+		//
+		// A failed read must not fail the request: callers reach this only after their participants
+		// and the new census size have already been committed, so returning an error here would
+		// report failure for work that was done. Fall back to enqueuing, which is what this did
+		// before the check existed — safe because every caller of this function only ever grows the
+		// census, and an unnecessary resize is harmless.
 		elec, err := a.account.Election(questions[i].UpstreamID)
 		if err != nil {
-			errors.ErrVochainRequestFailed.WithErr(err).Write(w)
-			return "", false
-		}
-		if elec.Census != nil && size <= elec.Census.MaxCensusSize {
+			log.Warnw("could not read election size, enqueuing the resize anyway",
+				"upstreamId", questions[i].UpstreamID.String(), "error", err)
+		} else if elec.Census != nil && size <= elec.Census.MaxCensusSize {
 			continue
 		}
 		published = append(published, questions[i])

--- a/api/processes_census_test.go
+++ b/api/processes_census_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/csp/handlers"
 	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 )
@@ -189,4 +190,62 @@ func TestProcessesCensusGroupID(t *testing.T) {
 	c.Assert(groups, qt.Contains, group.ID)
 	c.Assert(groups, qt.Contains, "")
 	c.Assert(groups, qt.Not(qt.Contains), primitive.NilObjectID.Hex())
+}
+
+// TestRemoveProcessCensus covers DELETE /processes/{processId}/census: members can be taken off a
+// published census, but not once they have voted, and nothing is sent on chain either way.
+func TestRemoveProcessCensus(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateProvisionedOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	req := newVotingProcessRequest(orgAddress, ids)
+	req.StartDate = ""
+	req.Census.AuthFields = db.OrgMemberAuthFields{db.OrgMemberAuthFieldsName, db.OrgMemberAuthFieldsSurname}
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, req, processesCreateEndpoint)
+	pid := created.ProcessID
+
+	// a draft cannot be edited this way; it is rebuilt wholesale by PUT /processes
+	requestAndAssertError(errors.ErrDuplicateConflict, t, http.MethodDelete, token,
+		&apicommon.AddCensusParticipantsRequest{MemberIDs: ids[:1]}, "processes", pid, "census")
+
+	job := enqueueAndPollJob(t, http.MethodPost, token, nil, "processes", pid, "publish")
+	c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("job error: %s", job.Errors))
+	got := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	openElection := got.Questions[0].UpstreamID
+	c.Assert(got.Census.Size, qt.Equals, int64(2))
+
+	before, err := testAPI.account.Election(openElection)
+	c.Assert(err, qt.IsNil)
+	c.Assert(before.Census.MaxCensusSize, qt.Equals, uint64(2))
+
+	// an empty list is a no-op rather than an error
+	noop := requestAndParse[apicommon.RemoveProcessCensusResponse](t, http.MethodDelete, token,
+		&apicommon.AddCensusParticipantsRequest{MemberIDs: nil}, "processes", pid, "census")
+	c.Assert(noop.Removed, qt.Equals, 0)
+
+	// removing a member who has not voted works, shrinks the stored size, and touches nothing on chain
+	removed := requestAndParse[apicommon.RemoveProcessCensusResponse](t, http.MethodDelete, token,
+		&apicommon.AddCensusParticipantsRequest{MemberIDs: ids[1:]}, "processes", pid, "census")
+	c.Assert(removed.Removed, qt.Equals, 1)
+	got = requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	c.Assert(got.Census.Size, qt.Equals, int64(1))
+	after, err := testAPI.account.Election(openElection)
+	c.Assert(err, qt.IsNil)
+	c.Assert(after.Census.MaxCensusSize, qt.Equals, uint64(2),
+		qt.Commentf("a removal must never resize the election: the chain only accepts growth"))
+
+	// the removed member can no longer authenticate
+	resp, code := testRequest(t, http.MethodPost, "", &handlers.AuthRequest{
+		Name: members[1].Name, Surname: members[1].Surname, Email: members[1].Email,
+	}, "processes", pid, "auth", "0")
+	c.Assert(code, qt.Equals, http.StatusNotFound, qt.Commentf("resp: %s", resp))
+
+	// the caller must manage the organization
+	requestAndAssertError(errors.ErrUnauthorized, t, http.MethodDelete, testCreateUser(t, "otherpassword123"),
+		&apicommon.AddCensusParticipantsRequest{MemberIDs: ids[:1]}, "processes", pid, "census")
 }

--- a/api/processes_census_test.go
+++ b/api/processes_census_test.go
@@ -245,6 +245,18 @@ func TestRemoveProcessCensus(t *testing.T) {
 	}, "processes", pid, "auth", "0")
 	c.Assert(code, qt.Equals, http.StatusNotFound, qt.Commentf("resp: %s", resp))
 
+	// a malformed member id is a 400, not an internal failure. The ids reach code that hex-decodes
+	// them, and internal.HexBytesFromString panics by design on invalid input, so this asserts the
+	// request never gets that far.
+	for _, bad := range []string{"zz", "not-an-objectid", "", "0x"} {
+		requestAndAssertError(errors.ErrInvalidData, t, http.MethodDelete, token,
+			&apicommon.AddCensusParticipantsRequest{MemberIDs: []string{ids[0], bad}},
+			"processes", pid, "census")
+	}
+	// nothing was removed by the rejected requests
+	got = requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	c.Assert(got.Census.Size, qt.Equals, int64(1))
+
 	// the caller must manage the organization
 	requestAndAssertError(errors.ErrUnauthorized, t, http.MethodDelete, testCreateUser(t, "otherpassword123"),
 		&apicommon.AddCensusParticipantsRequest{MemberIDs: ids[:1]}, "processes", pid, "census")

--- a/api/processes_csp_test.go
+++ b/api/processes_csp_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"net/http"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/saas-backend/api/apicommon"
@@ -289,4 +290,89 @@ func TestProcessCSPRevocation(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(votesAfter, qt.Equals, votesBefore+1,
 		qt.Commentf("an already-issued CSP signature cannot be revoked and still votes"))
+}
+
+// TestProcessCSPElectionStateGates pins the three refusals that decide whether a voter is allowed to
+// obtain a signature at all. They are the changes most likely to turn away a legitimate voter, so
+// each one is asserted explicitly rather than left to the happy path.
+func TestProcessCSPElectionStateGates(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateProvisionedOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	authReq := func(i int) *handlers.AuthRequest {
+		return &handlers.AuthRequest{Name: members[i].Name, Surname: members[i].Surname, Email: members[i].Email}
+	}
+
+	// --- a draft cannot be authenticated against: the token would outlive the draft and be
+	// spendable the moment it is published ---
+	draftReq := newVotingProcessRequest(orgAddress, ids)
+	draftReq.StartDate = ""
+	draftReq.Census.AuthFields = db.OrgMemberAuthFields{db.OrgMemberAuthFieldsName, db.OrgMemberAuthFieldsSurname}
+	draft := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, draftReq, processesCreateEndpoint)
+	resp, code := testRequest(t, http.MethodPost, "", authReq(0), "processes", draft.ProcessID, "auth", "0")
+	c.Assert(code, qt.Equals, http.StatusNotFound,
+		qt.Commentf("an unpublished process must not mint tokens: %s", resp))
+
+	// --- a published process that has not started yet cannot be signed for ---
+	futureReq := newVotingProcessRequest(orgAddress, ids)
+	futureReq.StartDate = time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339)
+	futureReq.Census.AuthFields = db.OrgMemberAuthFields{db.OrgMemberAuthFieldsName, db.OrgMemberAuthFieldsSurname}
+	future := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, futureReq, processesCreateEndpoint)
+	job := enqueueAndPollJob(t, http.MethodPost, token, nil, "processes", future.ProcessID, "publish")
+	c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("job error: %s", job.Errors))
+	futureGot := requestAndParse[apicommon.VotingProcessResponse](
+		t, http.MethodGet, token, nil, "processes", future.ProcessID)
+
+	voter := ethereum.SignKeys{}
+	c.Assert(voter.Generate(), qt.IsNil)
+	tokFuture := authProcessCSP(t, future.ProcessID, authReq(0))
+	_, code = testRequest(t, http.MethodPost, "", &handlers.SignRequest{
+		AuthToken: tokFuture, ProcessID: futureGot.Questions[0].UpstreamID,
+		Payload: hex.EncodeToString(voter.Address().Bytes()),
+	}, "processes", future.ProcessID, "sign")
+	c.Assert(code, qt.Equals, http.StatusUnauthorized,
+		qt.Commentf("a signature must not be obtainable before the process opens"))
+
+	// --- a question that is not READY cannot be signed for ---
+	liveReq := newVotingProcessRequest(orgAddress, ids)
+	liveReq.StartDate = ""
+	liveReq.Census.AuthFields = db.OrgMemberAuthFields{db.OrgMemberAuthFieldsName, db.OrgMemberAuthFieldsSurname}
+	live := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, liveReq, processesCreateEndpoint)
+	job = enqueueAndPollJob(t, http.MethodPost, token, nil, "processes", live.ProcessID, "publish")
+	c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("job error: %s", job.Errors))
+	liveGot := requestAndParse[apicommon.VotingProcessResponse](
+		t, http.MethodGet, token, nil, "processes", live.ProcessID)
+	openQuestion := liveGot.Questions[0]
+
+	tokLive := authProcessCSP(t, live.ProcessID, authReq(1))
+	// signing works while the question is READY
+	ok := requestAndParse[handlers.AuthResponse](t, http.MethodPost, "", &handlers.SignRequest{
+		AuthToken: tokLive, ProcessID: openQuestion.UpstreamID,
+		Payload: hex.EncodeToString(voter.Address().Bytes()),
+	}, "processes", live.ProcessID, "sign")
+	c.Assert(ok.Signature, qt.Not(qt.HasLen), 0)
+
+	// pause it, and the same token is refused
+	statusJob := enqueueAndPollJob(t, http.MethodPut, token,
+		&apicommon.SetProcessStatusRequest{Status: "paused"},
+		"processes", live.ProcessID, "questions", openQuestion.ID.Hex(), "status")
+	c.Assert(statusJob.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("status job: %s", statusJob.Errors))
+	waitForElectionStatus(t, openQuestion.UpstreamID, "PAUSED")
+
+	paused := ethereum.SignKeys{}
+	c.Assert(paused.Generate(), qt.IsNil)
+	tokPaused := authProcessCSP(t, live.ProcessID, authReq(0))
+	_, code = testRequest(t, http.MethodPost, "", &handlers.SignRequest{
+		AuthToken: tokPaused, ProcessID: openQuestion.UpstreamID,
+		Payload: hex.EncodeToString(paused.Address().Bytes()),
+	}, "processes", live.ProcessID, "sign")
+	c.Assert(code, qt.Equals, http.StatusUnauthorized,
+		qt.Commentf("a paused question must not be signed for"))
 }

--- a/api/processes_csp_test.go
+++ b/api/processes_csp_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/csp/handlers"
 	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/errors"
 	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.vocdoni.io/dvote/crypto/ethereum"
@@ -192,4 +193,100 @@ func TestProcessCSP(t *testing.T) {
 	// a malformed process id is a client error
 	requestAndAssertCode(http.StatusBadRequest, t, http.MethodPost, "",
 		&handlers.CheckMembershipRequest{AuthToken: tok0}, "processes", "not-a-valid-id", "check")
+}
+
+// TestProcessCSPRevocation covers what happens when the electorate changes under a live election.
+// It pins the guarantee the backend can make (a voter taken off the census stops being signed for)
+// and, just as importantly, the one it cannot (a signature already handed out still votes).
+func TestProcessCSPRevocation(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateProvisionedOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(3)...)
+	ids := memberIDs(members)
+
+	req := newVotingProcessRequest(orgAddress, ids)
+	req.StartDate = ""
+	req.Census.AuthFields = db.OrgMemberAuthFields{db.OrgMemberAuthFieldsName, db.OrgMemberAuthFieldsSurname}
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, req, processesCreateEndpoint)
+	pid := created.ProcessID
+
+	job := enqueueAndPollJob(t, http.MethodPost, token, nil, "processes", pid, "publish")
+	c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("job error: %s", job.Errors))
+	got := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	openElection := got.Questions[0].UpstreamID
+
+	authReq := func(i int) *handlers.AuthRequest {
+		return &handlers.AuthRequest{Name: members[i].Name, Surname: members[i].Surname, Email: members[i].Email}
+	}
+	// --- member 0 authenticates, is then removed from the census, and is refused at sign ---
+	tok0 := authProcessCSP(t, pid, authReq(0))
+	voter0 := ethereum.SignKeys{}
+	c.Assert(voter0.Generate(), qt.IsNil)
+
+	removed := requestAndParse[apicommon.RemoveProcessCensusResponse](t, http.MethodDelete, token,
+		&apicommon.AddCensusParticipantsRequest{MemberIDs: ids[:1]}, "processes", pid, "census")
+	c.Assert(removed.Removed, qt.Equals, 1)
+
+	// the token was minted while they were still in the census; removal invalidates the session, so
+	// it is not spendable now
+	_, code := testRequest(t, http.MethodPost, "", &handlers.SignRequest{
+		AuthToken: tok0, ProcessID: openElection, Payload: hex.EncodeToString(voter0.Address().Bytes()),
+	}, "processes", pid, "sign")
+	c.Assert(code, qt.Equals, http.StatusUnauthorized, qt.Commentf("a removed member must not be signed for"))
+
+	// and they cannot authenticate again either
+	resp, code := testRequest(t, http.MethodPost, "", authReq(0), "processes", pid, "auth", "0")
+	c.Assert(code, qt.Equals, http.StatusNotFound, qt.Commentf("resp: %s", resp))
+
+	// --- member 2 keeps a live token while the participant row disappears underneath it, which is
+	// what a group edit does. Sign must re-check the census rather than trust the token. ---
+	tok2 := authProcessCSP(t, pid, authReq(2))
+	voter2 := ethereum.SignKeys{}
+	c.Assert(voter2.Generate(), qt.IsNil)
+	processOID, err := primitive.ObjectIDFromHex(pid)
+	c.Assert(err, qt.IsNil)
+	vp, err := testDB.VotingProcess(processOID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(testDB.DelCensusParticipant(vp.CensusID.Hex(), ids[2]), qt.IsNil)
+
+	_, code = testRequest(t, http.MethodPost, "", &handlers.SignRequest{
+		AuthToken: tok2, ProcessID: openElection, Payload: hex.EncodeToString(voter2.Address().Bytes()),
+	}, "processes", pid, "sign")
+	c.Assert(code, qt.Equals, http.StatusNotFound,
+		qt.Commentf("sign must re-check census participation, not trust the token"))
+
+	// --- member 1 signs FIRST, then is removed: the signature still votes ---
+	tok1 := authProcessCSP(t, pid, authReq(1))
+	voter1 := ethereum.SignKeys{}
+	c.Assert(voter1.Generate(), qt.IsNil)
+	sign1 := requestAndParse[handlers.AuthResponse](t, http.MethodPost, "",
+		&handlers.SignRequest{
+			AuthToken: tok1, ProcessID: openElection, Payload: hex.EncodeToString(voter1.Address().Bytes()),
+		}, "processes", pid, "sign")
+	c.Assert(sign1.Signature, qt.Not(qt.HasLen), 0)
+
+	// removing them is now refused: the ballot is already theirs to cast and hiding that would be
+	// a lie. The error names them.
+	errResp := requestAndExpectError(t, http.MethodDelete, token,
+		&apicommon.AddCensusParticipantsRequest{MemberIDs: ids[1:2]}, "processes", pid, "census")
+	c.Assert(errResp.Code, qt.Equals, errors.ErrCensusMemberAlreadyVoted.Code)
+	data, isMap := errResp.Data.(map[string]any)
+	c.Assert(isMap, qt.IsTrue, qt.Commentf("error data: %#v", errResp.Data))
+	c.Assert(data["votedMemberIds"], qt.DeepEquals, []any{ids[1]})
+
+	// the signature they already hold still produces a vote the chain accepts — the documented
+	// ceiling: revocation closes the door on new signatures, it cannot recall one.
+	vocdoniClient := testNewVocdoniClient(t)
+	votesBefore, err := vocdoniClient.ElectionVoteCount(openElection.Bytes())
+	c.Assert(err, qt.IsNil)
+	proof := testGenerateVoteProof(openElection, voter1.Address().Bytes(), sign1.Signature, 1)
+	nullifier := testRelayVoteRequest(t, &voter1, openElection, proof, []byte("[\"1\"]"))
+	c.Assert(nullifier, qt.Not(qt.HasLen), 0)
+	votesAfter, err := vocdoniClient.ElectionVoteCount(openElection.Bytes())
+	c.Assert(err, qt.IsNil)
+	c.Assert(votesAfter, qt.Equals, votesBefore+1,
+		qt.Commentf("an already-issued CSP signature cannot be revoked and still votes"))
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -212,7 +212,8 @@ const (
 	processesEndpoint = "/processes/{processId}"
 	// POST /processes/census/validation validates a census spec (duplicates/missing fields) before create
 	processesCensusValidateEndpoint = "/processes/census/validation"
-	// PUT /processes/{processId}/census adds members to a published process's census (+ maxCensusSize bump)
+	// PUT /processes/{processId}/census adds members to a published process's census (+ maxCensusSize bump);
+	// DELETE removes members from it, revoking their CSP sessions, unless they have already voted
 	processesCensusEndpoint = "/processes/{processId}/census"
 	// GET /processes/{processId}/validation publish-readiness dry-run (protected)
 	processesValidateEndpoint = "/processes/{processId}/validation"

--- a/csp/handlers/handlers.go
+++ b/csp/handlers/handlers.go
@@ -421,16 +421,18 @@ func (c *CSPHandlers) BundleSignHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Re-check the census here and not only at auth: the token outlives the request that minted it,
+	// so a voter dropped from the census in between must not still be signed for.
+	if _, err := c.mainDB.CensusParticipant(bundle.Census.ID.Hex(), oid.Hex()); err != nil {
+		errors.ErrCensusParticipantNotFound.WithErr(err).Write(w)
+		return
+	}
+
 	// default weight to 1 if not set
 	weight := uint64(1)
 	if census.Weighted {
 		weight = member.Weight
 	}
-
-	// // Check if the participant is in the census
-	// if !c.checkCensusParticipant(w, bundle.Census.ID.Hex(), string(auth.UserID)) {
-	// 	return
-	// }
 
 	// Parse the address from the payload
 	address, ok := parseAddress(w, req.Payload)

--- a/csp/handlers/processes.go
+++ b/csp/handlers/processes.go
@@ -19,6 +19,12 @@ import (
 	"go.vocdoni.io/dvote/vochain/state"
 )
 
+// startDateGrace is how far ahead of a process's stored start date signing is still allowed. The
+// gate compares this host's clock against a date the backend wrote, neither of which is the chain,
+// so a small window keeps a host running marginally behind from refusing voters on an election that
+// is already open.
+const startDateGrace = time.Minute
+
 // parseProcessID parses the {processId} URL param (a voting-process Mongo ObjectID) and
 // returns both the ObjectID and its bytes, which are used as the CSP token anchor.
 func parseProcessID(w http.ResponseWriter, r *http.Request) (primitive.ObjectID, internal.HexBytes, bool) {
@@ -253,7 +259,13 @@ func (c *CSPHandlers) ProcessSignHandler(w http.ResponseWriter, r *http.Request)
 	// a process scheduled to start later is READY on chain but not yet accepting votes; refuse to
 	// hand out a signature that could simply be held until it opens. Only the start is checked:
 	// EndDate is optional (it may be zero), while publish always persists a start date.
-	if !vp.StartDate.IsZero() && time.Now().Before(vp.StartDate) {
+	//
+	// The comparison is against this host's clock and a stored date, not against the chain, so an
+	// exact one would turn a host running slightly behind into 401s on an election the chain is
+	// already accepting. The grace window makes the gate err towards letting a legitimate voter
+	// through: the worst it allows is a signature minted seconds early, which the chain will refuse
+	// anyway until the election opens.
+	if !vp.StartDate.IsZero() && time.Now().Add(startDateGrace).Before(vp.StartDate) {
 		errors.ErrUnauthorized.Withf("process has not started yet").Write(w)
 		return
 	}

--- a/csp/handlers/processes.go
+++ b/csp/handlers/processes.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-chi/chi/v5"
@@ -91,6 +92,12 @@ func (c *CSPHandlers) ProcessAuthHandler(w http.ResponseWriter, r *http.Request)
 	}
 	vp, ok := c.getVotingProcess(w, oid)
 	if !ok {
+		return
+	}
+	// a draft has no on-chain election to vote, so authenticating against it only mints a token
+	// that outlives the draft and is spendable the moment it is published.
+	if !vp.Published {
+		errors.ErrProcessNotFound.Withf("process is not published").Write(w)
 		return
 	}
 	c.handleAuthStep(w, r, step, anchor, vp.CensusID.Hex())
@@ -236,6 +243,20 @@ func (c *CSPHandlers) ProcessSignHandler(w http.ResponseWriter, r *http.Request)
 		errors.ErrUnauthorized.Withf("member not eligible for this question").Write(w)
 		return
 	}
+	// only a live election may be signed for. Without this a voter can obtain a signature against a
+	// paused or ended question and hold it until the chain would accept it — the CSP is the only
+	// place that can refuse, since the signature it hands out carries no expiry.
+	if question.Status != db.QuestionStatusReady {
+		errors.ErrUnauthorized.Withf("question is not open for voting").Write(w)
+		return
+	}
+	// a process scheduled to start later is READY on chain but not yet accepting votes; refuse to
+	// hand out a signature that could simply be held until it opens. Only the start is checked:
+	// EndDate is optional (it may be zero), while publish always persists a start date.
+	if !vp.StartDate.IsZero() && time.Now().Before(vp.StartDate) {
+		errors.ErrUnauthorized.Withf("process has not started yet").Write(w)
+		return
+	}
 	member, ok := c.orgMemberFromAuth(w, vp.OrgAddress, auth)
 	if !ok {
 		return
@@ -243,6 +264,13 @@ func (c *CSPHandlers) ProcessSignHandler(w http.ResponseWriter, r *http.Request)
 	census, err := c.mainDB.Census(vp.CensusID.Hex())
 	if err != nil {
 		errors.ErrCensusNotFound.WithErr(err).Write(w)
+		return
+	}
+	// re-check census participation, which auth only checked when the token was minted. A token
+	// stays valid indefinitely, so without this a voter removed from the census afterwards — by a
+	// group edit, a member deletion or an explicit removal — would still be signed for.
+	if _, err := c.mainDB.CensusParticipant(vp.CensusID.Hex(), auth.UserID.String()); err != nil {
+		errors.ErrCensusParticipantNotFound.WithErr(err).Write(w)
 		return
 	}
 	weight := uint64(1)

--- a/db/census_participant.go
+++ b/db/census_participant.go
@@ -248,6 +248,13 @@ func (ms *MongoStorage) DelCensusParticipant(censusID, participantID string) err
 // This cannot recall a signature the member already holds — that is a bearer credential the chain
 // accepts until the election closes. It only closes the door on future signatures.
 //
+// Unlike removal through the census endpoint or a group edit, this deliberately does NOT refuse
+// members who already voted. Deleting a member is erasure: their ballot is already on chain and
+// unaffected either way, and making the delete conditional would leave no way to remove a person
+// while any election they voted is live. The visible consequence is that census.Size can end up
+// below the number of ballots cast for that election, so a finished process may report more votes
+// than census members.
+//
 // Assumes ms.keysLock is already held by the caller.
 func (ms *MongoStorage) purgeMembersFromCensuses(ctx context.Context, memberIDs []string) error {
 	if len(memberIDs) == 0 {
@@ -321,7 +328,14 @@ func (ms *MongoStorage) RemoveCensusParticipantsByMemberIDs(censusID string, mem
 //
 // Eligibility is pruned only for processes using these censuses — the same member may legitimately
 // remain in another census. Token deletion is deliberately not scoped: re-authenticating re-checks
-// census participation, so dropping a token can only force a fresh login, never grant anything.
+// census participation, so dropping a token can only force a fresh login, never grant anything. The
+// cost is that removal from one process logs the member out of every other one too, so they need a
+// fresh OTP there; the endpoint documents it.
+//
+// Note the asymmetry when several processes share a census: this prunes eligibility on all of them,
+// while the caller's already-voted check only looks at the process it was asked about. One census
+// per process today makes it unreachable, but the plural lookup below is deliberate, so if that ever
+// changes the check has to widen with it.
 //
 // Like purgeMembersFromCensuses this leaves consumption rows untouched; see that function for why.
 // Assumes ms.keysLock is held.
@@ -331,9 +345,12 @@ func (ms *MongoStorage) revokeCensusMembers(ctx context.Context, censusIDs, memb
 	}
 	censusOIDs := make([]primitive.ObjectID, 0, len(censusIDs))
 	for _, id := range censusIDs {
-		if oid, err := primitive.ObjectIDFromHex(id); err == nil {
-			censusOIDs = append(censusOIDs, oid)
+		oid, err := primitive.ObjectIDFromHex(id)
+		if err != nil {
+			log.Warnw("skipping undecodable census id while revoking members", "censusId", id)
+			continue
 		}
+		censusOIDs = append(censusOIDs, oid)
 	}
 	if len(censusOIDs) > 0 {
 		processIDs, err := ms.votingProcesses.Distinct(ctx, "_id", bson.M{"censusId": bson.M{"$in": censusOIDs}})
@@ -387,6 +404,10 @@ func (ms *MongoStorage) recountCensuses(ctx context.Context, censusIDs []string)
 	for _, censusID := range censusIDs {
 		oid, err := primitive.ObjectIDFromHex(censusID)
 		if err != nil {
+			// a census id that does not decode means a participant row points at something that
+			// cannot exist; skipping keeps the sweep going, but say so rather than persist a size
+			// silently computed from a broken reference.
+			log.Warnw("skipping undecodable census id while recounting", "censusId", censusID)
 			continue
 		}
 		count, err := ms.censusParticipants.CountDocuments(ctx, bson.M{"censusId": censusID})

--- a/db/census_participant.go
+++ b/db/census_participant.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -231,6 +232,165 @@ func (ms *MongoStorage) DelCensusParticipant(censusID, participantID string) err
 		return fmt.Errorf("failed to delete census participant: %w", err)
 	}
 
+	return nil
+}
+
+// purgeMembersFromCensuses revokes the given members' ability to vote anything they have not voted
+// yet: it drops their census participant rows, removes them from every question's eligibility
+// subset, and deletes their CSP auth tokens so an already-issued session cannot be reused. The
+// affected censuses have their stored Size recounted.
+//
+// It deliberately does NOT delete cspTokensStatus (consumption) rows. Those pin the single address
+// a member was ever signed for; dropping one would let a member who is later re-added be signed for
+// a second address, producing a second nullifier and a double vote the chain would accept. They are
+// also the record CSPProcessVoters reads to refuse revoking someone who already voted.
+//
+// This cannot recall a signature the member already holds — that is a bearer credential the chain
+// accepts until the election closes. It only closes the door on future signatures.
+//
+// Assumes ms.keysLock is already held by the caller.
+func (ms *MongoStorage) purgeMembersFromCensuses(ctx context.Context, memberIDs []string) error {
+	if len(memberIDs) == 0 {
+		return nil
+	}
+	// the censuses that will need their size recounted, resolved before the rows are gone
+	censusIDs, err := ms.censusParticipants.Distinct(ctx, "censusId", bson.M{
+		"participantID": bson.M{"$in": memberIDs},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to resolve affected censuses: %w", err)
+	}
+	if _, err := ms.censusParticipants.DeleteMany(ctx, bson.M{
+		"participantID": bson.M{"$in": memberIDs},
+	}); err != nil {
+		return fmt.Errorf("failed to delete census participants: %w", err)
+	}
+	// the member is gone entirely, so their id has no business in any eligibility subset
+	if _, err := ms.processesQuestions.UpdateMany(ctx,
+		bson.M{"eligibleMemberIds": bson.M{"$in": memberIDs}},
+		bson.M{"$pull": bson.M{"eligibleMemberIds": bson.M{"$in": memberIDs}}},
+	); err != nil {
+		return fmt.Errorf("failed to prune question eligibility: %w", err)
+	}
+	if err := ms.deleteCSPAuthByMembers(ctx, memberIDs); err != nil {
+		return err
+	}
+	affected := make([]string, 0, len(censusIDs))
+	for _, raw := range censusIDs {
+		if censusID, ok := raw.(string); ok {
+			affected = append(affected, censusID)
+		}
+	}
+	return ms.recountCensuses(ctx, affected)
+}
+
+// RemoveCensusParticipantsByMemberIDs takes the given members off a census and revokes what that
+// implies: their eligibility on the census's processes and their CSP sessions. It is the inverse of
+// AddCensusParticipantsByMemberIDs, and returns how many participant rows were actually removed.
+//
+// It does not retract anything already voted — a signature the member holds stays valid on chain.
+func (ms *MongoStorage) RemoveCensusParticipantsByMemberIDs(censusID string, memberIDs []string) (int, error) {
+	if censusID == "" {
+		return 0, ErrInvalidData
+	}
+	if len(memberIDs) == 0 {
+		return 0, nil
+	}
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	res, err := ms.censusParticipants.DeleteMany(ctx, bson.M{
+		"censusId":      censusID,
+		"participantID": bson.M{"$in": memberIDs},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to remove census participants: %w", err)
+	}
+	if err := ms.revokeCensusMembers(ctx, []string{censusID}, memberIDs); err != nil {
+		return 0, err
+	}
+	return int(res.DeletedCount), nil
+}
+
+// revokeCensusMembers takes the given members off the given censuses' voting path without deleting
+// the members themselves: it prunes them from the eligibility subsets of those censuses' processes,
+// invalidates their CSP sessions and recounts the census sizes. The caller has already removed the
+// participant rows.
+//
+// Eligibility is pruned only for processes using these censuses — the same member may legitimately
+// remain in another census. Token deletion is deliberately not scoped: re-authenticating re-checks
+// census participation, so dropping a token can only force a fresh login, never grant anything.
+//
+// Like purgeMembersFromCensuses this leaves consumption rows untouched; see that function for why.
+// Assumes ms.keysLock is held.
+func (ms *MongoStorage) revokeCensusMembers(ctx context.Context, censusIDs, memberIDs []string) error {
+	if len(censusIDs) == 0 || len(memberIDs) == 0 {
+		return nil
+	}
+	censusOIDs := make([]primitive.ObjectID, 0, len(censusIDs))
+	for _, id := range censusIDs {
+		if oid, err := primitive.ObjectIDFromHex(id); err == nil {
+			censusOIDs = append(censusOIDs, oid)
+		}
+	}
+	if len(censusOIDs) > 0 {
+		processIDs, err := ms.votingProcesses.Distinct(ctx, "_id", bson.M{"censusId": bson.M{"$in": censusOIDs}})
+		if err != nil {
+			return fmt.Errorf("failed to resolve processes of the census: %w", err)
+		}
+		if len(processIDs) > 0 {
+			if _, err := ms.processesQuestions.UpdateMany(ctx,
+				bson.M{"processId": bson.M{"$in": processIDs}, "eligibleMemberIds": bson.M{"$in": memberIDs}},
+				bson.M{"$pull": bson.M{"eligibleMemberIds": bson.M{"$in": memberIDs}}},
+			); err != nil {
+				return fmt.Errorf("failed to prune question eligibility: %w", err)
+			}
+		}
+	}
+	if err := ms.deleteCSPAuthByMembers(ctx, memberIDs); err != nil {
+		return err
+	}
+	return ms.recountCensuses(ctx, censusIDs)
+}
+
+// deleteCSPAuthByMembers drops the CSP auth tokens of the given members so a session minted while
+// they were still in the census cannot be spent afterwards. Consumption rows (cspTokensStatus) are
+// never touched — see purgeMembersFromCensuses.
+func (ms *MongoStorage) deleteCSPAuthByMembers(ctx context.Context, memberIDs []string) error {
+	// tokens key the member by the binary form of its ObjectID hex
+	userIDs := make([]internal.HexBytes, 0, len(memberIDs))
+	for _, id := range memberIDs {
+		userIDs = append(userIDs, internal.HexBytesFromString(id))
+	}
+	if _, err := ms.cspTokens.DeleteMany(ctx, bson.M{"userid": bson.M{"$in": userIDs}}); err != nil {
+		return fmt.Errorf("failed to delete CSP auth tokens: %w", err)
+	}
+	return nil
+}
+
+// recountCensuses refreshes the stored Size of each census from its participant rows, so quota
+// checks and future publishes see the truth. The smaller number is never pushed to the chain:
+// maxCensusSize can only grow there, and the leftover headroom is harmless because the CSP, not
+// that number, decides who may vote.
+func (ms *MongoStorage) recountCensuses(ctx context.Context, censusIDs []string) error {
+	for _, censusID := range censusIDs {
+		oid, err := primitive.ObjectIDFromHex(censusID)
+		if err != nil {
+			continue
+		}
+		count, err := ms.censusParticipants.CountDocuments(ctx, bson.M{"censusId": censusID})
+		if err != nil {
+			return fmt.Errorf("failed to recount census participants: %w", err)
+		}
+		if _, err := ms.censuses.UpdateOne(ctx,
+			bson.M{"_id": oid},
+			bson.M{"$set": bson.M{"size": count, "updatedAt": time.Now()}},
+		); err != nil {
+			return fmt.Errorf("failed to update census size: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/db/census_participant.go
+++ b/db/census_participant.go
@@ -359,10 +359,19 @@ func (ms *MongoStorage) revokeCensusMembers(ctx context.Context, censusIDs, memb
 // they were still in the census cannot be spent afterwards. Consumption rows (cspTokensStatus) are
 // never touched — see purgeMembersFromCensuses.
 func (ms *MongoStorage) deleteCSPAuthByMembers(ctx context.Context, memberIDs []string) error {
-	// tokens key the member by the binary form of its ObjectID hex
+	// tokens key the member by the binary form of its ObjectID hex. Decode without
+	// internal.HexBytesFromString, which panics on a malformed id by design: an id that cannot be
+	// decoded cannot match a stored token either, so skipping it is both safe and total.
 	userIDs := make([]internal.HexBytes, 0, len(memberIDs))
 	for _, id := range memberIDs {
-		userIDs = append(userIDs, internal.HexBytesFromString(id))
+		userID := internal.HexBytes{}
+		if err := userID.ParseString(id); err != nil {
+			continue
+		}
+		userIDs = append(userIDs, userID)
+	}
+	if len(userIDs) == 0 {
+		return nil
 	}
 	if _, err := ms.cspTokens.DeleteMany(ctx, bson.M{"userid": bson.M{"$in": userIDs}}); err != nil {
 		return fmt.Errorf("failed to delete CSP auth tokens: %w", err)

--- a/db/census_participant_test.go
+++ b/db/census_participant_test.go
@@ -994,3 +994,65 @@ func TestCreateCensusParticipantBulkOperationsFiltering(t *testing.T) {
 		}
 	})
 }
+
+// TestPurgeMembersFromCensuses covers the cascade that revokes a deleted member: their census
+// participation, question eligibility and CSP session all go, the census size is recounted — and,
+// critically, their consumption row survives.
+func TestPurgeMembersFromCensuses(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	member, census := setupTestCensusParticipantPrerequisites(t, "_purge")
+	memberID := member.ID.Hex()
+	censusID := census.ID.Hex()
+
+	added, memberErrs, err := testDB.AddCensusParticipantsByMemberIDs(censusID, []string{memberID})
+	c.Assert(err, qt.IsNil)
+	c.Assert(memberErrs, qt.HasLen, 0)
+	c.Assert(added, qt.Equals, 1)
+
+	// a process on that census, with the member in a question's eligibility subset
+	vpID, err := testDB.SetVotingProcess(&VotingProcess{
+		OrgAddress: testOrgAddress, Title: MultiLangString{"default": "P"}, CensusID: census.ID,
+	})
+	c.Assert(err, qt.IsNil)
+	election := internal.HexBytes{0xd0, 0x0d}
+	qID, err := testDB.SetQuestion(&VotingProcessQuestion{
+		ProcessID: vpID, OrgAddress: testOrgAddress, Type: VotingTypeSingleChoice,
+		EligibleMemberIDs: []string{memberID}, UpstreamID: election, Status: QuestionStatusReady,
+	})
+	c.Assert(err, qt.IsNil)
+
+	// an authenticated CSP session, and a consumed election (i.e. they already voted)
+	token := internal.HexBytes{0x01, 0x02, 0x03}
+	c.Assert(testDB.SetCSPAuth(token, internal.HexBytesFromString(memberID), internal.HexBytes{0x09}, "s"), qt.IsNil)
+	c.Assert(testDB.VerifyCSPAuth(token), qt.IsNil)
+	c.Assert(testDB.ConsumeCSPProcess(token, election, internal.HexBytes{0xaa}), qt.IsNil)
+
+	deleted, err := testDB.DeleteOrgMembers(testOrgAddress, []string{memberID})
+	c.Assert(err, qt.IsNil)
+	c.Assert(deleted, qt.Equals, 1)
+
+	// census participation is gone and the stored size follows
+	_, err = testDB.CensusParticipant(censusID, memberID)
+	c.Assert(err, qt.Equals, ErrNotFound)
+	updatedCensus, err := testDB.Census(censusID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(updatedCensus.Size, qt.Equals, int64(0))
+
+	// the eligibility subset no longer counts them
+	q, err := testDB.Question(qID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(q.EligibleMemberIDs, qt.HasLen, 0)
+
+	// the CSP session is invalidated, so a token minted earlier cannot be spent
+	_, err = testDB.CSPAuth(token)
+	c.Assert(err, qt.Not(qt.IsNil))
+
+	// ...but the consumption row survives. Deleting it would let this member, if ever re-added, be
+	// signed for a second address — a second nullifier, and a double vote the chain would accept.
+	voters, err := testDB.MembersWithUsedCSPProcess(election, []string{memberID})
+	c.Assert(err, qt.IsNil)
+	c.Assert(voters[memberID], qt.IsTrue,
+		qt.Commentf("consumption rows must outlive the member, or removal opens a double-vote hole"))
+}

--- a/db/csp.go
+++ b/db/csp.go
@@ -10,8 +10,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.vocdoni.io/dvote/log"
 )
 
 // CSPAuth represents a user authentication information for a bundle of processes
@@ -409,6 +411,57 @@ func (ms *MongoStorage) GetOrgMembersByProcess(orgAddress common.Address, proces
 		return nil, err
 	}
 	return orgMembers, nil
+}
+
+// MembersWithUsedCSPProcesses returns which of the given members have already cast a ballot in any
+// of the given processes, as one query. Prefer it over calling MembersWithUsedCSPProcess in a loop:
+// that one costs a round-trip per member, so a caller sweeping several elections turns
+// questions × members into that many queries.
+//
+// The returned map is keyed by the member id hex and only contains entries set to true. Undecodable
+// ids are skipped — they cannot have a CSP process — rather than failing the whole lookup.
+func (ms *MongoStorage) MembersWithUsedCSPProcesses(
+	processIDs []internal.HexBytes,
+	memberIDs []string,
+) (map[string]bool, error) {
+	result := make(map[string]bool, len(memberIDs))
+	if len(processIDs) == 0 || len(memberIDs) == 0 {
+		return result, nil
+	}
+	userIDs := make([]internal.HexBytes, 0, len(memberIDs))
+	for _, id := range memberIDs {
+		userID := internal.HexBytes{}
+		if err := userID.ParseString(id); err != nil {
+			continue
+		}
+		userIDs = append(userIDs, userID)
+	}
+	if len(userIDs) == 0 {
+		return result, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	// covered by the userid+processid index on cspTokensStatus (migrations/0002_initial_indexes.go)
+	voted, err := ms.cspTokensStatus.Distinct(ctx, "userid", bson.M{
+		"processid": bson.M{"$in": processIDs},
+		"userid":    bson.M{"$in": userIDs},
+		"consumed":  true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to query CSP process status: %w", err)
+	}
+	for _, raw := range voted {
+		switch v := raw.(type) {
+		case string:
+			result[v] = true
+		case primitive.Binary:
+			// HexBytes marshals to bson binary, so that is the shape stored userids come back in
+			result[internal.HexBytes(v.Data).String()] = true
+		default:
+			log.Warnw("unexpected userid type in CSP process status", "type", fmt.Sprintf("%T", raw))
+		}
+	}
+	return result, nil
 }
 
 // MembersWithUsedCSPProcess returns the subset of the given memberIDs (each the

--- a/db/csp.go
+++ b/db/csp.go
@@ -430,7 +430,13 @@ func (ms *MongoStorage) MembersWithUsedCSPProcess(
 
 	result := make(map[string]bool, len(memberIDs))
 	for _, id := range memberIDs {
-		userID := internal.HexBytesFromString(id)
+		// decode without internal.HexBytesFromString, which panics on a malformed id by design.
+		// Callers now include handlers that pass member ids straight from a request body, and an id
+		// that cannot be decoded simply has no CSP process, so skipping it is the right answer.
+		userID := internal.HexBytes{}
+		if err := userID.ParseString(id); err != nil {
+			continue
+		}
 		proc, err := ms.CSPProcessByUserAndProcess(userID, processID)
 		if err != nil {
 			if errors.Is(err, ErrTokenNotFound) {

--- a/db/errors.go
+++ b/db/errors.go
@@ -29,6 +29,28 @@ var (
 	ErrManagedQuotaReached = fmt.Errorf("integrator managed quota reached")
 )
 
+// CensusInUseByPublishedProcessError reports that an operation would tear down a census that a
+// published process is still voting on, naming the processes that block it. Deleting a group is a
+// metadata operation for every other purpose, so it must not double as a way to wipe a live
+// electorate; the caller removes members explicitly instead.
+type CensusInUseByPublishedProcessError struct {
+	ProcessIDs []string
+}
+
+func (e *CensusInUseByPublishedProcessError) Error() string {
+	return fmt.Sprintf("census is in use by %d published process(es)", len(e.ProcessIDs))
+}
+
+// MembersAlreadyVotedError reports the members an operation refuses to strip of eligibility because
+// they have already cast a ballot. Carrying the ids lets the caller name them back to the client.
+type MembersAlreadyVotedError struct {
+	MemberIDs []string
+}
+
+func (e *MembersAlreadyVotedError) Error() string {
+	return fmt.Sprintf("%d member(s) already voted", len(e.MemberIDs))
+}
+
 // errorsAsStrings converts a slice of errors to a slice of strings
 func errorsAsStrings(errs []error) []string {
 	s := []string{}

--- a/db/errors.go
+++ b/db/errors.go
@@ -48,7 +48,7 @@ type MembersAlreadyVotedError struct {
 }
 
 func (e *MembersAlreadyVotedError) Error() string {
-	return fmt.Sprintf("%d member(s) already voted", len(e.MemberIDs))
+	return fmt.Sprintf("%d member(s) already signed for", len(e.MemberIDs))
 }
 
 // errorsAsStrings converts a slice of errors to a slice of strings

--- a/db/org_members.go
+++ b/db/org_members.go
@@ -610,6 +610,13 @@ func (ms *MongoStorage) DeleteOrgMembers(orgAddress common.Address, ids []string
 		return 0, fmt.Errorf("failed to update groups after deleting orgMembers: %w", err)
 	}
 
+	// A deleted member must stop being able to vote. Their census participant rows, question
+	// eligibility and CSP sessions all outlive the member document otherwise, and a live election
+	// would keep accepting them.
+	if err := ms.purgeMembersFromCensuses(ctx, stringIDs); err != nil {
+		return 0, fmt.Errorf("failed to purge deleted members from censuses: %w", err)
+	}
+
 	// Clean up the auto group if the org now has no members.
 	if err := ms.DeleteAutoMemberGroupIfEmpty(orgAddress); err != nil {
 		log.Warnw("could not clean up auto member group after DeleteOrgMembers", "error", err)
@@ -636,6 +643,12 @@ func (ms *MongoStorage) DeleteAllOrgMembers(orgAddress common.Address) (int, err
 	ms.keysLock.Lock()
 	defer ms.keysLock.Unlock()
 
+	// collect the ids before the documents go, so the census/CSP cascade below knows who to revoke
+	memberIDs, err := ms.GetAllOrgMemberIDs(orgAddress)
+	if err != nil {
+		return 0, err
+	}
+
 	result, err := ms.orgMembers.DeleteMany(ctx, filter)
 	if err != nil {
 		return 0, fmt.Errorf("failed to delete all orgMembers: %w", err)
@@ -655,6 +668,11 @@ func (ms *MongoStorage) DeleteAllOrgMembers(orgAddress common.Address) (int, err
 	_, err = ms.orgMemberGroups.UpdateMany(ctx, groupFilter, groupUpdate)
 	if err != nil {
 		return 0, fmt.Errorf("failed to update groups after deleting all orgMembers: %w", err)
+	}
+
+	// see DeleteOrgMembers: deleted members must lose census participation and their CSP sessions.
+	if err := ms.purgeMembersFromCensuses(ctx, memberIDs); err != nil {
+		return 0, fmt.Errorf("failed to purge deleted members from censuses: %w", err)
 	}
 
 	// All members are gone — remove the auto group too.

--- a/db/org_members_groups.go
+++ b/db/org_members_groups.go
@@ -219,9 +219,40 @@ func (ms *MongoStorage) UpdateOrganizationMemberGroup(
 		if err != nil {
 			return err
 		}
+
+		// A census built from this group is a snapshot taken when it was created, so without this a
+		// member dropped from the group keeps voting a live election. Removals propagate; additions
+		// deliberately do not, because growing a census consumes plan quota and needs an on-chain
+		// maxCensusSize bump — that is what PUT /processes/{processId}/census is for, and doing it
+		// implicitly from a group edit would bill the organization for an unrelated action.
+		if len(removedMembers) > 0 {
+			if err := ms.purgeMembersFromGroupCensuses(ctx, updatedGroup, removedMembers); err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil
+}
+
+// purgeMembersFromGroupCensuses revokes the given members from every census derived from the group.
+// It is scoped to the group's own censuses: a member removed from one group may still legitimately
+// belong to another group's census. Assumes ms.keysLock is held.
+func (ms *MongoStorage) purgeMembersFromGroupCensuses(
+	ctx context.Context, group *OrganizationMemberGroup, memberIDs []string,
+) error {
+	if group == nil || len(group.CensusIDs) == 0 || len(memberIDs) == 0 {
+		return nil
+	}
+	// only the participant rows of this group's censuses; the shared purge would reach every census
+	// the member belongs to, including ones built from a different group.
+	if _, err := ms.censusParticipants.DeleteMany(ctx, bson.M{
+		"censusId":      bson.M{"$in": group.CensusIDs},
+		"participantID": bson.M{"$in": memberIDs},
+	}); err != nil {
+		return fmt.Errorf("failed to remove members from the group censuses: %w", err)
+	}
+	return ms.revokeCensusMembers(ctx, group.CensusIDs, memberIDs)
 }
 
 // AddOrganizationMemberGroupCensus adds a census to an organization member group
@@ -280,7 +311,9 @@ func (ms *MongoStorage) DeleteOrganizationMemberGroup(groupID string, orgAddress
 	if _, err := ms.orgMemberGroups.DeleteOne(ctx, filter); err != nil {
 		return fmt.Errorf("could not delete organization members group: %w", err)
 	}
-	return nil
+	// the censuses built from this group outlive it, so deleting the group must also take its
+	// members off them — otherwise a group can be deleted while its electorate keeps voting.
+	return ms.purgeMembersFromGroupCensuses(ctx, group, group.MemberIDs)
 }
 
 // ListOrganizationMemberGroup lists all the members of an organization member group (paginated)

--- a/db/org_members_groups.go
+++ b/db/org_members_groups.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -226,6 +227,17 @@ func (ms *MongoStorage) UpdateOrganizationMemberGroup(
 		// maxCensusSize bump — that is what PUT /processes/{processId}/census is for, and doing it
 		// implicitly from a group edit would bill the organization for an unrelated action.
 		if len(removedMembers) > 0 {
+			// removing someone from the group takes their eligibility away, so it answers to the
+			// same rule as DELETE /processes/{processId}/census: a ballot already cast cannot be
+			// taken back. Without this the endpoint's guard is bypassable — a manager refused there
+			// could strip the same voter by editing the group instead.
+			blocked, err := ms.membersWhoVotedGroupCensuses(ctx, updatedGroup.CensusIDs, removedMembers)
+			if err != nil {
+				return err
+			}
+			if len(blocked) > 0 {
+				return &MembersAlreadyVotedError{MemberIDs: blocked}
+			}
 			if err := ms.purgeMembersFromGroupCensuses(ctx, updatedGroup, removedMembers); err != nil {
 				return err
 			}
@@ -306,6 +318,17 @@ func (ms *MongoStorage) DeleteOrganizationMemberGroup(groupID string, orgAddress
 	ms.keysLock.Lock()
 	defer ms.keysLock.Unlock()
 
+	// deleting a group takes its members off the censuses built from it, which for a published
+	// process means wiping a live electorate. That is too destructive to happen as a side effect of
+	// a metadata operation, so refuse and let the caller remove members explicitly instead.
+	inUse, err := ms.publishedProcessesUsingCensuses(ctx, group.CensusIDs)
+	if err != nil {
+		return err
+	}
+	if len(inUse) > 0 {
+		return &CensusInUseByPublishedProcessError{ProcessIDs: inUse}
+	}
+
 	// delete the group from the database
 	filter := bson.M{"_id": objID, "orgAddress": orgAddress}
 	if _, err := ms.orgMemberGroups.DeleteOne(ctx, filter); err != nil {
@@ -314,6 +337,89 @@ func (ms *MongoStorage) DeleteOrganizationMemberGroup(groupID string, orgAddress
 	// the censuses built from this group outlive it, so deleting the group must also take its
 	// members off them — otherwise a group can be deleted while its electorate keeps voting.
 	return ms.purgeMembersFromGroupCensuses(ctx, group, group.MemberIDs)
+}
+
+// publishedProcessesUsingCensuses returns the ids of the published processes voting on any of the
+// given censuses. Empty means the censuses are only backing drafts, or nothing at all.
+func (ms *MongoStorage) publishedProcessesUsingCensuses(
+	ctx context.Context, censusIDs []string,
+) ([]string, error) {
+	if len(censusIDs) == 0 {
+		return nil, nil
+	}
+	censusOIDs := make([]primitive.ObjectID, 0, len(censusIDs))
+	for _, id := range censusIDs {
+		oid, err := primitive.ObjectIDFromHex(id)
+		if err != nil {
+			log.Warnw("skipping undecodable census id on a group", "censusId", id)
+			continue
+		}
+		censusOIDs = append(censusOIDs, oid)
+	}
+	if len(censusOIDs) == 0 {
+		return nil, nil
+	}
+	raw, err := ms.votingProcesses.Distinct(ctx, "_id", bson.M{
+		"censusId":  bson.M{"$in": censusOIDs},
+		"published": true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve published processes of the group censuses: %w", err)
+	}
+	processIDs := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if oid, ok := v.(primitive.ObjectID); ok {
+			processIDs = append(processIDs, oid.Hex())
+		}
+	}
+	return processIDs, nil
+}
+
+// membersWhoVotedGroupCensuses returns which of the given members have already cast a ballot in any
+// election of the processes voting on the group's censuses.
+func (ms *MongoStorage) membersWhoVotedGroupCensuses(
+	ctx context.Context, censusIDs, memberIDs []string,
+) ([]string, error) {
+	processIDs, err := ms.publishedProcessesUsingCensuses(ctx, censusIDs)
+	if err != nil {
+		return nil, err
+	}
+	if len(processIDs) == 0 {
+		return nil, nil
+	}
+	oids := make([]primitive.ObjectID, 0, len(processIDs))
+	for _, id := range processIDs {
+		if oid, err := primitive.ObjectIDFromHex(id); err == nil {
+			oids = append(oids, oid)
+		}
+	}
+	cur, err := ms.processesQuestions.Find(ctx,
+		bson.M{"processId": bson.M{"$in": oids}, "upstreamId": bson.M{"$exists": true}},
+		options.Find().SetProjection(bson.M{"upstreamId": 1}))
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve the questions of the group censuses: %w", err)
+	}
+	defer func() { _ = cur.Close(ctx) }()
+	var questions []VotingProcessQuestion
+	if err := cur.All(ctx, &questions); err != nil {
+		return nil, fmt.Errorf("failed to decode questions: %w", err)
+	}
+	elections := make([]internal.HexBytes, 0, len(questions))
+	for i := range questions {
+		elections = append(elections, questions[i].UpstreamID)
+	}
+	voted, err := ms.MembersWithUsedCSPProcesses(elections, memberIDs)
+	if err != nil {
+		return nil, err
+	}
+	// keep the caller's order so the reported ids are stable
+	blocked := make([]string, 0, len(voted))
+	for _, id := range memberIDs {
+		if voted[id] {
+			blocked = append(blocked, id)
+		}
+	}
+	return blocked, nil
 }
 
 // ListOrganizationMemberGroup lists all the members of an organization member group (paginated)

--- a/db/org_members_groups_test.go
+++ b/db/org_members_groups_test.go
@@ -1214,3 +1214,68 @@ func TestOrganizationMemberGroup(t *testing.T) {
 		}
 	})
 }
+
+// TestGroupCensusRevocation covers the snapshot problem: a census built from a group does not track
+// the group, so removing a member must be propagated explicitly. Additions deliberately are not —
+// growing a census bills the organization and needs an on-chain resize.
+func TestGroupCensusRevocation(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	orgAddress := common.Address{0x5a}
+	c.Assert(testDB.SetOrganization(&Organization{
+		Address: orgAddress, Active: true, CreatedAt: time.Now(),
+	}), qt.IsNil)
+
+	newMember := func(suffix string) string {
+		m := &OrgMember{
+			ID: primitive.NewObjectID(), OrgAddress: orgAddress,
+			MemberNumber: "grp" + suffix, Email: "grp" + suffix + "@example.com",
+			CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		}
+		_, err := testDB.SetOrgMember("test_salt", m)
+		c.Assert(err, qt.IsNil)
+		return m.ID.Hex()
+	}
+	stays, leaves, outsider := newMember("_a"), newMember("_b"), newMember("_c")
+
+	groupID, err := testDB.CreateOrganizationMemberGroup(&OrganizationMemberGroup{
+		OrgAddress: orgAddress, Title: "voters", MemberIDs: []string{stays, leaves},
+	})
+	c.Assert(err, qt.IsNil)
+
+	census := &Census{
+		OrgAddress: orgAddress,
+		AuthFields: OrgMemberAuthFields{OrgMemberAuthFieldsMemberNumber},
+		CreatedAt:  time.Now(), UpdatedAt: time.Now(),
+	}
+	censusID, err := testDB.SetCensus(census)
+	c.Assert(err, qt.IsNil)
+	oid, err := primitive.ObjectIDFromHex(censusID)
+	c.Assert(err, qt.IsNil)
+	census.ID = oid
+	inserted, err := testDB.PopulateGroupCensus(census, groupID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(inserted, qt.Equals, int64(2))
+
+	// removing a member from the group takes them off the census it was built from
+	c.Assert(testDB.UpdateOrganizationMemberGroup(groupID, orgAddress, "", "", nil, []string{leaves}), qt.IsNil)
+	_, err = testDB.CensusParticipant(censusID, leaves)
+	c.Assert(err, qt.Equals, ErrNotFound, qt.Commentf("a member dropped from the group must leave its census"))
+	_, err = testDB.CensusParticipant(censusID, stays)
+	c.Assert(err, qt.IsNil)
+	updated, err := testDB.Census(censusID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(updated.Size, qt.Equals, int64(1))
+
+	// adding one does NOT silently grow the census
+	c.Assert(testDB.UpdateOrganizationMemberGroup(groupID, orgAddress, "", "", []string{outsider}, nil), qt.IsNil)
+	_, err = testDB.CensusParticipant(censusID, outsider)
+	c.Assert(err, qt.Equals, ErrNotFound,
+		qt.Commentf("additions go through PUT /processes/{processId}/census, which bills and resizes"))
+
+	// deleting the group takes its remaining members off the census too
+	c.Assert(testDB.DeleteOrganizationMemberGroup(groupID, orgAddress), qt.IsNil)
+	_, err = testDB.CensusParticipant(censusID, stays)
+	c.Assert(err, qt.Equals, ErrNotFound)
+}

--- a/db/org_members_groups_test.go
+++ b/db/org_members_groups_test.go
@@ -1,11 +1,13 @@
 package db
 
 import (
+	stderrors "errors"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -1277,5 +1279,98 @@ func TestGroupCensusRevocation(t *testing.T) {
 	// deleting the group takes its remaining members off the census too
 	c.Assert(testDB.DeleteOrganizationMemberGroup(groupID, orgAddress), qt.IsNil)
 	_, err = testDB.CensusParticipant(censusID, stays)
+	c.Assert(err, qt.Equals, ErrNotFound)
+}
+
+// TestGroupCensusGuards covers the two refusals that keep group management from doubling as a way to
+// tamper with a live election: a group whose census is being voted cannot be deleted, and a member
+// who already voted cannot be removed from it.
+func TestGroupCensusGuards(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	orgAddress := common.Address{0x6b}
+	c.Assert(testDB.SetOrganization(&Organization{
+		Address: orgAddress, Active: true, CreatedAt: time.Now(),
+	}), qt.IsNil)
+
+	newMember := func(suffix string) string {
+		m := &OrgMember{
+			ID: primitive.NewObjectID(), OrgAddress: orgAddress,
+			MemberNumber: "gd" + suffix, Email: "gd" + suffix + "@example.com",
+			CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		}
+		_, err := testDB.SetOrgMember("test_salt", m)
+		c.Assert(err, qt.IsNil)
+		return m.ID.Hex()
+	}
+	voter, quiet := newMember("_v"), newMember("_q")
+
+	groupID, err := testDB.CreateOrganizationMemberGroup(&OrganizationMemberGroup{
+		OrgAddress: orgAddress, Title: "voters", MemberIDs: []string{voter, quiet},
+	})
+	c.Assert(err, qt.IsNil)
+
+	census := &Census{
+		OrgAddress: orgAddress,
+		AuthFields: OrgMemberAuthFields{OrgMemberAuthFieldsMemberNumber},
+		CreatedAt:  time.Now(), UpdatedAt: time.Now(),
+	}
+	censusID, err := testDB.SetCensus(census)
+	c.Assert(err, qt.IsNil)
+	censusOID, err := primitive.ObjectIDFromHex(censusID)
+	c.Assert(err, qt.IsNil)
+	census.ID = censusOID
+	_, err = testDB.PopulateGroupCensus(census, groupID)
+	c.Assert(err, qt.IsNil)
+
+	// a published process voting on that census, with one on-chain question
+	vpID, err := testDB.SetVotingProcess(&VotingProcess{
+		OrgAddress: orgAddress, Title: MultiLangString{"default": "P"},
+		CensusID: censusOID, Published: true,
+	})
+	c.Assert(err, qt.IsNil)
+	election := internal.HexBytes{0xbe, 0xef}
+	_, err = testDB.SetQuestion(&VotingProcessQuestion{
+		ProcessID: vpID, OrgAddress: orgAddress, Type: VotingTypeSingleChoice,
+		UpstreamID: election, Status: QuestionStatusReady,
+	})
+	c.Assert(err, qt.IsNil)
+
+	// deleting the group would wipe the electorate of a live election, so it is refused
+	err = testDB.DeleteOrganizationMemberGroup(groupID, orgAddress)
+	var inUse *CensusInUseByPublishedProcessError
+	c.Assert(stderrors.As(err, &inUse), qt.IsTrue, qt.Commentf("got %v", err))
+	c.Assert(inUse.ProcessIDs, qt.DeepEquals, []string{vpID.Hex()})
+	// and nothing was removed
+	_, err = testDB.CensusParticipant(censusID, voter)
+	c.Assert(err, qt.IsNil)
+
+	// one member votes
+	token := internal.HexBytes{0x0a, 0x0b}
+	c.Assert(testDB.SetCSPAuth(token, internal.HexBytesFromString(voter), internal.HexBytes{0x01}, "s"), qt.IsNil)
+	c.Assert(testDB.VerifyCSPAuth(token), qt.IsNil)
+	c.Assert(testDB.ConsumeCSPProcess(token, election, internal.HexBytes{0xcc}), qt.IsNil)
+
+	// removing them from the group is refused for the same reason the census endpoint refuses it,
+	// otherwise that endpoint's guard would be bypassable through group management
+	err = testDB.UpdateOrganizationMemberGroup(groupID, orgAddress, "", "", nil, []string{voter})
+	var votedErr *MembersAlreadyVotedError
+	c.Assert(stderrors.As(err, &votedErr), qt.IsTrue, qt.Commentf("got %v", err))
+	c.Assert(votedErr.MemberIDs, qt.DeepEquals, []string{voter})
+	_, err = testDB.CensusParticipant(censusID, voter)
+	c.Assert(err, qt.IsNil)
+
+	// the member who has not voted can still be removed
+	c.Assert(testDB.UpdateOrganizationMemberGroup(groupID, orgAddress, "", "", nil, []string{quiet}), qt.IsNil)
+	_, err = testDB.CensusParticipant(censusID, quiet)
+	c.Assert(err, qt.Equals, ErrNotFound)
+
+	// deleting the member outright is never blocked: the ballot is already on chain, and refusing
+	// would make erasure impossible
+	deleted, err := testDB.DeleteOrgMembers(orgAddress, []string{voter})
+	c.Assert(err, qt.IsNil)
+	c.Assert(deleted, qt.Equals, 1)
+	_, err = testDB.CensusParticipant(censusID, voter)
 	c.Assert(err, qt.Equals, ErrNotFound)
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -6168,9 +6168,10 @@ paths:
         are deleted, they are pruned from every question's eligibility subset, and their CSP
         sessions are invalidated, so a token minted while they were still in the census cannot
         be spent afterwards.
-        A member who has already voted any of the process's questions cannot be removed: the
-        request is refused with 409 and the offending ids in the error's data.votedMemberIds.
-        Their ballot is already on chain and removing them would only hide that, not undo it.
+        A member the CSP has already signed for, on any of the process's questions, cannot be
+        removed: the request is refused with 409 and the offending ids in the error's
+        data.votedMemberIds. They hold a valid signature whether or not the ballot has reached
+        the chain yet, so removing them would only hide that, not undo it.
         Nothing is sent on chain — an election's maxCensusSize can only grow, and the leftover
         headroom is harmless because the CSP, not that number, decides who may vote. Note that a
         CSP signature already handed out stays valid until the election closes; removal closes
@@ -6210,7 +6211,7 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
         "409":
-          description: Process is not published, or a member has already voted
+          description: Process is not published, or a member was already signed for
           schema:
             $ref: '#/definitions/errors.Error'
         "500":

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -6199,7 +6199,7 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
         "409":
-          description: A member has already voted
+          description: Process is not published, or a member has already voted
           schema:
             $ref: '#/definitions/errors.Error'
         "500":

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1400,6 +1400,11 @@ definitions:
         format: hex
         type: string
     type: object
+  apicommon.RemoveProcessCensusResponse:
+    properties:
+      removed:
+        type: integer
+    type: object
   apicommon.SetProcessStatusRequest:
     properties:
       status:
@@ -6146,6 +6151,66 @@ paths:
       tags:
       - processes
   /processes/{processId}/census:
+    delete:
+      consumes:
+      - application/json
+      description: |-
+        Take organization members off the census of an already-published voting process, so
+        they can no longer authenticate or be signed for by the CSP. Their participant rows
+        are deleted, they are pruned from every question's eligibility subset, and their CSP
+        sessions are invalidated, so a token minted while they were still in the census cannot
+        be spent afterwards.
+        A member who has already voted any of the process's questions cannot be removed: the
+        request is refused with 409 and the offending ids in the error's data.votedMemberIds.
+        Their ballot is already on chain and removing them would only hide that, not undo it.
+        Nothing is sent on chain — an election's maxCensusSize can only grow, and the leftover
+        headroom is harmless because the CSP, not that number, decides who may vote. Note that a
+        CSP signature already handed out stays valid until the election closes; removal closes
+        the door on new signatures, it cannot recall one. Requires Manager/Admin role.
+      parameters:
+      - description: Process ID
+        in: path
+        name: processId
+        required: true
+        type: string
+      - description: Member IDs to remove
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/apicommon.AddCensusParticipantsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Members removed
+          schema:
+            $ref: '#/definitions/apicommon.RemoveProcessCensusResponse'
+        "400":
+          description: Invalid input data
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "404":
+          description: Process not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "409":
+          description: A member has already voted
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+      security:
+      - BearerAuth: []
+      summary: Remove members from a published process's census
+      tags:
+      - processes
     put:
       consumes:
       - application/json

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1400,6 +1400,14 @@ definitions:
         format: hex
         type: string
     type: object
+  apicommon.RemoveCensusParticipantsRequest:
+    properties:
+      memberIds:
+        description: Member ids to remove from the census
+        items:
+          type: string
+        type: array
+    type: object
   apicommon.RemoveProcessCensusResponse:
     properties:
       removed:
@@ -6166,7 +6174,10 @@ paths:
         Nothing is sent on chain — an election's maxCensusSize can only grow, and the leftover
         headroom is harmless because the CSP, not that number, decides who may vote. Note that a
         CSP signature already handed out stays valid until the election closes; removal closes
-        the door on new signatures, it cannot recall one. Requires Manager/Admin role.
+        the door on new signatures, it cannot recall one.
+        Removal invalidates the member's CSP sessions across every process, not just this one,
+        so they will have to authenticate again elsewhere. Note also that this request carries a
+        body, which some proxies and HTTP clients drop on DELETE. Requires Manager/Admin role.
       parameters:
       - description: Process ID
         in: path
@@ -6178,7 +6189,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/apicommon.AddCensusParticipantsRequest'
+          $ref: '#/definitions/apicommon.RemoveCensusParticipantsRequest'
       produces:
       - application/json
       responses:

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -108,7 +108,10 @@ var (
 	ErrAPIKeyNotFound                         = Error{Code: 40160, HTTPstatus: http.StatusNotFound, Err: fmt.Errorf("API key not found")}
 	ErrManagedOrgHasActiveElections           = Error{Code: 40161, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("managed organization has active elections and cannot be deleted")}
 	ErrVotingTypeNotAllowed                   = Error{Code: 40163, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("voting type not allowed by the subscription plan")}
-	ErrCensusMemberAlreadyVoted               = Error{Code: 40169, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("members that already voted cannot be removed from the census")}
+	// 40164-40167 are claimed by the open batch-vote-relay PR and 40168 by the open per-question
+	// eligibility PR, so this range continues past them rather than filling what looks like a gap.
+	ErrCensusMemberAlreadyVoted   = Error{Code: 40169, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("members that already voted cannot lose eligibility")}
+	ErrCensusInUseByPublishedProc = Error{Code: 40170, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("census is in use by a published process")}
 
 	// CSP errors (408)
 	ErrZeroWeightVoter = Error{Code: 40801, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("voter weight cannot be zero")}

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -108,6 +108,7 @@ var (
 	ErrAPIKeyNotFound                         = Error{Code: 40160, HTTPstatus: http.StatusNotFound, Err: fmt.Errorf("API key not found")}
 	ErrManagedOrgHasActiveElections           = Error{Code: 40161, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("managed organization has active elections and cannot be deleted")}
 	ErrVotingTypeNotAllowed                   = Error{Code: 40163, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("voting type not allowed by the subscription plan")}
+	ErrCensusMemberAlreadyVoted               = Error{Code: 40169, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("members that already voted cannot be removed from the census")}
 
 	// CSP errors (408)
 	ErrZeroWeightVoter = Error{Code: 40801, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("voter weight cannot be zero")}

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -110,7 +110,9 @@ var (
 	ErrVotingTypeNotAllowed                   = Error{Code: 40163, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("voting type not allowed by the subscription plan")}
 	// 40164-40167 are claimed by the open batch-vote-relay PR and 40168 by the open per-question
 	// eligibility PR, so this range continues past them rather than filling what looks like a gap.
-	ErrCensusMemberAlreadyVoted   = Error{Code: 40169, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("members that already voted cannot lose eligibility")}
+	// "signed for" rather than "voted": the flag behind this is set when the CSP issues the
+	// signature, not when the ballot reaches the chain, so it can name a member who never submitted.
+	ErrCensusMemberAlreadyVoted   = Error{Code: 40169, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("members already signed for cannot lose eligibility")}
 	ErrCensusInUseByPublishedProc = Error{Code: 40170, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("census is in use by a published process")}
 
 	// CSP errors (408)

--- a/migrations/0018_census_revocation_indexes.go
+++ b/migrations/0018_census_revocation_indexes.go
@@ -1,0 +1,46 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func init() {
+	AddMigration(18, "census_revocation_indexes", upCensusRevocationIndexes, downCensusRevocationIndexes)
+}
+
+// upCensusRevocationIndexes indexes the two lookups that census revocation introduced, both of
+// which are collection scans without them:
+//
+//   - cspTokens.userid — revoking a member deletes their auth tokens by user id, and this
+//     collection had no index at all, so every removal scanned every token ever issued.
+//   - processesQuestions.eligibleMemberIds — deleting a member prunes them from every question's
+//     eligibility subset, which is an unscoped update across the whole collection. Multikey, since
+//     the field is an array.
+func upCensusRevocationIndexes(ctx context.Context, database *mongo.Database) error {
+	if _, err := database.Collection("cspTokens").Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{{Key: "userid", Value: 1}},
+	}); err != nil {
+		return fmt.Errorf("failed to create index on userid for cspTokens: %w", err)
+	}
+	if _, err := database.Collection("processesQuestions").Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{{Key: "eligibleMemberIds", Value: 1}},
+	}); err != nil {
+		return fmt.Errorf("failed to create index on eligibleMemberIds for processesQuestions: %w", err)
+	}
+	return nil
+}
+
+func downCensusRevocationIndexes(ctx context.Context, database *mongo.Database) error {
+	// indexes only, so dropping them is safe and loses no data
+	if _, err := database.Collection("cspTokens").Indexes().DropOne(ctx, "userid_1"); err != nil {
+		return fmt.Errorf("failed to drop index on userid for cspTokens: %w", err)
+	}
+	if _, err := database.Collection("processesQuestions").Indexes().DropOne(ctx, "eligibleMemberIds_1"); err != nil {
+		return fmt.Errorf("failed to drop index on eligibleMemberIds for processesQuestions: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Audit of CSP census management during published processes, and the fixes for what it found.

## What was broken

Removing a voter from a live election mostly did not work:

| Action on a live process | Authenticated? | Got a CSP signature? |
|---|---|---|
| Deleted from the member base | No | No — but only incidentally, via the `OrgMember` lookup that exists to read `Weight` |
| **Removed from a group** | **Yes** | **Yes** |
| Removed from question eligibility | Yes | No, for that question |

Two causes:

1. **A census is a snapshot.** `PopulateGroupCensus` materializes `censusParticipants` once and
   nothing re-derives it, so group edits never reach it. `DeleteOrgMembers` cascaded **only** to
   `orgMemberGroups.memberIds` — census participants, CSP tokens and `eligibleMemberIds` were all
   left behind. `DelCensusParticipant` existed with no caller, and no endpoint removed a participant.
2. **`ProcessSignHandler` never re-checked census participation.** It loaded the census only to read
   `Weighted`, one call away from the `CensusParticipant` lookup `ProcessCheckHandler` already makes.
   A token minted while the voter was eligible kept signing indefinitely.

Plus **no election-state gate anywhere in the CSP**: auth and sign both succeeded against drafts,
paused and ended processes, and before the start date.

## What this changes

**Sign re-checks the census**, in the `/processes` flow and in the legacy bundle flow. The same check
sat commented out in the bundle handler since the commit that removed member-number dependencies
from `auth/0` and `/sign` — `git log -S` shows it was disabled because it used a *member-number*
lookup, not because participation should go unchecked. A member-id accessor exists now, so it is
restored correctly rather than left as a fossil.

**Auth refuses unpublished processes; sign refuses questions that are not READY, or whose process
has not started.** The CSP is the only place that can refuse — the signature it hands out has no
expiry, so otherwise a voter can bank one against a paused or not-yet-open election and spend it
when the chain opens. Only the start date is checked: publish always persists one, while `EndDate`
is optional.

**Member deletion and group removal now cascade** to the censuses involved: participant rows,
question eligibility and CSP sessions go, and the census size is recounted.

**`DELETE /processes/{processId}/census`** (new, Manager/Admin) is the explicit removal path, so
revoking someone no longer requires deleting the member outright. It refuses anyone who has already
voted, with the ids in `data.votedMemberIds` (code `40169`).

**Group additions deliberately do not propagate.** Growing a census consumes plan quota and needs an
on-chain `maxCensusSize` bump — that is what `PUT /processes/{processId}/census` is for, and doing it
implicitly from an unrelated group edit would silently bill the organization and submit
transactions. Removals are safe and are what revocation needs.

## Two traps this was careful about

**Consumption rows are never deleted.** `ConsumeCSPProcess` pins the single address a member was ever
signed for. Delete that row and a removed-then-re-added member could be signed for a *second*
address → a second nullifier → **a double vote the chain would accept**. The cascade drops auth
tokens and participants; `cspTokensStatus` stays forever. There is an explicit test asserting the row
survives a member deletion.

**`maxCensusSize` is never shrunk on chain.** The chain accepts an increase only. Now that a census
can shrink for the first time, `enqueueCensusSizeUpdate` — which submitted `census.Size` blindly —
would eventually submit a value below the election's current size and fail the job. It now reads the
election and enqueues only on a genuine increase.

## The ceiling, stated plainly

**None of this can recall a signature already issued.** The chain verifier
(`cspproof.go`) checks only that the bundle address matches the tx signer, the process id matches,
and the signature recovers to the salted CSP key — no timestamp, no nonce, no revocation list — and
the relay endpoints are unauthenticated structural validators. Revocation closes the door on *new*
signatures; a voter already holding one still votes. `TestProcessCSPRevocation` asserts exactly that
rather than pretending the hole is closed, so the guarantee is not oversold to whoever reads the
tests next.

Related, and **not** addressed here (you scoped it out): verified CSP tokens have no TTL, no expiry
index and `VerifiedAt` is written but never read, so an abandoned session is resumable indefinitely.
`DeleteCSPAuthByBundle` also walks `ProcessBundlesByOrg` only, so `/processes` tokens survive even a
full organization teardown. Worth a follow-up.

## Verification

- `go build ./...`, `go vet` clean; `golangci-lint` v2.12.2 **0 issues**; `check-qt-patterns.sh` clean; `make swagger` regenerated.
- Full `go test ./db/` passes.
- Full `go test ./api/` passes except `TestVotingProcessStalePublishReclaim`, which is a
  **pre-existing flake on `main`**, unrelated to this branch: `ClaimVotingProcessForPublish` returns
  `res.ModifiedCount == 1`, but a reclaim landing in the same millisecond as the original claim
  writes an identical `publishing` timestamp, so Mongo reports `MatchedCount=1, ModifiedCount=0` and
  the claim is wrongly reported lost. Verified non-deterministic here (1 pass / 2 fails in three
  consecutive runs) and reproducible on `main`. One-line fix, kept out of this PR.

New tests:
- `TestProcessCSPRevocation` — a member authenticates, is removed, and is refused at `/sign`; a
  second member has the participant row deleted underneath a live token (what a group edit does) and
  is refused with 404, proving the sign-time re-check itself; a third signs first, is then refused
  removal with `data.votedMemberIds`, and their existing signature still produces an accepted vote.
- `TestRemoveProcessCensus` — the new endpoint, incl. drafts rejected, empty no-op, size shrink,
  the election's `MaxCensusSize` **unchanged**, and the removed member unable to authenticate.
- `TestPurgeMembersFromCensuses` — the deletion cascade, with an explicit assertion that the
  consumption row survives.
- `TestGroupCensusRevocation` — group removal propagates, group addition does not, group deletion
  clears the census.
