### PR TITLE
fix(processes): stop concurrent draft updates from duplicating questions

### DIFF
--- a/api/apicommon/voting_processes.go
+++ b/api/apicommon/voting_processes.go
@@ -38,6 +38,11 @@ type EligibilitySpec struct {
 	MemberIDs []string `json:"memberIds,omitempty"`
 }
 
+// UpdatedAtLayout is the wire format of the conditional-update token carried by
+// VotingProcessResponse.UpdatedAt and CreateVotingProcessRequest.UpdatedAt: RFC3339 with the
+// millisecond precision mongo stores, so a value read and echoed back compares equal.
+const UpdatedAtLayout = "2006-01-02T15:04:05.000Z"
+
 // VotingProcessQuestionRequest is one question in a create/update request.
 type VotingProcessQuestionRequest struct {
 	Title             db.MultiLangString   `json:"title"`
@@ -63,6 +68,11 @@ type CreateVotingProcessRequest struct {
 	StartDate   string                         `json:"startDate,omitempty"`
 	EndDate     string                         `json:"endDate,omitempty"`
 	Questions   []VotingProcessQuestionRequest `json:"questions"`
+	// UpdatedAt, on a PUT, is the updatedAt the client last read. The update then applies only if
+	// the process has not been written since, and is rejected with 409 otherwise, so two clients
+	// editing the same draft cannot silently overwrite each other. Optional: omitting it keeps the
+	// unconditional last-writer-wins behaviour. Ignored on POST.
+	UpdatedAt string `json:"updatedAt,omitempty"`
 }
 
 // ValidateProcessCensusRequest is the body of POST /processes/census/validation: the same
@@ -104,6 +114,10 @@ type VotingProcessResponse struct {
 	// ChainID is the Vochain chain id votes must be signed against; clients need it because vote
 	// signatures are chain-id-bound (a mismatch makes the on-chain signer recovery diverge).
 	ChainID string `json:"chainId,omitempty"`
+	// UpdatedAt is the process's last-write timestamp, in millisecond precision. Echo it back in a
+	// PUT to make the update conditional on nothing else having written in between (see
+	// CreateVotingProcessRequest.UpdatedAt).
+	UpdatedAt string `json:"updatedAt,omitempty"`
 }
 
 // VotingProcessListResponse is the paginated list of voting processes.
@@ -251,6 +265,11 @@ func VotingProcessResponseFromDB(
 	}
 	if !vp.EndDate.IsZero() {
 		resp.EndDate = vp.EndDate.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	if !vp.UpdatedAt.IsZero() {
+		// millisecond precision, because that is what mongo stores: a coarser format would never
+		// match the stored value when echoed back as a conditional-update token
+		resp.UpdatedAt = vp.UpdatedAt.UTC().Format(UpdatedAtLayout)
 	}
 	if census != nil {
 		resp.Census = CensusSpec{

--- a/api/processes.go
+++ b/api/processes.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -185,27 +186,14 @@ func (a *API) buildQuestions(
 	return built, nil
 }
 
-// writeQuestions replaces the process's stored questions with a pre-built (already validated)
-// set and updates its ordered QuestionIDs. Existing questions are removed first so a draft
-// update replaces them. Callers run buildQuestions first, so this only fails on infra errors.
+// writeQuestions replaces the process's stored questions with a pre-built (already validated) set
+// and records their ids on the process. The replacement is per slot rather than delete-all then
+// insert-all, so two overlapping draft updates cannot strand a row — see db.SetProcessQuestions.
+// Callers run buildQuestions first, so this only fails on infra errors.
 func (a *API) writeQuestions(vp *db.VotingProcess, built []*db.VotingProcessQuestion) error {
-	existing, err := a.db.QuestionsByProcess(vp.ID)
+	questionIDs, err := a.db.SetProcessQuestions(vp.ID, built)
 	if err != nil {
-		return fmt.Errorf("failed to load existing questions: %w", err)
-	}
-	for i := range existing {
-		if err := a.db.DeleteQuestion(existing[i].ID); err != nil {
-			return fmt.Errorf("failed to remove existing question: %w", err)
-		}
-	}
-	questionIDs := make([]primitive.ObjectID, 0, len(built))
-	for _, question := range built {
-		question.ProcessID = vp.ID
-		qID, err := a.db.SetQuestion(question)
-		if err != nil {
-			return fmt.Errorf("failed to store question: %w", err)
-		}
-		questionIDs = append(questionIDs, qID)
+		return fmt.Errorf("failed to store questions: %w", err)
 	}
 	vp.QuestionIDs = questionIDs
 	if _, err := a.db.SetVotingProcess(vp); err != nil {
@@ -214,10 +202,38 @@ func (a *API) writeQuestions(vp *db.VotingProcess, built []*db.VotingProcessQues
 	return nil
 }
 
+// parseUpdatedAt reads the optional conditional-update token of an update request. The zero time
+// means the client sent none and opts out of the check.
+func parseUpdatedAt(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid updatedAt %q: expected RFC3339 as returned by the read endpoint", s)
+	}
+	return t.UTC(), nil
+}
+
+// storeUpdatedProcess persists a draft edit, conditionally on seen when the client sent an
+// updatedAt token. It reports db.ErrConflict when someone else wrote the process in between.
+func (a *API) storeUpdatedProcess(vp *db.VotingProcess, seen time.Time) error {
+	if seen.IsZero() {
+		if _, err := a.db.SetVotingProcess(vp); err != nil {
+			return fmt.Errorf("failed to update voting process: %w", err)
+		}
+		return nil
+	}
+	return a.db.SetVotingProcessIfUnchanged(vp, seen)
+}
+
 // updateVotingProcessHandler godoc
 //
 //	@Summary		Update a voting process draft
 //	@Description	Update a voting process while it is still a draft (not published). 409 if already published.
+//	@Description	Send the updatedAt read from GET /processes/{processId} to make the update conditional: it is
+//	@Description	rejected with 409 (40171) if anything wrote the process in between, so two editors cannot
+//	@Description	overwrite each other. Omitting updatedAt opts out of that guarantee and keeps last-writer-wins.
 //	@Tags			processes
 //	@Accept			json
 //	@Produce		json
@@ -282,10 +298,21 @@ func (a *API) updateVotingProcessHandler(w http.ResponseWriter, r *http.Request)
 		writeSubscriptionError(w, err)
 		return
 	}
+	seen, err := parseUpdatedAt(req.UpdatedAt)
+	if err != nil {
+		_ = a.db.DelCensus(census.ID.Hex())
+		errors.ErrMalformedBody.WithErr(err).Write(w)
+		return
+	}
 	vp.Title, vp.Description, vp.Header, vp.StreamURI = req.Title, req.Description, req.Header, req.StreamURI
 	vp.StartDate, vp.EndDate, vp.CensusID = start, end, census.ID
-	if _, err := a.db.SetVotingProcess(vp); err != nil {
+	if err := a.storeUpdatedProcess(vp, seen); err != nil {
 		_ = a.db.DelCensus(census.ID.Hex())
+		if stderrors.Is(err, db.ErrConflict) {
+			errors.ErrStaleUpdate.Withf("the process was modified after updatedAt %s; refetch and retry",
+				req.UpdatedAt).Write(w)
+			return
+		}
 		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
 		return
 	}
@@ -878,7 +905,38 @@ func validateVotingProcessForPublish(
 			problems = append(problems, fmt.Sprintf("question %d has an unsupported type %q", i, q.Type))
 		}
 	}
+	if p := questionSetProblem(vp, questions); p != "" {
+		problems = append(problems, p)
+	}
 	return problems
+}
+
+// questionSetProblem reports a stored question set that does not match the ids the process itself
+// records. That means a row carrying this processId is not one of the questions the last writer
+// stored — a leftover from a pre-fix concurrent draft update, or a direct database write. Publishing
+// such a process is the one irreversible step in the whole flow (the stray becomes a real on-chain
+// election that cannot be withdrawn), so it is refused and the draft has to be saved again first.
+// Processes predating QuestionIDs carry none and are not checked.
+func questionSetProblem(vp *db.VotingProcess, questions []db.VotingProcessQuestion) string {
+	if len(vp.QuestionIDs) == 0 {
+		return ""
+	}
+	expected := make(map[primitive.ObjectID]bool, len(vp.QuestionIDs))
+	for _, id := range vp.QuestionIDs {
+		expected[id] = true
+	}
+	stray := 0
+	for i := range questions {
+		if !expected[questions[i].ID] {
+			stray++
+		}
+	}
+	if stray == 0 && len(questions) == len(vp.QuestionIDs) {
+		return ""
+	}
+	return fmt.Sprintf(
+		"stored questions do not match the process (%d found, %d expected, %d unknown): save the draft again",
+		len(questions), len(vp.QuestionIDs), stray)
 }
 
 // writeSubscriptionError writes a typed API error verbatim, falling back to 500.

--- a/api/processes.go
+++ b/api/processes.go
@@ -190,13 +190,17 @@ func (a *API) buildQuestions(
 // and records their ids on the process. The replacement is per slot rather than delete-all then
 // insert-all, so two overlapping draft updates cannot strand a row — see db.SetProcessQuestions.
 // Callers run buildQuestions first, so this only fails on infra errors.
+//
+// The ids are stored through a targeted update rather than a whole-document write: this runs right
+// after a conditional update may have forced updatedAt forward, and re-stamping the document with a
+// fresh time.Now() could push that token back to a value a client already spent.
 func (a *API) writeQuestions(vp *db.VotingProcess, built []*db.VotingProcessQuestion) error {
 	questionIDs, err := a.db.SetProcessQuestions(vp.ID, built)
 	if err != nil {
 		return fmt.Errorf("failed to store questions: %w", err)
 	}
 	vp.QuestionIDs = questionIDs
-	if _, err := a.db.SetVotingProcess(vp); err != nil {
+	if err := a.db.SetVotingProcessQuestionIDs(vp.ID, questionIDs); err != nil {
 		return fmt.Errorf("failed to update process questions: %w", err)
 	}
 	return nil

--- a/api/processes.go
+++ b/api/processes.go
@@ -208,13 +208,22 @@ func (a *API) writeQuestions(vp *db.VotingProcess, built []*db.VotingProcessQues
 
 // parseUpdatedAt reads the optional conditional-update token of an update request. The zero time
 // means the client sent none and opts out of the check.
+//
+// It parses with apicommon.UpdatedAtLayout first — the exact shape the read endpoint emits, so the
+// round-trip of a value the client just read goes through the layout that documents itself as the
+// wire format — and falls back to RFC3339 for a client sending a different sub-second precision or a
+// non-Z offset.
 func parseUpdatedAt(s string) (time.Time, error) {
 	if s == "" {
 		return time.Time{}, nil
 	}
-	t, err := time.Parse(time.RFC3339, s)
+	t, err := time.Parse(apicommon.UpdatedAtLayout, s)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("invalid updatedAt %q: expected RFC3339 as returned by the read endpoint", s)
+		if t, err = time.Parse(time.RFC3339, s); err != nil {
+			return time.Time{}, fmt.Errorf(
+				"invalid updatedAt %q: expected %s (or RFC3339) as returned by the read endpoint",
+				s, apicommon.UpdatedAtLayout)
+		}
 	}
 	return t.UTC(), nil
 }

--- a/api/processes.go
+++ b/api/processes.go
@@ -541,7 +541,9 @@ func (a *API) validateVotingProcessHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	census, _ := a.db.Census(vp.CensusID.Hex())
-	problems := a.publishPreflightProblems(vp, questions, census, user)
+	// the dry-run reports every problem the same way: a mismatched question set is just one more
+	// entry in errors, so the mismatch flag publish acts on is irrelevant here.
+	problems, _ := a.publishPreflightProblems(vp, questions, census, user)
 	apicommon.HTTPWriteJSON(w, &apicommon.VotingProcessValidateResponse{
 		Valid:  len(problems) == 0,
 		Errors: problems,
@@ -888,8 +890,9 @@ func (a *API) loadVotingProcess(w http.ResponseWriter, oid primitive.ObjectID) (
 	return vp, true
 }
 
-// validateVotingProcessForPublish returns the list of reasons a process cannot be published
-// (empty when it is ready). Used by GET .../check and by publish.
+// validateVotingProcessForPublish returns the structural reasons a process cannot be published
+// (empty when it is ready). The stored-question-set check lives in publishPreflightProblems instead,
+// which needs to tell that one apart from the rest to answer publish with a 409.
 func validateVotingProcessForPublish(
 	vp *db.VotingProcess, questions []db.VotingProcessQuestion, census *db.Census,
 ) []string {
@@ -917,9 +920,6 @@ func validateVotingProcessForPublish(
 		if q.BallotProtocol == nil && q.Type != db.VotingTypeSingleChoice && q.Type != db.VotingTypeMultiChoice {
 			problems = append(problems, fmt.Sprintf("question %d has an unsupported type %q", i, q.Type))
 		}
-	}
-	if p := questionSetProblem(vp, questions); p != "" {
-		problems = append(problems, p)
 	}
 	return problems
 }

--- a/api/processes_publish.go
+++ b/api/processes_publish.go
@@ -82,17 +82,25 @@ func (a *API) reconcileStalePublishing() {
 // determined synchronously (without building/funding a tx or touching the chain): the structural
 // checks, plus the plan/quota/permission denials that would otherwise only surface asynchronously
 // as an opaque job failure. It is shared by GET .../check (reported as {valid,errors}) and by
-// publish (enforced as a 400 before enqueueing). Funding and chain submission stay async.
+// publish (enforced before enqueueing). Funding and chain submission stay async.
+//
+// questionsMismatch singles out the one problem that is not the caller's request but the server's
+// own data state — a stored question set that does not match the process. Publish answers that with
+// a 409 rather than a 400; the dry-run ignores the flag and just reports the problem.
 func (a *API) publishPreflightProblems(
 	vp *db.VotingProcess, questions []db.VotingProcessQuestion, census *db.Census, user *db.User,
-) []string {
-	problems := validateVotingProcessForPublish(vp, questions, census)
+) (problems []string, questionsMismatch bool) {
+	problems = validateVotingProcessForPublish(vp, questions, census)
+	if p := questionSetProblem(vp, questions); p != "" {
+		problems = append(problems, p)
+		questionsMismatch = true
+	}
 	if census == nil {
-		return problems // plan checks below need the census
+		return problems, questionsMismatch // plan checks below need the census
 	}
 	orgDoc, err := a.db.Organization(vp.OrgAddress)
 	if err != nil {
-		return append(problems, "organization not found")
+		return append(problems, "organization not found"), questionsMismatch
 	}
 	if !user.HasRoleFor(vp.OrgAddress, db.AdminRole) {
 		problems = append(problems, "publishing requires the admin role")
@@ -118,7 +126,7 @@ func (a *API) publishPreflightProblems(
 	// the checks below but fail in the worker (electionParamsForQuestion). Reject it here.
 	if maxSize == 0 {
 		problems = append(problems, "census has no members")
-		return problems
+		return problems, questionsMismatch
 	}
 	start := vp.StartDate
 	if start.IsZero() || start.Before(time.Now()) {
@@ -149,7 +157,7 @@ func (a *API) publishPreflightProblems(
 	if err := a.subscriptions.OrgCanPublishCensus(census, notifyCount, voteCount); err != nil {
 		problems = append(problems, err.Error())
 	}
-	return problems
+	return problems, questionsMismatch
 }
 
 // publishVotingProcessHandler godoc
@@ -158,6 +166,8 @@ func (a *API) publishPreflightProblems(
 //	@Description	Publish a voting process: one on-chain election per question, submitted as a batch.
 //	@Description	Requires Admin role (or a `voting:write` key). Returns 202 with a job id; poll
 //	@Description	GET /jobs/{jobId}. Idempotent once published.
+//	@Description	409 (40172) means the stored questions do not match the process and the draft has to be
+//	@Description	saved again before it can be published.
 //	@Tags			processes
 //	@Accept			json
 //	@Produce		json
@@ -165,10 +175,10 @@ func (a *API) publishPreflightProblems(
 //	@Param			processId	path		string	true	"Process ID"
 //	@Success		202			{object}	apicommon.EnqueuedResponse
 //	@Success		200			{object}	apicommon.CreateVotingProcessResponse	"Already published"
-//	@Failure		400			{object}	errors.Error
+//	@Failure		400			{object}	errors.Error							"Not ready to publish"
 //	@Failure		401			{object}	errors.Error
 //	@Failure		404			{object}	errors.Error
-//	@Failure		409			{object}	errors.Error
+//	@Failure		409			{object}	errors.Error	"Publish in progress, or the stored questions do not match the process"
 //	@Failure		503			{object}	errors.Error
 //	@Router			/processes/{processId}/publish [post]
 func (a *API) publishVotingProcessHandler(w http.ResponseWriter, r *http.Request) {
@@ -205,10 +215,17 @@ func (a *API) publishVotingProcessHandler(w http.ResponseWriter, r *http.Request
 	}
 	// full synchronous publish-readiness gate (same as GET .../check): structural checks plus
 	// plan voting-type, census-size, process-count, duration, managed-quota and email/SMS/vote
-	// allowance. Anything predictable is a 400 here rather than an opaque async job failure;
+	// allowance. Anything predictable is rejected here rather than as an opaque async job failure;
 	// only funding and chain submission are left to the worker.
-	if problems := a.publishPreflightProblems(vp, questions, census, user); len(problems) > 0 {
-		errors.ErrMalformedBody.Withf("process is not ready to publish: %s", strings.Join(problems, "; ")).Write(w)
+	if problems, questionsMismatch := a.publishPreflightProblems(vp, questions, census, user); len(problems) > 0 {
+		// a stored question set that does not match the process is server-side state, not a bad
+		// request, so it answers 409. It wins over any other problem present: it has to be repaired
+		// (by saving the draft again) before the rest of the draft is even worth looking at.
+		apiErr := errors.ErrMalformedBody
+		if questionsMismatch {
+			apiErr = errors.ErrProcessQuestionsMismatch
+		}
+		apiErr.Withf("process is not ready to publish: %s", strings.Join(problems, "; ")).Write(w)
 		return
 	}
 

--- a/api/processes_publish_test.go
+++ b/api/processes_publish_test.go
@@ -10,7 +10,9 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/errors"
 	"github.com/vocdoni/saas-backend/internal"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 // testCreateProvisionedOrganization creates an organization with eager on-chain account
@@ -91,4 +93,65 @@ func TestVotingProcessPublish(t *testing.T) {
 
 	// re-publishing a published process is an idempotent no-op (200, not a new job)
 	requestAndAssertCode(http.StatusOK, t, http.MethodPost, token, nil, "processes", pid, "publish")
+}
+
+// TestVotingProcessPublishRejectsStrayQuestion covers the last-line guard of issue #614: a database
+// that already carries a duplicated question (written before the per-slot fix, or directly) must not
+// have it turned into a real on-chain election, which is the one step nothing can undo. Publish is
+// refused until the draft is saved again.
+func TestVotingProcessPublishRejectsStrayQuestion(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateProvisionedOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	req := newVotingProcessRequest(orgAddress, ids)
+	req.StartDate = ""
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, req, processesCreateEndpoint)
+	pid := created.ProcessID
+	oid, err := primitive.ObjectIDFromHex(pid)
+	c.Assert(err, qt.IsNil)
+
+	// reproduce the corrupted state the old write path could leave behind: a third question row
+	// carrying this processId that the process itself does not list
+	stray := &db.VotingProcessQuestion{
+		ProcessID: oid, OrgAddress: orgAddress, Order: 1,
+		Title:     db.MultiLangString{"default": "stray"},
+		Type:      db.VotingTypeSingleChoice,
+		TypeSetup: db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1},
+		Choices:   []db.Choice{{Title: db.MultiLangString{"default": "Yes"}, Value: 0}},
+	}
+	_, err = testDB.SetQuestion(stray)
+	c.Assert(err, qt.IsNil)
+
+	stored, err := testDB.QuestionsByProcess(oid)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stored, qt.HasLen, 3)
+
+	// both the dry-run validation and publish itself refuse it
+	validation := requestAndParse[apicommon.VotingProcessValidateResponse](
+		t, http.MethodGet, token, nil, "processes", pid, "validation")
+	c.Assert(validation.Valid, qt.IsFalse)
+	c.Assert(fmt.Sprint(validation.Errors), qt.Contains, "stored questions do not match the process")
+
+	requestAndAssertError(errors.ErrMalformedBody, t, http.MethodPost, token, nil, "processes", pid, "publish")
+
+	// nothing reached the chain, and the process is still a draft
+	after := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	c.Assert(after.Published, qt.IsFalse)
+	for i := range after.Questions {
+		c.Assert(after.Questions[i].UpstreamID, qt.HasLen, 0)
+	}
+
+	// saving the draft again reconciles the stored set, and publish is allowed once more
+	requestAndAssertCode(http.StatusOK, t, http.MethodPut, token, req, "processes", pid)
+	stored, err = testDB.QuestionsByProcess(oid)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stored, qt.HasLen, 2)
+	validation = requestAndParse[apicommon.VotingProcessValidateResponse](
+		t, http.MethodGet, token, nil, "processes", pid, "validation")
+	c.Assert(validation.Valid, qt.IsTrue, qt.Commentf("errors: %v", validation.Errors))
 }

--- a/api/processes_publish_test.go
+++ b/api/processes_publish_test.go
@@ -115,10 +115,11 @@ func TestVotingProcessPublishRejectsStrayQuestion(t *testing.T) {
 	oid, err := primitive.ObjectIDFromHex(pid)
 	c.Assert(err, qt.IsNil)
 
-	// reproduce the corrupted state the old write path could leave behind: a third question row
-	// carrying this processId that the process itself does not list
+	// reproduce a corrupted state that is still representable now that the unique
+	// (processId, order) index forbids same-slot duplicates: a stray tail row carrying this
+	// processId that the process itself does not list (what a token-less sweep race leaves behind)
 	stray := &db.VotingProcessQuestion{
-		ProcessID: oid, OrgAddress: orgAddress, Order: 1,
+		ProcessID: oid, OrgAddress: orgAddress, Order: 2,
 		Title:     db.MultiLangString{"default": "stray"},
 		Type:      db.VotingTypeSingleChoice,
 		TypeSetup: db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1},

--- a/api/processes_publish_test.go
+++ b/api/processes_publish_test.go
@@ -137,7 +137,8 @@ func TestVotingProcessPublishRejectsStrayQuestion(t *testing.T) {
 	c.Assert(validation.Valid, qt.IsFalse)
 	c.Assert(fmt.Sprint(validation.Errors), qt.Contains, "stored questions do not match the process")
 
-	requestAndAssertError(errors.ErrMalformedBody, t, http.MethodPost, token, nil, "processes", pid, "publish")
+	// server-side data state, not a bad request: 409 (40172), not 400
+	requestAndAssertError(errors.ErrProcessQuestionsMismatch, t, http.MethodPost, token, nil, "processes", pid, "publish")
 
 	// nothing reached the chain, and the process is still a draft
 	after := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)

--- a/api/processes_test.go
+++ b/api/processes_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -657,4 +658,111 @@ func TestVotingProcessStalePublishReclaim(t *testing.T) {
 	won, err = testDB.ClaimVotingProcessForPublish(oid)
 	c.Assert(err, qt.IsNil)
 	c.Assert(won, qt.IsTrue, qt.Commentf("a stale marker must be reclaimable"))
+}
+
+// TestVotingProcessConcurrentUpdates is the regression test for issue #614: two overlapping draft
+// updates left a question stranded, and publish then turned the orphan into a real on-chain
+// election. The old write path deleted every question and re-inserted with fresh ids, so an
+// interleaved pair of writers could delete rows the other had not inserted yet.
+func TestVotingProcessConcurrentUpdates(t *testing.T) {
+	c := qt.New(t)
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, adminToken, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, adminToken, newVotingProcessRequest(orgAddress, ids), processesCreateEndpoint)
+	pid := created.ProcessID
+
+	before := requestAndParse[apicommon.VotingProcessResponse](
+		t, http.MethodGet, adminToken, nil, "processes", pid)
+	c.Assert(before.Questions, qt.HasLen, 2)
+
+	// fire overlapping updates the way the wizard did: an auto-save on blur racing the submit. Each
+	// request is a complete, valid draft; whichever lands last is the one that should survive.
+	const writers = 6
+	var wg sync.WaitGroup
+	for i := range writers {
+		wg.Go(func() {
+			req := newVotingProcessRequest(orgAddress, ids)
+			req.Title = db.MultiLangString{"default": fmt.Sprintf("concurrent update %d", i)}
+			// tolerate whatever status the race produces; the assertion is on the stored state
+			_, _ = testRequest(t, http.MethodPut, adminToken, req, "processes", pid)
+		})
+	}
+	wg.Wait()
+
+	after := requestAndParse[apicommon.VotingProcessResponse](
+		t, http.MethodGet, adminToken, nil, "processes", pid)
+	c.Assert(after.Questions, qt.HasLen, 2,
+		qt.Commentf("concurrent updates must not leave a stranded question: %d found", len(after.Questions)))
+
+	// the surviving pair is one slot each, in order, with distinct ids reused from the original draft
+	c.Assert(after.Questions[0].Type, qt.Equals, db.VotingTypeSingleChoice)
+	c.Assert(after.Questions[1].Type, qt.Equals, db.VotingTypeMultiChoice)
+	c.Assert(after.Questions[0].ID, qt.Not(qt.Equals), after.Questions[1].ID)
+	c.Assert(after.Questions[0].ID, qt.Equals, before.Questions[0].ID,
+		qt.Commentf("question ids must survive a draft edit"))
+	c.Assert(after.Questions[1].ID, qt.Equals, before.Questions[1].ID)
+}
+
+// TestVotingProcessConditionalUpdate covers the optimistic-concurrency token of PUT /processes/{id}:
+// an update carrying the updatedAt the client read applies, the same token replayed after that write
+// is stale and rejected with 409, and an update with no token keeps working unconditionally.
+func TestVotingProcessConditionalUpdate(t *testing.T) {
+	c := qt.New(t)
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, adminToken, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, adminToken, newVotingProcessRequest(orgAddress, ids), processesCreateEndpoint)
+	pid := created.ProcessID
+
+	read := requestAndParse[apicommon.VotingProcessResponse](
+		t, http.MethodGet, adminToken, nil, "processes", pid)
+	c.Assert(read.UpdatedAt, qt.Not(qt.Equals), "")
+	seen := read.UpdatedAt
+
+	// the token the client just read still matches: the update applies
+	req := newVotingProcessRequest(orgAddress, ids)
+	req.Title = db.MultiLangString{"default": "conditional edit"}
+	req.UpdatedAt = seen
+	requestAndAssertCode(http.StatusOK, t, http.MethodPut, adminToken, req, "processes", pid)
+
+	refetched := requestAndParse[apicommon.VotingProcessResponse](
+		t, http.MethodGet, adminToken, nil, "processes", pid)
+	c.Assert(refetched.Title["default"], qt.Equals, "conditional edit")
+	c.Assert(refetched.UpdatedAt, qt.Not(qt.Equals), seen)
+
+	// replaying the now-stale token is refused rather than overwriting the newer state
+	stale := newVotingProcessRequest(orgAddress, ids)
+	stale.Title = db.MultiLangString{"default": "should not land"}
+	stale.UpdatedAt = seen
+	requestAndAssertError(errors.ErrStaleUpdate, t, http.MethodPut, adminToken, stale, "processes", pid)
+
+	unchanged := requestAndParse[apicommon.VotingProcessResponse](
+		t, http.MethodGet, adminToken, nil, "processes", pid)
+	c.Assert(unchanged.Title["default"], qt.Equals, "conditional edit")
+
+	// the same request with the refreshed token succeeds
+	stale.UpdatedAt = unchanged.UpdatedAt
+	requestAndAssertCode(http.StatusOK, t, http.MethodPut, adminToken, stale, "processes", pid)
+
+	// and omitting the token keeps the previous unconditional behaviour
+	noToken := newVotingProcessRequest(orgAddress, ids)
+	noToken.Title = db.MultiLangString{"default": "unconditional"}
+	requestAndAssertCode(http.StatusOK, t, http.MethodPut, adminToken, noToken, "processes", pid)
+	final := requestAndParse[apicommon.VotingProcessResponse](
+		t, http.MethodGet, adminToken, nil, "processes", pid)
+	c.Assert(final.Title["default"], qt.Equals, "unconditional")
+
+	// a malformed token is a 400, not a silent opt-out
+	bad := newVotingProcessRequest(orgAddress, ids)
+	bad.UpdatedAt = "not-a-timestamp"
+	requestAndAssertError(errors.ErrMalformedBody, t, http.MethodPut, adminToken, bad, "processes", pid)
 }

--- a/api/processes_test.go
+++ b/api/processes_test.go
@@ -708,6 +708,58 @@ func TestVotingProcessConcurrentUpdates(t *testing.T) {
 	c.Assert(after.Questions[1].ID, qt.Equals, before.Questions[1].ID)
 }
 
+// TestVotingProcessConcurrentUpdatesVaryingLengths races draft updates of differing lengths, so the
+// writers contend over question slots that do not exist yet — the insert path
+// TestVotingProcessConcurrentUpdates never reaches, since every writer there sends the same two
+// questions. Whatever the race leaves behind, the stored set is never both inconsistent and
+// publishable: a lost row makes the process refuse to publish until the draft is saved again.
+func TestVotingProcessConcurrentUpdatesVaryingLengths(t *testing.T) {
+	c := qt.New(t)
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, adminToken, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, adminToken, newVotingProcessRequest(orgAddress, ids), processesCreateEndpoint)
+	pid := created.ProcessID
+
+	const writers = 9
+	var wg sync.WaitGroup
+	for i := range writers {
+		wg.Go(func() {
+			req := newVotingProcessRequest(orgAddress, ids)
+			// 2, 3 or 4 questions: the extra slots are inserted rather than replaced
+			for range i % 3 {
+				req.Questions = append(req.Questions, req.Questions[0])
+			}
+			req.Title = db.MultiLangString{"default": fmt.Sprintf("varying update %d", i)}
+			// tolerate whatever status the race produces; the assertions are on the stored state
+			_, _ = testRequest(t, http.MethodPut, adminToken, req, "processes", pid)
+		})
+	}
+	wg.Wait()
+
+	after := requestAndParse[apicommon.VotingProcessResponse](
+		t, http.MethodGet, adminToken, nil, "processes", pid)
+	seen := make(map[string]bool, len(after.Questions))
+	for i := range after.Questions {
+		id := after.Questions[i].ID.Hex()
+		c.Assert(seen[id], qt.IsFalse, qt.Commentf("question %s stored twice (issue #614)", id))
+		seen[id] = true
+	}
+
+	// the fail-safe property end to end: the process is never reported ready to publish while its
+	// stored question set is inconsistent, and the only tolerated problem is that inconsistency.
+	validation := requestAndParse[apicommon.VotingProcessValidateResponse](
+		t, http.MethodGet, adminToken, nil, "processes", pid, "validation")
+	if !validation.Valid {
+		c.Assert(fmt.Sprint(validation.Errors), qt.Contains, "stored questions do not match the process",
+			qt.Commentf("unexpected validation errors: %v", validation.Errors))
+	}
+}
+
 // TestVotingProcessConditionalUpdate covers the optimistic-concurrency token of PUT /processes/{id}:
 // an update carrying the updatedAt the client read applies, the same token replayed after that write
 // is stale and rejected with 409, and an update with no token keeps working unconditionally.

--- a/db/errors.go
+++ b/db/errors.go
@@ -6,6 +6,9 @@ var (
 	ErrNotFound      = fmt.Errorf("not found")
 	ErrInvalidData   = fmt.Errorf("invalid data provided")
 	ErrAlreadyExists = fmt.Errorf("already exists")
+	// ErrConflict is returned by the conditional writers when the stored document changed since
+	// the caller read it, so the write was refused rather than applied on top of someone else's.
+	ErrConflict = fmt.Errorf("document changed since it was read")
 	// ErrTokenNotFound is returned if the token is not found in the database
 	ErrTokenNotFound = fmt.Errorf("token not found")
 	// ErrPrepareDocument is returned if the update document cannot be created

--- a/db/migration_question_slots_test.go
+++ b/db/migration_question_slots_test.go
@@ -1,0 +1,136 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/migrations"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// questionSlotsMigration returns migration 0018.
+func questionSlotsMigration(c *qt.C) migrations.Migration {
+	mig, ok := migrations.AsMap()[18]
+	c.Assert(ok, qt.IsTrue)
+	return mig
+}
+
+// TestUniqueProcessQuestionSlotsMigration seeds the duplicate slots a pre-fix concurrent draft
+// update stranded (issue #614) and asserts migration 0018 repairs them under its stated policy:
+// published rows are never deleted (the keeper wins the slot, extras relocate to the tail), the
+// keeper of an unpublished slot is the row the process lists in questionIds, everything else is
+// deleted — and the unique (processId, order) index then makes the state unrepresentable.
+func TestUniqueProcessQuestionSlotsMigration(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+	ctx := context.Background()
+	mig := questionSlotsMigration(c)
+	database := testDB.DBClient.Database(testDB.database)
+
+	// the test database is migrated on init, so the unique index already exists; roll it back to
+	// the pre-migration state (plain processId index) so duplicates can be seeded at all
+	c.Assert(mig.Down(ctx, database), qt.IsNil)
+
+	org := common.Address{0x61, 0x18}
+	setupVotingProcessOrg(c, org)
+	pid, err := testDB.SetVotingProcess(&VotingProcess{OrgAddress: org, Title: MultiLangString{"default": "P"}})
+	c.Assert(err, qt.IsNil)
+	ids, err := testDB.SetProcessQuestions(pid, questionSet(org, 2, "listed"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(testDB.SetVotingProcessQuestionIDs(pid, ids), qt.IsNil)
+
+	// seed the duplicates directly, bypassing the write chokepoint that now prevents them.
+	// slot 0 gains two published extras: the older one (pubOld) must take the slot, the newer one
+	// (pubNew) must be relocated to the tail, and the listed-but-unpublished original is deleted.
+	pubOld := seedQuestionRow(c, pid, org, 0, []byte{0xaa, 0x01}, time.Now().Add(-2*time.Hour))
+	pubNew := seedQuestionRow(c, pid, org, 0, []byte{0xaa, 0x02}, time.Now().Add(-time.Hour))
+	// slot 1 gains an unpublished extra that is OLDER than the listed row: the listed row must
+	// still win the slot (listed beats oldest), and the extra is deleted
+	unlisted := seedQuestionRow(c, pid, org, 1, nil, time.Now().Add(-time.Hour))
+
+	c.Assert(mig.Up(ctx, database), qt.IsNil)
+
+	stored, err := testDB.QuestionsByProcess(pid)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stored, qt.HasLen, 3)
+	c.Assert(stored[0].Order, qt.Equals, 0)
+	c.Assert(stored[0].ID, qt.Equals, pubOld, qt.Commentf("the oldest published row must keep the slot"))
+	c.Assert(stored[1].Order, qt.Equals, 1)
+	c.Assert(stored[1].ID, qt.Equals, ids[1], qt.Commentf("the row listed in questionIds must beat an older unlisted one"))
+	c.Assert(stored[2].Order, qt.Equals, 2)
+	c.Assert(stored[2].ID, qt.Equals, pubNew, qt.Commentf("a published extra must be relocated to the tail, not deleted"))
+	for i := range stored {
+		c.Assert(stored[i].ID, qt.Not(qt.Equals), unlisted)
+		c.Assert(stored[i].ID, qt.Not(qt.Equals), ids[0], qt.Commentf("the unpublished original loses slot 0 to a published row"))
+	}
+
+	// running the migration again over the repaired state is a no-op
+	c.Assert(mig.Up(ctx, database), qt.IsNil)
+	again, err := testDB.QuestionsByProcess(pid)
+	c.Assert(err, qt.IsNil)
+	c.Assert(again, qt.DeepEquals, stored)
+
+	// the state is now unrepresentable: a direct duplicate write fails on the unique index
+	_, err = testDB.processesQuestions.InsertOne(ctx, &VotingProcessQuestion{
+		ID: primitive.NewObjectID(), ProcessID: pid, OrgAddress: org, Order: 0,
+		Type: VotingTypeSingleChoice, Title: MultiLangString{"default": "dup"},
+	})
+	c.Assert(mongo.IsDuplicateKeyError(err), qt.IsTrue,
+		qt.Commentf("expected a duplicate-key error on (processId, order), got %v", err))
+}
+
+// seedQuestionRow inserts a question row directly with a chosen creation time (the _id timestamp
+// decides which duplicate is "oldest") and, when upstreamID is set, as published.
+func seedQuestionRow(
+	c *qt.C, pid primitive.ObjectID, org common.Address, order int, upstreamID []byte, createdAt time.Time,
+) primitive.ObjectID {
+	c.Helper()
+	q := &VotingProcessQuestion{
+		ID:         primitive.NewObjectIDFromTimestamp(createdAt),
+		ProcessID:  pid,
+		OrgAddress: org,
+		Order:      order,
+		Type:       VotingTypeSingleChoice,
+		Title:      MultiLangString{"default": "stray"},
+		Choices:    []Choice{{Title: MultiLangString{"default": "Yes"}, Value: 0}},
+	}
+	if len(upstreamID) > 0 {
+		q.UpstreamID = upstreamID
+		q.Status = QuestionStatusReady
+	}
+	_, err := testDB.processesQuestions.InsertOne(context.Background(), q)
+	c.Assert(err, qt.IsNil)
+	return q.ID
+}
+
+// TestUniqueProcessQuestionSlotsMigrationDown asserts the down migration restores the plain
+// processId index and drops the unique one, so duplicates become representable again.
+func TestUniqueProcessQuestionSlotsMigrationDown(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() {
+		// restore the migrated state for the rest of the suite
+		c.Assert(questionSlotsMigration(c).Up(context.Background(), testDB.DBClient.Database(testDB.database)), qt.IsNil)
+		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+	})
+	ctx := context.Background()
+	mig := questionSlotsMigration(c)
+	database := testDB.DBClient.Database(testDB.database)
+
+	c.Assert(mig.Down(ctx, database), qt.IsNil)
+
+	cursor, err := testDB.processesQuestions.Indexes().List(ctx)
+	c.Assert(err, qt.IsNil)
+	var indexes []bson.M
+	c.Assert(cursor.All(ctx, &indexes), qt.IsNil)
+	names := make([]string, 0, len(indexes))
+	for _, idx := range indexes {
+		names = append(names, idx["name"].(string))
+	}
+	c.Assert(names, qt.Contains, "processId_1")
+	c.Assert(names, qt.Not(qt.Contains), "processId_1_order_1")
+}

--- a/db/processes_questions.go
+++ b/db/processes_questions.go
@@ -54,21 +54,19 @@ func (ms *MongoStorage) SetQuestion(q *VotingProcessQuestion) (primitive.ObjectI
 //   - A slot that already holds a row is replaced atomically. The worst two writers do to it is
 //     leave it belonging to whichever wrote last, keeping the _id it already had — a state some
 //     client actually asked for.
-//   - A slot that does not exist yet is not protected. FindOneAndReplace is atomic only for a
-//     matched document, and there is no unique index on (processId, order), so two callers racing on
-//     an empty slot can both insert. Each one's sweep then deletes the other's row, leaving the slot
-//     empty and the process's QuestionIDs naming an id that no longer exists.
-//   - Either way at most one row per slot survives, so the residual failure loses a row rather than
-//     duplicating one. A row survives only if every other writer's sweep ran before that row was
-//     inserted, while each writer's own sweep always runs after its own insert; two survivors in one
-//     slot would need each writer's sweep to precede the other's, which cannot both hold.
-//     Duplication is the failure mode of issue #614, and that one is closed.
+//   - A slot that does not exist yet is protected by the unique (processId, order) index
+//     (migration 0018). Two callers racing on an empty slot cannot both insert: the loser's upsert
+//     fails with a duplicate-key error, and the retry below matches the winner's row and replaces
+//     it, preserving its _id. Duplication is the failure mode of issue #614, and it is closed both
+//     here and at the storage level.
+//   - Two token-less writers sending different lengths can still disagree about the tail: the
+//     shorter one's sweep may delete a slot the longer one just wrote, leaving the longer writer's
+//     QuestionIDs naming an id that no longer exists.
 //
-// Losing a row is fail-safe: the stored set no longer matches the process's QuestionIDs, so
-// questionSetProblem refuses the publish and saving the draft again repairs it. Closing the hole for
-// real needs a unique index on (processId, order), which is what makes each slot upsert genuinely
-// atomic. A transaction is not an option here — the repo opens no session anywhere, and the tests run
-// a standalone mongo:7.
+// That last case is fail-safe: the stored set no longer matches the process's QuestionIDs, so
+// questionSetProblem refuses the publish and saving the draft again repairs it. Closing it too
+// would take a transaction, which is not an option here — the repo opens no session anywhere, and
+// the tests run a standalone mongo:7.
 //
 // Note this is not atomic across slots either: a concurrent reader can still observe a half-applied
 // update.
@@ -94,12 +92,22 @@ func (ms *MongoStorage) SetProcessQuestions(
 		stored := struct {
 			ID primitive.ObjectID `bson:"_id"`
 		}{}
-		err := ms.processesQuestions.FindOneAndReplace(ctx, filter, doc,
-			options.FindOneAndReplace().
-				SetUpsert(true).
-				SetReturnDocument(options.After).
-				SetProjection(bson.M{"_id": 1}),
-		).Decode(&stored)
+		var err error
+		// losing the insert race on an empty slot surfaces as a duplicate-key error on the unique
+		// (processId, order) index; the retry then matches the winner's row and replaces it. More
+		// than one retry means the row keeps vanishing between attempts (a concurrent sweep), so
+		// give up after a few rather than spin.
+		for range 3 {
+			err = ms.processesQuestions.FindOneAndReplace(ctx, filter, doc,
+				options.FindOneAndReplace().
+					SetUpsert(true).
+					SetReturnDocument(options.After).
+					SetProjection(bson.M{"_id": 1}),
+			).Decode(&stored)
+			if !mongo.IsDuplicateKeyError(err) {
+				break
+			}
+		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to store question %d: %w", i, err)
 		}

--- a/db/processes_questions.go
+++ b/db/processes_questions.go
@@ -40,8 +40,7 @@ func (ms *MongoStorage) SetQuestion(q *VotingProcessQuestion) (primitive.ObjectI
 // against a second writer. Two overlapping draft updates interleave so that one deletes rows the
 // other has not inserted yet, and the stragglers survive as duplicates carrying the same processId —
 // which publish then turns into real elections (issue #614). Addressing rows by slot means neither
-// writer deletes what the other is inserting: the worst a race can do is leave slot i belonging to
-// whichever request wrote it last, which is a state some client actually asked for.
+// writer deletes what the other is inserting.
 //
 // It also keeps a question's _id stable across draft edits, since an existing row in a slot is
 // replaced rather than dropped and re-created. Publish, the status syncer and the eligibility lists
@@ -50,8 +49,29 @@ func (ms *MongoStorage) SetQuestion(q *VotingProcessQuestion) (primitive.ObjectI
 // The final sweep deletes every other row of the process, not just the tail past the new length, so
 // re-saving a draft repairs a database that a pre-fix update had already duplicated.
 //
-// Note this is not atomic across slots: a concurrent reader can still observe a half-applied update.
-// What it guarantees is that no row is ever orphaned, which is the part that reaches the chain.
+// What concurrent writers can and cannot do to a slot:
+//
+//   - A slot that already holds a row is replaced atomically. The worst two writers do to it is
+//     leave it belonging to whichever wrote last, keeping the _id it already had — a state some
+//     client actually asked for.
+//   - A slot that does not exist yet is not protected. FindOneAndReplace is atomic only for a
+//     matched document, and there is no unique index on (processId, order), so two callers racing on
+//     an empty slot can both insert. Each one's sweep then deletes the other's row, leaving the slot
+//     empty and the process's QuestionIDs naming an id that no longer exists.
+//   - Either way at most one row per slot survives, so the residual failure loses a row rather than
+//     duplicating one. A row survives only if every other writer's sweep ran before that row was
+//     inserted, while each writer's own sweep always runs after its own insert; two survivors in one
+//     slot would need each writer's sweep to precede the other's, which cannot both hold.
+//     Duplication is the failure mode of issue #614, and that one is closed.
+//
+// Losing a row is fail-safe: the stored set no longer matches the process's QuestionIDs, so
+// questionSetProblem refuses the publish and saving the draft again repairs it. Closing the hole for
+// real needs a unique index on (processId, order), which is what makes each slot upsert genuinely
+// atomic. A transaction is not an option here — the repo opens no session anywhere, and the tests run
+// a standalone mongo:7.
+//
+// Note this is not atomic across slots either: a concurrent reader can still observe a half-applied
+// update.
 func (ms *MongoStorage) SetProcessQuestions(
 	processID primitive.ObjectID, questions []*VotingProcessQuestion,
 ) ([]primitive.ObjectID, error) {

--- a/db/processes_questions.go
+++ b/db/processes_questions.go
@@ -32,6 +32,89 @@ func (ms *MongoStorage) SetQuestion(q *VotingProcessQuestion) (primitive.ObjectI
 	return q.ID, nil
 }
 
+// SetProcessQuestions replaces a process's questions, addressing each by the slot it occupies:
+// question i is upserted on (processId, order=i), and anything beyond the new length is deleted.
+// It returns the resulting ids in order, for the process's own QuestionIDs.
+//
+// This exists instead of delete-everything-then-insert-everything because that sequence is not safe
+// against a second writer. Two overlapping draft updates interleave so that one deletes rows the
+// other has not inserted yet, and the stragglers survive as duplicates carrying the same processId —
+// which publish then turns into real elections (issue #614). Addressing rows by slot means neither
+// writer deletes what the other is inserting: the worst a race can do is leave slot i belonging to
+// whichever request wrote it last, which is a state some client actually asked for.
+//
+// It also keeps a question's _id stable across draft edits, since an existing row in a slot is
+// replaced rather than dropped and re-created. Publish, the status syncer and the eligibility lists
+// all key off those ids.
+//
+// The final sweep deletes every other row of the process, not just the tail past the new length, so
+// re-saving a draft repairs a database that a pre-fix update had already duplicated.
+//
+// Note this is not atomic across slots: a concurrent reader can still observe a half-applied update.
+// What it guarantees is that no row is ever orphaned, which is the part that reaches the chain.
+func (ms *MongoStorage) SetProcessQuestions(
+	processID primitive.ObjectID, questions []*VotingProcessQuestion,
+) ([]primitive.ObjectID, error) {
+	if processID == primitive.NilObjectID {
+		return nil, ErrInvalidData
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	ids := make([]primitive.ObjectID, 0, len(questions))
+	for i, q := range questions {
+		q.ProcessID = processID
+		q.Order = i
+		// the replacement carries no _id, so an existing row in this slot keeps the one it has and a
+		// brand new slot gets a server-generated one. Doing it in a single atomic find-and-replace
+		// (rather than reading the slot first) leaves no window for a second writer to insert
+		// between the read and the write, which would make the replacement fail on the immutable _id.
+		doc, err := questionDocWithoutID(q)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode question %d: %w", i, err)
+		}
+		filter := bson.M{"processId": processID, "order": i} //nolint:goconst
+		stored := struct {
+			ID primitive.ObjectID `bson:"_id"`
+		}{}
+		err = ms.processesQuestions.FindOneAndReplace(ctx, filter, doc,
+			options.FindOneAndReplace().
+				SetUpsert(true).
+				SetReturnDocument(options.After).
+				SetProjection(bson.M{"_id": 1}),
+		).Decode(&stored)
+		if err != nil {
+			return nil, fmt.Errorf("failed to store question %d: %w", i, err)
+		}
+		q.ID = stored.ID
+		ids = append(ids, q.ID)
+	}
+	// drop anything else still carrying this processId: the tail of a longer previous version, and
+	// any duplicate a pre-fix concurrent update had stranded in a slot we just rewrote
+	if _, err := ms.processesQuestions.DeleteMany(ctx, bson.M{
+		"processId": processID,
+		"_id":       bson.M{"$nin": ids},
+	}); err != nil {
+		return nil, fmt.Errorf("failed to remove surplus questions: %w", err)
+	}
+	return ids, nil
+}
+
+// questionDocWithoutID encodes a question for storage with its _id stripped, so a replacement
+// neither overwrites the id of the row it lands on nor fails on the immutable field.
+func questionDocWithoutID(q *VotingProcessQuestion) (bson.M, error) {
+	raw, err := bson.Marshal(q)
+	if err != nil {
+		return nil, err
+	}
+	doc := bson.M{}
+	if err := bson.Unmarshal(raw, &doc); err != nil {
+		return nil, err
+	}
+	delete(doc, "_id")
+	return doc, nil
+}
+
 // Question returns a single question by its hex ObjectID.
 func (ms *MongoStorage) Question(id primitive.ObjectID) (*VotingProcessQuestion, error) {
 	if id == primitive.NilObjectID {

--- a/db/processes_questions.go
+++ b/db/processes_questions.go
@@ -89,15 +89,12 @@ func (ms *MongoStorage) SetProcessQuestions(
 		// brand new slot gets a server-generated one. Doing it in a single atomic find-and-replace
 		// (rather than reading the slot first) leaves no window for a second writer to insert
 		// between the read and the write, which would make the replacement fail on the immutable _id.
-		doc, err := questionDocWithoutID(q)
-		if err != nil {
-			return nil, fmt.Errorf("failed to encode question %d: %w", i, err)
-		}
+		doc := questionDocWithoutID(q)
 		filter := bson.M{"processId": processID, "order": i} //nolint:goconst
 		stored := struct {
 			ID primitive.ObjectID `bson:"_id"`
 		}{}
-		err = ms.processesQuestions.FindOneAndReplace(ctx, filter, doc,
+		err := ms.processesQuestions.FindOneAndReplace(ctx, filter, doc,
 			options.FindOneAndReplace().
 				SetUpsert(true).
 				SetReturnDocument(options.After).
@@ -120,19 +117,14 @@ func (ms *MongoStorage) SetProcessQuestions(
 	return ids, nil
 }
 
-// questionDocWithoutID encodes a question for storage with its _id stripped, so a replacement
-// neither overwrites the id of the row it lands on nor fails on the immutable field.
-func questionDocWithoutID(q *VotingProcessQuestion) (bson.M, error) {
-	raw, err := bson.Marshal(q)
-	if err != nil {
-		return nil, err
-	}
-	doc := bson.M{}
-	if err := bson.Unmarshal(raw, &doc); err != nil {
-		return nil, err
-	}
-	delete(doc, "_id")
-	return doc, nil
+// questionDocWithoutID returns a copy of a question with its _id zeroed, so a replacement neither
+// overwrites the id of the row it lands on nor fails on the immutable field. The bson tag carries
+// omitempty and primitive.ObjectID implements IsZero, so the driver leaves the field out entirely —
+// no marshal/unmarshal round-trip needed for what runs once per question on every draft save.
+func questionDocWithoutID(q *VotingProcessQuestion) *VotingProcessQuestion {
+	doc := *q
+	doc.ID = primitive.NilObjectID
+	return &doc
 }
 
 // Question returns a single question by its hex ObjectID.

--- a/db/processes_questions_test.go
+++ b/db/processes_questions_test.go
@@ -103,9 +103,10 @@ func TestSetProcessQuestionsConcurrent(t *testing.T) {
 // TestSetProcessQuestionsConcurrentGrowing races the insert path, which TestSetProcessQuestionsConcurrent
 // never reaches: every writer there sends the same number of questions, so each slot is always matched
 // and only the atomic replace is exercised. Writers of differing lengths make the tail slots brand new,
-// where two callers can both insert and then sweep each other's row away (documented on
-// SetProcessQuestions). What must still hold — and is the issue #614 regression — is that no slot ever
-// ends up carrying two rows.
+// where a losing insert now surfaces as a duplicate-key error on the unique (processId, order) index
+// (migration 0018) that SetProcessQuestions must absorb by retrying — every writer returning nil error
+// is that regression. What must also hold — the issue #614 regression — is that no slot ever ends up
+// carrying two rows.
 func TestSetProcessQuestionsConcurrentGrowing(t *testing.T) {
 	c := qt.New(t)
 	org := common.Address{0x61, 0x14, 0x03}
@@ -146,9 +147,10 @@ func TestSetProcessQuestionsConcurrentGrowing(t *testing.T) {
 		seenID[stored[i].ID] = true
 	}
 	// the bound is deliberately loose: slots 0 and 1 exist from the seed so they are always matched
-	// and can never be lost, while the grown tail is still exposed to the residual insert race
-	// documented on SetProcessQuestions. Only losing a row is tolerated, never gaining one.
+	// and can never be lost, while the grown tail depends on interleaving — a shorter writer's sweep
+	// may remove a slot a longer writer just wrote (documented on SetProcessQuestions). Only losing
+	// a tail row is tolerated, never gaining one.
 	c.Assert(len(stored) >= 2 && len(stored) <= 4, qt.IsTrue,
-		qt.Commentf("expected 2 to 4 rows, got %d: the tail may be lost to the residual insert race, "+
-			"but the seeded slots and the one-row-per-slot invariant may not", len(stored)))
+		qt.Commentf("expected 2 to 4 rows, got %d: the tail may be swept by a shorter concurrent writer, "+
+			"but the seeded slots and the one-row-per-slot invariant may not be violated", len(stored)))
 }

--- a/db/processes_questions_test.go
+++ b/db/processes_questions_test.go
@@ -1,0 +1,101 @@
+package db
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	qt "github.com/frankban/quicktest"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// questionSet builds n questions for a process, titled so a rewrite is distinguishable.
+func questionSet(org common.Address, n int, title string) []*VotingProcessQuestion {
+	qs := make([]*VotingProcessQuestion, 0, n)
+	for range n {
+		qs = append(qs, &VotingProcessQuestion{
+			OrgAddress: org,
+			Type:       VotingTypeSingleChoice,
+			Title:      MultiLangString{"default": title},
+			Choices:    []Choice{{Title: MultiLangString{"default": "Yes"}, Value: 0}},
+		})
+	}
+	return qs
+}
+
+// TestSetProcessQuestions covers the per-slot replacement that backs a draft update: ids are stable
+// across a rewrite, a shorter set truncates the tail, and concurrent writers cannot strand a row
+// (issue #614).
+func TestSetProcessQuestions(t *testing.T) {
+	c := qt.New(t)
+	org := common.Address{0x61, 0x14}
+	setupVotingProcessOrg(c, org)
+
+	pid, err := testDB.SetVotingProcess(&VotingProcess{OrgAddress: org, Title: MultiLangString{"default": "P"}})
+	c.Assert(err, qt.IsNil)
+
+	ids, err := testDB.SetProcessQuestions(pid, questionSet(org, 3, "first"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(ids, qt.HasLen, 3)
+
+	// a rewrite of the same length keeps the ids: publish, the status syncer and eligibleMemberIds
+	// all key off them, so they must survive an edit
+	rewritten, err := testDB.SetProcessQuestions(pid, questionSet(org, 3, "second"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(rewritten, qt.DeepEquals, ids)
+
+	stored, err := testDB.QuestionsByProcess(pid)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stored, qt.HasLen, 3)
+	for i := range stored {
+		c.Assert(stored[i].Order, qt.Equals, i)
+		c.Assert(stored[i].ProcessID, qt.Equals, pid)
+		c.Assert(stored[i].Title["default"], qt.Equals, "second")
+	}
+
+	// a shorter set truncates the tail rather than leaving orphans behind
+	shorter, err := testDB.SetProcessQuestions(pid, questionSet(org, 1, "third"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(shorter, qt.HasLen, 1)
+	c.Assert(shorter[0], qt.Equals, ids[0])
+	stored, err = testDB.QuestionsByProcess(pid)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stored, qt.HasLen, 1)
+}
+
+// TestSetProcessQuestionsConcurrent is the storage-level regression for issue #614: overlapping
+// writers must converge on exactly one question per slot, never leaving a stranded row for publish
+// to turn into an extra on-chain election.
+func TestSetProcessQuestionsConcurrent(t *testing.T) {
+	c := qt.New(t)
+	org := common.Address{0x61, 0x14, 0x02}
+	setupVotingProcessOrg(c, org)
+
+	pid, err := testDB.SetVotingProcess(&VotingProcess{OrgAddress: org, Title: MultiLangString{"default": "P"}})
+	c.Assert(err, qt.IsNil)
+	_, err = testDB.SetProcessQuestions(pid, questionSet(org, 2, "initial"))
+	c.Assert(err, qt.IsNil)
+
+	const writers = 8
+	results := make([][]primitive.ObjectID, writers)
+	errs := make([]error, writers)
+	var wg sync.WaitGroup
+	for i := range writers {
+		wg.Go(func() {
+			results[i], errs[i] = testDB.SetProcessQuestions(pid, questionSet(org, 2, "concurrent"))
+		})
+	}
+	wg.Wait()
+	for i := range writers {
+		c.Assert(errs[i], qt.IsNil)
+		c.Assert(results[i], qt.HasLen, 2)
+	}
+
+	stored, err := testDB.QuestionsByProcess(pid)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stored, qt.HasLen, 2,
+		qt.Commentf("concurrent writers must not strand a question: %d stored", len(stored)))
+	c.Assert(stored[0].Order, qt.Equals, 0)
+	c.Assert(stored[1].Order, qt.Equals, 1)
+	c.Assert(stored[0].ID, qt.Not(qt.Equals), stored[1].ID)
+}

--- a/db/processes_questions_test.go
+++ b/db/processes_questions_test.go
@@ -99,3 +99,56 @@ func TestSetProcessQuestionsConcurrent(t *testing.T) {
 	c.Assert(stored[1].Order, qt.Equals, 1)
 	c.Assert(stored[0].ID, qt.Not(qt.Equals), stored[1].ID)
 }
+
+// TestSetProcessQuestionsConcurrentGrowing races the insert path, which TestSetProcessQuestionsConcurrent
+// never reaches: every writer there sends the same number of questions, so each slot is always matched
+// and only the atomic replace is exercised. Writers of differing lengths make the tail slots brand new,
+// where two callers can both insert and then sweep each other's row away (documented on
+// SetProcessQuestions). What must still hold — and is the issue #614 regression — is that no slot ever
+// ends up carrying two rows.
+func TestSetProcessQuestionsConcurrentGrowing(t *testing.T) {
+	c := qt.New(t)
+	org := common.Address{0x61, 0x14, 0x03}
+	setupVotingProcessOrg(c, org)
+
+	pid, err := testDB.SetVotingProcess(&VotingProcess{OrgAddress: org, Title: MultiLangString{"default": "P"}})
+	c.Assert(err, qt.IsNil)
+	_, err = testDB.SetProcessQuestions(pid, questionSet(org, 2, "initial"))
+	c.Assert(err, qt.IsNil)
+
+	// lengths cycle 2, 3, 4 so slots 2 and 3 are inserted rather than replaced
+	const writers = 9
+	results := make([][]primitive.ObjectID, writers)
+	errs := make([]error, writers)
+	lengths := make([]int, writers)
+	var wg sync.WaitGroup
+	for i := range writers {
+		lengths[i] = 2 + i%3
+		wg.Go(func() {
+			results[i], errs[i] = testDB.SetProcessQuestions(pid, questionSet(org, lengths[i], "growing"))
+		})
+	}
+	wg.Wait()
+	for i := range writers {
+		c.Assert(errs[i], qt.IsNil)
+		c.Assert(results[i], qt.HasLen, lengths[i])
+	}
+
+	stored, err := testDB.QuestionsByProcess(pid)
+	c.Assert(err, qt.IsNil)
+	seenOrder := make(map[int]bool, len(stored))
+	seenID := make(map[primitive.ObjectID]bool, len(stored))
+	for i := range stored {
+		c.Assert(seenOrder[stored[i].Order], qt.IsFalse,
+			qt.Commentf("two rows share slot %d: a concurrent update duplicated a question (issue #614)", stored[i].Order))
+		c.Assert(seenID[stored[i].ID], qt.IsFalse, qt.Commentf("question %s stored twice", stored[i].ID.Hex()))
+		seenOrder[stored[i].Order] = true
+		seenID[stored[i].ID] = true
+	}
+	// the bound is deliberately loose: slots 0 and 1 exist from the seed so they are always matched
+	// and can never be lost, while the grown tail is still exposed to the residual insert race
+	// documented on SetProcessQuestions. Only losing a row is tolerated, never gaining one.
+	c.Assert(len(stored) >= 2 && len(stored) <= 4, qt.IsTrue,
+		qt.Commentf("expected 2 to 4 rows, got %d: the tail may be lost to the residual insert race, "+
+			"but the seeded slots and the one-row-per-slot invariant may not", len(stored)))
+}

--- a/db/types.go
+++ b/db/types.go
@@ -690,7 +690,7 @@ type VotingProcess struct {
 //
 //nolint:lll
 type VotingProcessQuestion struct {
-	ID                primitive.ObjectID `json:"id" bson:"_id"`
+	ID                primitive.ObjectID `json:"id" bson:"_id,omitempty"`
 	ProcessID         primitive.ObjectID `json:"parentProcessId" bson:"processId"`
 	OrgAddress        common.Address     `json:"-" bson:"orgAddress"`
 	Order             int                `json:"-" bson:"order"`

--- a/db/voting_processes.go
+++ b/db/voting_processes.go
@@ -47,14 +47,20 @@ func (ms *MongoStorage) SetVotingProcess(vp *VotingProcess) (primitive.ObjectID,
 // SetVotingProcessIfUnchanged replaces a voting process only if its stored UpdatedAt still equals
 // seen, i.e. nothing has written the document since the caller read it. It reports ErrConflict
 // otherwise, leaving the stored document untouched, so two clients editing the same draft cannot
-// silently overwrite each other. Same semantics as SetVotingProcess in every other respect, except
-// that it never creates: an unknown id is a conflict, not an insert.
+// silently overwrite each other. It enforces the same organization invariant as SetVotingProcess but
+// never creates: an unknown id is a conflict, not an insert.
 func (ms *MongoStorage) SetVotingProcessIfUnchanged(vp *VotingProcess, seen time.Time) error {
 	if vp.ID.IsZero() || (vp.OrgAddress.Cmp(common.Address{}) == 0) {
 		return ErrInvalidData
 	}
 	ms.keysLock.Lock()
 	defer ms.keysLock.Unlock()
+
+	// a voting process outlives its organization (nothing deletes votingProcesses on teardown), so
+	// this is checked here exactly as in SetVotingProcess rather than assumed from the caller
+	if _, err := ms.Organization(vp.OrgAddress); err != nil {
+		return fmt.Errorf("failed to get organization %s: %w", vp.OrgAddress, err)
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
@@ -78,6 +84,32 @@ func (ms *MongoStorage) SetVotingProcessIfUnchanged(vp *VotingProcess, seen time
 	if res.MatchedCount == 0 {
 		vp.UpdatedAt = prev
 		return ErrConflict
+	}
+	return nil
+}
+
+// SetVotingProcessQuestionIDs records the process's ordered question ids. It touches only that
+// field, so it cannot undo a concurrent edit of the rest of the document the way a whole-document
+// replace would, and it advances updatedAt without ever moving it backwards: the conditional-update
+// token of SetVotingProcessIfUnchanged has to stay monotonic, and this write can land inside the
+// same millisecond as the one that produced the token a client is holding.
+func (ms *MongoStorage) SetVotingProcessQuestionIDs(id primitive.ObjectID, questionIDs []primitive.ObjectID) error {
+	if id == primitive.NilObjectID {
+		return ErrInvalidData
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	// $max ignores a missing operand, so a document written before updatedAt existed just gets now
+	update := mongo.Pipeline{{{Key: "$set", Value: bson.M{
+		"questionIds": questionIDs,
+		"updatedAt":   bson.M{"$max": bson.A{"$updatedAt", time.Now()}},
+	}}}}
+	res, err := ms.votingProcesses.UpdateOne(ctx, bson.M{"_id": id}, update)
+	if err != nil {
+		return fmt.Errorf("failed to set voting process question ids: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return ErrNotFound
 	}
 	return nil
 }

--- a/db/voting_processes.go
+++ b/db/voting_processes.go
@@ -44,6 +44,44 @@ func (ms *MongoStorage) SetVotingProcess(vp *VotingProcess) (primitive.ObjectID,
 	return vp.ID, nil
 }
 
+// SetVotingProcessIfUnchanged replaces a voting process only if its stored UpdatedAt still equals
+// seen, i.e. nothing has written the document since the caller read it. It reports ErrConflict
+// otherwise, leaving the stored document untouched, so two clients editing the same draft cannot
+// silently overwrite each other. Same semantics as SetVotingProcess in every other respect, except
+// that it never creates: an unknown id is a conflict, not an insert.
+func (ms *MongoStorage) SetVotingProcessIfUnchanged(vp *VotingProcess, seen time.Time) error {
+	if vp.ID.IsZero() || (vp.OrgAddress.Cmp(common.Address{}) == 0) {
+		return ErrInvalidData
+	}
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	// mongo stores datetimes with millisecond precision, so the token the client echoes back can
+	// only ever match a truncated value — compare against, and advance past, the same truncation
+	seen = seen.UTC().Truncate(time.Millisecond)
+	now := time.Now()
+	if !now.Truncate(time.Millisecond).After(seen) {
+		// two writes inside the same millisecond would leave the token unchanged, and the second
+		// client's already-consumed token would still match. Force it forward instead.
+		now = seen.Add(time.Millisecond)
+	}
+	prev := vp.UpdatedAt
+	vp.UpdatedAt = now
+	filter := bson.M{"_id": vp.ID, "updatedAt": seen}
+	res, err := ms.votingProcesses.ReplaceOne(ctx, filter, vp)
+	if err != nil {
+		vp.UpdatedAt = prev
+		return fmt.Errorf("failed to update voting process: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		vp.UpdatedAt = prev
+		return ErrConflict
+	}
+	return nil
+}
+
 // VotingProcess returns a voting process by its hex ObjectID.
 func (ms *MongoStorage) VotingProcess(id primitive.ObjectID) (*VotingProcess, error) {
 	if id == primitive.NilObjectID {

--- a/db/voting_processes_test.go
+++ b/db/voting_processes_test.go
@@ -175,3 +175,38 @@ func TestQuestionStatusSyncMethods(t *testing.T) {
 	_, err = testDB.SetQuestionStatusSynced(nil, QuestionStatusReady, QuestionStatusEnded)
 	c.Assert(err, qt.ErrorIs, ErrInvalidData)
 }
+
+// TestSetVotingProcessIfUnchanged covers the conditional write behind the optimistic-concurrency
+// token: it applies while the stored updatedAt still matches what the caller read, and refuses with
+// ErrConflict once anything else has written.
+func TestSetVotingProcessIfUnchanged(t *testing.T) {
+	c := qt.New(t)
+	org := common.Address{0x61, 0x14, 0x03}
+	setupVotingProcessOrg(c, org)
+
+	vp := &VotingProcess{OrgAddress: org, Title: MultiLangString{"default": "P"}}
+	id, err := testDB.SetVotingProcess(vp)
+	c.Assert(err, qt.IsNil)
+
+	read, err := testDB.VotingProcess(id)
+	c.Assert(err, qt.IsNil)
+	seen := read.UpdatedAt
+
+	read.Title = MultiLangString{"default": "edited"}
+	c.Assert(testDB.SetVotingProcessIfUnchanged(read, seen), qt.IsNil)
+	got, err := testDB.VotingProcess(id)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.Title["default"], qt.Equals, "edited")
+	c.Assert(got.UpdatedAt.After(seen), qt.IsTrue)
+
+	// the same token again is now stale: refused, and the stored document is left alone
+	stale := &VotingProcess{ID: id, OrgAddress: org, Title: MultiLangString{"default": "clobbered"}}
+	c.Assert(testDB.SetVotingProcessIfUnchanged(stale, seen), qt.Equals, ErrConflict)
+	got, err = testDB.VotingProcess(id)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.Title["default"], qt.Equals, "edited")
+
+	// an unknown id is a conflict, never an insert
+	orphan := &VotingProcess{ID: primitive.NewObjectID(), OrgAddress: org}
+	c.Assert(testDB.SetVotingProcessIfUnchanged(orphan, got.UpdatedAt), qt.Equals, ErrConflict)
+}

--- a/db/voting_processes_test.go
+++ b/db/voting_processes_test.go
@@ -1,12 +1,14 @@
 package db
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/saas-backend/internal"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -209,4 +211,51 @@ func TestSetVotingProcessIfUnchanged(t *testing.T) {
 	// an unknown id is a conflict, never an insert
 	orphan := &VotingProcess{ID: primitive.NewObjectID(), OrgAddress: org}
 	c.Assert(testDB.SetVotingProcessIfUnchanged(orphan, got.UpdatedAt), qt.Equals, ErrConflict)
+
+	// a process whose organization no longer exists is refused, exactly as SetVotingProcess does:
+	// nothing deletes votingProcesses when an org is torn down, so drafts do outlive their org
+	noOrg := &VotingProcess{ID: id, OrgAddress: common.Address{0x61, 0x14, 0x04}, Title: got.Title}
+	c.Assert(testDB.SetVotingProcessIfUnchanged(noOrg, got.UpdatedAt), qt.ErrorMatches,
+		"failed to get organization .*")
+}
+
+// TestSetVotingProcessQuestionIDs covers the targeted question-ids write: it records the ids without
+// disturbing the rest of the document, reports an unknown process, and — the regression for the
+// conditional-update token — never moves updatedAt backwards, which a whole-document rewrite with a
+// fresh timestamp would do when it lands in the same millisecond as the token a client is holding.
+func TestSetVotingProcessQuestionIDs(t *testing.T) {
+	c := qt.New(t)
+	org := common.Address{0x61, 0x14, 0x05}
+	setupVotingProcessOrg(c, org)
+
+	id, err := testDB.SetVotingProcess(&VotingProcess{
+		OrgAddress: org, Title: MultiLangString{"default": "P"}, Header: "h",
+	})
+	c.Assert(err, qt.IsNil)
+
+	ids := []primitive.ObjectID{primitive.NewObjectID(), primitive.NewObjectID()}
+	c.Assert(testDB.SetVotingProcessQuestionIDs(id, ids), qt.IsNil)
+	got, err := testDB.VotingProcess(id)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.QuestionIDs, qt.DeepEquals, ids)
+	c.Assert(got.Title["default"], qt.Equals, "P") // the rest of the document is untouched
+	c.Assert(got.Header, qt.Equals, "h")
+
+	// a token ahead of the wall clock stands in for the forced-forward updatedAt a conditional
+	// update leaves behind: this write must not pull it back, or the spent token would match again
+	ahead := time.Now().Add(time.Hour).UTC().Truncate(time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	_, err = testDB.votingProcesses.UpdateOne(ctx,
+		bson.M{"_id": id}, bson.M{"$set": bson.M{"updatedAt": ahead}})
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(testDB.SetVotingProcessQuestionIDs(id, ids[:1]), qt.IsNil)
+	got, err = testDB.VotingProcess(id)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.QuestionIDs, qt.HasLen, 1)
+	c.Assert(got.UpdatedAt.Equal(ahead), qt.IsTrue,
+		qt.Commentf("updatedAt moved backwards: %s < %s", got.UpdatedAt, ahead))
+
+	c.Assert(testDB.SetVotingProcessQuestionIDs(primitive.NewObjectID(), ids), qt.Equals, ErrNotFound)
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -536,6 +536,13 @@ definitions:
         type: string
       title:
         $ref: '#/definitions/db.MultiLangString'
+      updatedAt:
+        description: |-
+          UpdatedAt, on a PUT, is the updatedAt the client last read. The update then applies only if
+          the process has not been written since, and is rejected with 409 otherwise, so two clients
+          editing the same draft cannot silently overwrite each other. Optional: omitting it keeps the
+          unconditional last-writer-wins behaviour. Ignored on POST.
+        type: string
     type: object
   apicommon.CreateVotingProcessResponse:
     properties:
@@ -1925,6 +1932,12 @@ definitions:
         type: string
       title:
         $ref: '#/definitions/db.MultiLangString'
+      updatedAt:
+        description: |-
+          UpdatedAt is the process's last-write timestamp, in millisecond precision. Echo it back in a
+          PUT to make the update conditional on nothing else having written in between (see
+          CreateVotingProcessRequest.UpdatedAt).
+        type: string
     type: object
   apicommon.VotingProcessResultsResponse:
     properties:
@@ -6037,8 +6050,11 @@ paths:
     put:
       consumes:
       - application/json
-      description: Update a voting process while it is still a draft (not published).
-        409 if already published.
+      description: |-
+        Update a voting process while it is still a draft (not published). 409 if already published.
+        Send the updatedAt read from GET /processes/{processId} to make the update conditional: it is
+        rejected with 409 (40171) if anything wrote the process in between, so two editors cannot
+        overwrite each other. Omitting updatedAt opts out of that guarantee and keeps last-writer-wins.
       parameters:
       - description: Process ID
         in: path

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -6395,6 +6395,8 @@ paths:
         Publish a voting process: one on-chain election per question, submitted as a batch.
         Requires Admin role (or a `voting:write` key). Returns 202 with a job id; poll
         GET /jobs/{jobId}. Idempotent once published.
+        409 (40172) means the stored questions do not match the process and the draft has to be
+        saved again before it can be published.
       parameters:
       - description: Process ID
         in: path
@@ -6413,7 +6415,7 @@ paths:
           schema:
             $ref: '#/definitions/apicommon.EnqueuedResponse'
         "400":
-          description: Bad Request
+          description: Not ready to publish
           schema:
             $ref: '#/definitions/errors.Error'
         "401":
@@ -6425,7 +6427,8 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
         "409":
-          description: Conflict
+          description: Publish in progress, or the stored questions do not match the
+            process
           schema:
             $ref: '#/definitions/errors.Error'
         "503":

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -112,6 +112,7 @@ var (
 	ErrVoteBatchTooLarge                      = Error{Code: 40165, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("vote batch is too large")}
 	ErrVoteBatchMixedOrganizations            = Error{Code: 40166, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("vote batch spans several organizations")}
 	ErrRequestBodyTooLarge                    = Error{Code: 40167, HTTPstatus: http.StatusRequestEntityTooLarge, Err: fmt.Errorf("request body is too large")}
+	ErrStaleUpdate                            = Error{Code: 40171, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("resource changed since it was read"), LogLevel: "info"}
 
 	// CSP errors (408)
 	ErrZeroWeightVoter = Error{Code: 40801, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("voter weight cannot be zero")}

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -113,6 +113,7 @@ var (
 	ErrVoteBatchMixedOrganizations            = Error{Code: 40166, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("vote batch spans several organizations")}
 	ErrRequestBodyTooLarge                    = Error{Code: 40167, HTTPstatus: http.StatusRequestEntityTooLarge, Err: fmt.Errorf("request body is too large")}
 	ErrStaleUpdate                            = Error{Code: 40171, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("resource changed since it was read"), LogLevel: "info"}
+	ErrProcessQuestionsMismatch               = Error{Code: 40172, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("stored questions do not match the process"), LogLevel: "info"}
 
 	// CSP errors (408)
 	ErrZeroWeightVoter = Error{Code: 40801, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("voter weight cannot be zero")}

--- a/errors/errors_definition.go
+++ b/errors/errors_definition.go
@@ -113,7 +113,7 @@ var (
 	ErrVoteBatchMixedOrganizations            = Error{Code: 40166, HTTPstatus: http.StatusBadRequest, Err: fmt.Errorf("vote batch spans several organizations")}
 	ErrRequestBodyTooLarge                    = Error{Code: 40167, HTTPstatus: http.StatusRequestEntityTooLarge, Err: fmt.Errorf("request body is too large")}
 	ErrStaleUpdate                            = Error{Code: 40171, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("resource changed since it was read"), LogLevel: "info"}
-	ErrProcessQuestionsMismatch               = Error{Code: 40172, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("stored questions do not match the process"), LogLevel: "info"}
+	ErrProcessQuestionsMismatch               = Error{Code: 40172, HTTPstatus: http.StatusConflict, Err: fmt.Errorf("stored questions do not match the process"), LogLevel: "warn"}
 
 	// CSP errors (408)
 	ErrZeroWeightVoter = Error{Code: 40801, HTTPstatus: http.StatusUnauthorized, Err: fmt.Errorf("voter weight cannot be zero")}

--- a/migrations/0018_unique_process_question_slots.go
+++ b/migrations/0018_unique_process_question_slots.go
@@ -1,0 +1,183 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.vocdoni.io/dvote/log"
+)
+
+func init() {
+	AddMigration(18, "unique_process_question_slots", upUniqueProcessQuestionSlots, downUniqueProcessQuestionSlots)
+}
+
+// upUniqueProcessQuestionSlots makes (processId, order) a storage-level key: it repairs the
+// processes that a pre-fix concurrent draft update duplicated (issue #614), then enforces
+// uniqueness so no future writer — including a direct database write — can reintroduce that state.
+//
+// The dedupe has to run first, because creating a unique index over existing duplicates fails.
+// That same pass is the bulk repair of already-corrupted drafts, so the two halves are one unit.
+//
+// The plain processId index from migration 0017 is dropped: the compound index below serves the
+// same prefix queries.
+func upUniqueProcessQuestionSlots(ctx context.Context, database *mongo.Database) error {
+	return replaceIndexWithUpdateFunc(ctx, database.Collection("processesQuestions"),
+		[]string{"processId_1"},
+		[]mongo.IndexModel{{
+			Keys:    bson.D{{Key: "processId", Value: 1}, {Key: "order", Value: 1}}, //nolint:goconst
+			Options: options.Index().SetUnique(true),
+		}},
+		func() error { return dedupeQuestionSlots(ctx, database) },
+	)
+}
+
+func downUniqueProcessQuestionSlots(ctx context.Context, database *mongo.Database) error {
+	// the repaired rows are not restored: the duplicates were the bug. Only the index reverts.
+	return replaceIndex(ctx, database.Collection("processesQuestions"),
+		[]string{"processId_1_order_1"},
+		[]mongo.IndexModel{{Keys: bson.D{{Key: "processId", Value: 1}}}},
+	)
+}
+
+// questionSlotKey identifies one question slot of a process.
+type questionSlotKey struct {
+	ProcessID primitive.ObjectID `bson:"processId"`
+	Order     int                `bson:"order"`
+}
+
+// questionSlotRow is one row found in a slot, with what decides whether it may be deleted.
+type questionSlotRow struct {
+	ID         primitive.ObjectID `bson:"id"`
+	UpstreamID []byte             `bson:"upstreamId"`
+}
+
+// questionSlotGroup is one (processId, order) slot holding more than one row.
+type questionSlotGroup struct {
+	Key  questionSlotKey   `bson:"_id"`
+	Rows []questionSlotRow `bson:"rows"`
+}
+
+// dedupeQuestionSlots leaves exactly one row per (processId, order).
+//
+// A row that carries an upstreamId is a published question: a real on-chain election exists for it
+// and deleting the row would hide that election from the API forever. Those are never deleted —
+// the extras are moved to free slots at the tail of the process instead, which loses the intended
+// ordering of an already-broken process but no data. Only unpublished rows are deleted, and the
+// keeper is the one the parent process names in questionIds (the set every reader agrees on),
+// falling back to the oldest row.
+func dedupeQuestionSlots(ctx context.Context, database *mongo.Database) error {
+	questions := database.Collection("processesQuestions")
+	cursor, err := questions.Aggregate(ctx, mongo.Pipeline{
+		{{Key: "$sort", Value: bson.D{{Key: "_id", Value: 1}}}},
+		{{Key: "$group", Value: bson.M{
+			"_id":  bson.M{"processId": "$processId", "order": "$order"},
+			"rows": bson.M{"$push": bson.M{"id": "$_id", "upstreamId": "$upstreamId"}},
+		}}},
+		{{Key: "$match", Value: bson.M{"rows.1": bson.M{"$exists": true}}}},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to scan for duplicated question slots: %w", err)
+	}
+	var groups []questionSlotGroup
+	if err := cursor.All(ctx, &groups); err != nil {
+		return fmt.Errorf("failed to decode duplicated question slots: %w", err)
+	}
+	if len(groups) == 0 {
+		return nil
+	}
+	// next free slot per process, so a published extra can be moved rather than dropped
+	tail := map[primitive.ObjectID]int{}
+	for _, g := range groups {
+		pid := g.Key.ProcessID
+		listed, err := processQuestionIDs(ctx, database, pid)
+		if err != nil {
+			return err
+		}
+		if _, ok := tail[pid]; !ok {
+			next, err := nextFreeOrder(ctx, questions, pid)
+			if err != nil {
+				return err
+			}
+			tail[pid] = next
+		}
+		keep := pickKeeper(g, listed)
+		for _, row := range g.Rows {
+			if row.ID == keep {
+				continue
+			}
+			if len(row.UpstreamID) > 0 {
+				// published: relocate, never delete
+				if _, err := questions.UpdateByID(ctx, row.ID,
+					bson.M{"$set": bson.M{"order": tail[pid]}}); err != nil {
+					return fmt.Errorf("failed to relocate published question %s: %w", row.ID.Hex(), err)
+				}
+				log.Warnw("relocated a duplicated published question",
+					"processId", pid.Hex(), "questionId", row.ID.Hex(),
+					"fromOrder", g.Key.Order, "toOrder", tail[pid])
+				tail[pid]++
+				continue
+			}
+			if _, err := questions.DeleteOne(ctx, bson.M{"_id": row.ID}); err != nil {
+				return fmt.Errorf("failed to remove duplicated question %s: %w", row.ID.Hex(), err)
+			}
+			log.Infow("removed a duplicated draft question",
+				"processId", pid.Hex(), "questionId", row.ID.Hex(), "order", g.Key.Order)
+		}
+	}
+	return nil
+}
+
+// pickKeeper chooses the row that keeps the slot: a published one first (it has an on-chain
+// election), then the one the process itself lists, then the oldest.
+func pickKeeper(g questionSlotGroup, listed map[primitive.ObjectID]bool) primitive.ObjectID {
+	for _, row := range g.Rows {
+		if len(row.UpstreamID) > 0 {
+			return row.ID
+		}
+	}
+	for _, row := range g.Rows {
+		if listed[row.ID] {
+			return row.ID
+		}
+	}
+	return g.Rows[0].ID // sorted by _id, so the oldest
+}
+
+// processQuestionIDs is the set of question ids the process itself records, empty for a process
+// predating the field.
+func processQuestionIDs(
+	ctx context.Context, database *mongo.Database, processID primitive.ObjectID,
+) (map[primitive.ObjectID]bool, error) {
+	var vp struct {
+		QuestionIDs []primitive.ObjectID `bson:"questionIds"`
+	}
+	err := database.Collection("votingProcesses").FindOne(ctx, bson.M{"_id": processID}).Decode(&vp)
+	if err != nil && err != mongo.ErrNoDocuments {
+		return nil, fmt.Errorf("failed to read process %s: %w", processID.Hex(), err)
+	}
+	listed := make(map[primitive.ObjectID]bool, len(vp.QuestionIDs))
+	for _, id := range vp.QuestionIDs {
+		listed[id] = true
+	}
+	return listed, nil
+}
+
+// nextFreeOrder is one past the highest slot currently used by the process.
+func nextFreeOrder(ctx context.Context, questions *mongo.Collection, processID primitive.ObjectID) (int, error) {
+	var highest struct {
+		Order int `bson:"order"`
+	}
+	err := questions.FindOne(ctx, bson.M{"processId": processID},
+		options.FindOne().SetSort(bson.D{{Key: "order", Value: -1}})).Decode(&highest)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to read the highest question order of %s: %w", processID.Hex(), err)
+	}
+	return highest.Order + 1, nil
+}


### PR DESCRIPTION
Closes #614.

## The bug

`PUT /processes/{processId}` rewrote a draft's questions by **deleting every row of the process and re-inserting each one with a fresh `_id`**. That sequence is not safe against a second writer: two overlapping updates interleave so that one deletes rows the other has not inserted yet, and the stragglers survive carrying the same `processId`. Publish reads *everything with that processId*, so the orphan became a real on-chain election — the one step in the whole flow that cannot be undone. The reported case published three elections for a two-question process, the second duplicated.

Two things made it reachable rather than theoretical:

- `VotingProcess.QuestionIDs` was written and **read nowhere** (`git grep` finds only the assignment and the field). Every reader, publish included, went through `QuestionsByProcess`, so the process's own idea of its questions was never consulted.
- `SetVotingProcess` is an unguarded whole-document `ReplaceOne`, so concurrent edits of the same draft already lost one silently, questions aside.

## What this changes

**1. The write path can no longer create duplicates.** `db.SetProcessQuestions` replaces questions **per slot**: question *i* is one atomic `FindOneAndReplace` on `(processId, order: i)` with `upsert`, and the replacement document carries no `_id`, so an existing row keeps the id it has and only a brand-new slot mints one. Neither of two interleaved writers deletes what the other is inserting; the worst a race can do is leave slot *i* belonging to whichever request wrote it last, which is a state some client actually asked for. Question ids now also survive a draft edit — publish, the status syncer and `eligibleMemberIds` all key off them.

The closing sweep deletes *every other row of the process*, not just the tail past the new length, so **re-saving a draft repairs a database a pre-fix update had already duplicated**.

**2. Overlapping editors are serialized, opt-in.** `VotingProcessResponse` now exposes `updatedAt`, and `CreateVotingProcessRequest` accepts it on `PUT`. When present, the update applies only while the stored `updatedAt` still matches, and is rejected with **409 / 40171** otherwise so the client refetches and retries. Omitting it keeps today's unconditional last-writer-wins, so no existing client breaks. The token is millisecond-precision (what mongo stores) and is forced strictly forward, so two writes inside the same millisecond cannot leave an already-consumed token still matching.

**3. Publish refuses a mismatched question set.** `QuestionIDs` becomes load-bearing: publish and the dry-run `GET /processes/{id}/validation` refuse when the stored questions are not exactly the ids the process records, instead of minting an election per stray row. Processes predating the field carry none and are not checked.

## What this does *not* close

**There is no migration**, so no unique `(processId, order)` index and no bulk repair. Two consequences, stated plainly:

- The guarantee is **code-level, not storage-level**. Nothing stops a future writer, or a direct database write, from reintroducing duplicates.
- **Existing duplicates are not repaired in bulk.** They are repaired when that draft is next saved, and until then §3 is what stands between an already-corrupted draft and a permanent extra election.

Worth a follow-up on the issue rather than assuming it is handled.

## Tests

- `api`: `TestVotingProcessConcurrentUpdates` — six overlapping `PUT`s on one draft. **Verified to fail on `main`** (the process ends up with a third question) and pass here.
- `api`: `TestVotingProcessConditionalUpdate` — a fresh token applies; the same token replayed is 409 and leaves the stored state alone; a refreshed token succeeds; no token still succeeds; a malformed token is 400.
- `api`: `TestVotingProcessPublishRejectsStrayQuestion` — injects the corrupted state directly, asserts validation and publish both refuse it and nothing reaches the chain, then that re-saving the draft heals it and publish is allowed again.
- `db`: `TestSetProcessQuestions` (id stability, tail truncation), `TestSetProcessQuestionsConcurrent` (eight concurrent writers converge on one row per slot), `TestSetVotingProcessIfUnchanged` (applies, then conflicts; unknown id is a conflict, never an insert).

`go build ./... && go vet ./...`, `golangci-lint run` (0 issues), `scripts/check-qt-patterns.sh`, and the full `./db/` and `./api/` suites pass. `docs/swagger.yaml` regenerated.
