### PR TITLE
ci(swagger): publish the stage Swagger UI to GitHub Pages

### DIFF
--- a/.github/workflows/swag.yml
+++ b/.github/workflows/swag.yml
@@ -62,3 +62,44 @@ jobs:
           git add docs/swagger.yaml
           git commit -m "ci: regenerate swagger.yaml after merge"
           git push
+
+  deploy-pages:
+    name: Deploy Swagger UI to GitHub Pages
+    needs: api-swagger
+    # on.push.branches is already [stage], so a push event is always stage.
+    # Pull request runs must never publish.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    # Scoped to this job on purpose: api-swagger pushes the regenerated
+    # swagger.yaml with the repo-default token, so it must keep its own scopes.
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+
+      # The checked out swagger.yaml predates the "regenerate after merge"
+      # commit, so take the spec api-swagger just produced instead.
+      - name: Overwrite docs/swagger.yaml with the freshly generated spec
+        uses: actions/download-artifact@v4
+        with:
+          name: swagger.yaml
+          path: docs
+
+      - uses: actions/configure-pages@v5
+
+      - name: Upload docs/ (Swagger UI + spec)
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/swag.yml
+++ b/.github/workflows/swag.yml
@@ -73,6 +73,11 @@ jobs:
     # Scoped to this job on purpose: api-swagger pushes the regenerated
     # swagger.yaml with the repo-default token, so it must keep its own scopes.
     permissions:
+      # Same-run artifact downloads authenticate with the runner's
+      # ACTIONS_RUNTIME_TOKEN rather than GITHUB_TOKEN, so this is not strictly
+      # required today -- it is here so the job keeps working if it ever grows a
+      # github-token/run-id input to fetch artifacts from another run.
+      actions: read
       contents: read
       pages: write
       id-token: write


### PR DESCRIPTION
## What

`docs/` already contains a complete Swagger UI bundle (`index.html` + `dist/` v5.18.2) alongside the generated `swagger.yaml`, but nothing has ever served it — there is no Pages workflow, no `gh-pages` branch, no `CNAME`.

This adds a `deploy-pages` job to `.github/workflows/swag.yml` that publishes that directory to GitHub Pages, so the spec becomes browsable at:

**https://vocdoni.github.io/saas-backend/**

## Only `stage` publishes

The job is gated on `if: github.event_name == 'push'`. Since `on.push.branches` is already `[stage]` (set in #589, "deploy swagger during stage deploys, not main ones"), a push event is always `stage`. Pull request runs of the workflow are skipped and never deploy.

## Notes for reviewers

- **The spec comes from the artifact, not the checkout.** `api-swagger` commits `ci: regenerate swagger.yaml after merge` *after* the SHA being built, so the checked-out `docs/swagger.yaml` can be one commit stale. Downloading the artifact it just produced publishes the fresh spec with no race against the bot push. `index.html` and `dist/` come from the checkout.
- **Permissions are job-scoped on purpose.** The workflow has no top-level `permissions:` block, so `api-swagger` runs with repo-default token scopes — its `git push` depends on `contents: write` being among them. A workflow-level block would silently break that push.
- **`concurrency: {group: pages, cancel-in-progress: false}`** is job-level so PR runs of `api-swagger` are unaffected; two rapid `stage` merges queue rather than cancelling a half-finished deploy.
- **No `.nojekyll` needed** — `upload-pages-artifact` publishes the tarball verbatim; Jekyll does not run for Actions-sourced Pages.
- Artifact is ~11 MB (the `dist/` bundle ships `.map` files), well within Pages limits.

## :warning: Two repository settings are required before this does anything

Neither can live in the repo; both need admin:

1. **Settings → Pages → Source = "GitHub Actions".** Without it `actions/configure-pages` fails and nothing is served.
2. **Settings → Environments → `github-pages` → Deployment branches.** GitHub typically seeds this environment allowing only the default branch (`main`). Since we deploy from `stage`, `stage` must be added, or `deploy-pages` fails on a protection rule even though the workflow is correct.

## Known caveat, deliberately not fixed here

`api/api.go` declares `@host localhost:8080`, so the published spec carries `host: localhost:8080` and Swagger UI's "Try it out" will fire at the reader's own localhost. Changing it rewrites the committed `docs/swagger.yaml` for everyone, so it belongs in its own PR.

## Verification

- `actionlint v1.7.7` passes clean on all three workflow files.
- On this PR: `deploy-pages` should be **skipped**, with no deployment under the Environments tab.
- After promotion to `stage`: `deploy-pages` green with a `page_url`; `curl -sI https://vocdoni.github.io/saas-backend/swagger.yaml` → 200, and an endpoint from that promotion should be present in the served spec.