### PR TITLE
feat(db): standardized user erasure (GDPR right to erasure)

### DIFF
--- a/cmd/userdel/main.go
+++ b/cmd/userdel/main.go
@@ -1,0 +1,214 @@
+// Command userdel erases a registered user and their personal data from the
+// database, to serve GDPR right-to-erasure requests in a standardized way.
+//
+// Organizations where the user is the sole admin are deleted entirely
+// (members, groups, censuses, participants, processes, bundles, CSP tokens,
+// jobs, invitations). Organizations with other admins are kept: only the
+// user's membership is removed. In kept organizations created by the user the
+// creator email is retained on purpose — the org signing key is derived from
+// secret+creator+nonce (account.OrganizationSigner), so redacting it would
+// break the org's on-chain account; such orgs are listed in the output for
+// manual follow-up.
+//
+// Out of scope (handle manually where applicable): Stripe customer data and
+// database backups.
+//
+// Usage:
+//
+//	go run ./cmd/userdel -email user@example.com -dryRun  # print the impact report only
+//	go run ./cmd/userdel -email user@example.com          # report + confirmation prompt
+//	go run ./cmd/userdel -id 42 -yes                      # skip confirmation
+//
+// The MongoDB connection may also be supplied via the VOCDONI_MONGOURL and
+// VOCDONI_MONGODB environment variables.
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/vocdoni/saas-backend/db"
+)
+
+// options holds the parsed CLI flags.
+type options struct {
+	mongoURL string
+	database string
+	email    string
+	userID   uint64
+	yes      bool
+	dryRun   bool
+}
+
+func main() {
+	var opts options
+	flag.StringVar(&opts.mongoURL, "mongoURL", os.Getenv("VOCDONI_MONGOURL"), "MongoDB connection URL (or VOCDONI_MONGOURL)")
+	flag.StringVar(&opts.database, "mongoDB", os.Getenv("VOCDONI_MONGODB"), "MongoDB database name (or VOCDONI_MONGODB)")
+	flag.StringVar(&opts.email, "email", "", "email of the user to erase")
+	flag.Uint64Var(&opts.userID, "id", 0, "ID of the user to erase")
+	flag.BoolVar(&opts.yes, "yes", false, "skip the confirmation prompt")
+	flag.BoolVar(&opts.dryRun, "dryRun", false, "print the impact report and exit without deleting anything")
+	flag.Parse()
+	if err := run(&opts); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// run holds the whole CLI flow so os.Exit and flag.Parse stay in main.
+func run(opts *options) error {
+	if opts.mongoURL == "" || (opts.email == "" && opts.userID == 0) {
+		flag.Usage()
+		return fmt.Errorf("-mongoURL and one of -email or -id are required")
+	}
+
+	ms, err := db.New(opts.mongoURL, opts.database)
+	if err != nil {
+		return fmt.Errorf("could not connect to mongodb: %w", err)
+	}
+	defer ms.Close()
+
+	user, err := resolveUser(ms, opts.email, opts.userID)
+	if err != nil {
+		return fmt.Errorf("could not find user: %w", err)
+	}
+
+	if err := printPlan(ms, user); err != nil {
+		return err
+	}
+	if opts.dryRun {
+		fmt.Println("\ndry run: nothing was deleted")
+		return nil
+	}
+
+	if !opts.yes && !confirm() {
+		return fmt.Errorf("aborted")
+	}
+
+	report, err := ms.EraseUser(user.ID)
+	if report != nil {
+		fmt.Printf("erased user %d <%s>\n", report.UserID, report.Email)
+		for _, org := range report.DeletedOrgs {
+			fmt.Printf("  deleted org %s\n", org)
+		}
+		for _, org := range report.KeptOrgs {
+			fmt.Printf("  removed membership in org %s\n", org)
+		}
+		for _, org := range report.CreatorEmailRetained {
+			fmt.Printf("  WARNING: creator email retained in org %s (signing-key derivation input), follow up manually\n", org)
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("erasure finished with errors: %w", err)
+	}
+	return nil
+}
+
+// printPlan prints a human-readable report of everything the erasure will
+// touch: the user's identity, each organization with its classification (full
+// teardown vs membership removal) and, for organizations about to be deleted,
+// how much data they hold.
+func printPlan(ms *db.MongoStorage, user *db.User) error {
+	name := strings.TrimSpace(user.FirstName + " " + user.LastName)
+	fmt.Printf("\nThis will erase user #%d: %s <%s>\n", user.ID, name, user.Email)
+	if len(user.Organizations) == 0 {
+		fmt.Println("\nThe user belongs to no organization.")
+	}
+	for _, userOrg := range user.Organizations {
+		org, err := ms.Organization(userOrg.Address)
+		if err != nil {
+			return fmt.Errorf("could not fetch org %s: %w", userOrg.Address, err)
+		}
+		orgName := org.DisplayName()
+		if orgName == "" {
+			orgName = "unnamed"
+		}
+		fmt.Printf("\nOrganization %s (%q, role: %s)\n", userOrg.Address, orgName, userOrg.Role)
+		soleAdmin, err := ms.IsSoleOrgAdmin(userOrg.Address, user.ID)
+		if err != nil {
+			return fmt.Errorf("could not classify org %s: %w", userOrg.Address, err)
+		}
+		if !soleAdmin {
+			fmt.Println("  KEPT: other admins exist, only this user's membership is removed.")
+			if org.Creator == user.Email {
+				fmt.Println("  NOTE: the creator email stays (the org signing key is derived from it);")
+				fmt.Println("        follow up manually if it must be redacted.")
+			}
+			continue
+		}
+		fmt.Println("  DELETED ENTIRELY: this user is its only admin. This removes:")
+		if err := printOrgContents(ms, userOrg.Address); err != nil {
+			return err
+		}
+	}
+	fmt.Println("\nAlso deleted: invitations sent to or issued by the user,")
+	fmt.Println("pending verification codes, and the user account itself.")
+	fmt.Println("Not touched: Stripe billing data and database backups.")
+	return nil
+}
+
+// printOrgContents prints how much data an organization about to be torn down
+// currently holds.
+func printOrgContents(ms *db.MongoStorage, address common.Address) error {
+	members, err := ms.CountOrgMembers(address)
+	if err != nil {
+		return fmt.Errorf("could not count members of org %s: %w", address, err)
+	}
+	groups, _, err := ms.OrganizationMemberGroups(address, 1, 1)
+	if err != nil {
+		return fmt.Errorf("could not count groups of org %s: %w", address, err)
+	}
+	censuses, err := ms.CensusesByOrg(address)
+	if err != nil {
+		return fmt.Errorf("could not list censuses of org %s: %w", address, err)
+	}
+	var participants int64
+	for _, census := range censuses {
+		n, err := ms.CountCensusParticipants(census.ID.Hex())
+		if err != nil {
+			return fmt.Errorf("could not count participants of census %s: %w", census.ID.Hex(), err)
+		}
+		participants += n
+	}
+	processes, err := ms.CountProcesses(address, db.AllProcesses)
+	if err != nil {
+		return fmt.Errorf("could not count processes of org %s: %w", address, err)
+	}
+	bundles, err := ms.ProcessBundlesByOrg(address)
+	if err != nil {
+		return fmt.Errorf("could not list bundles of org %s: %w", address, err)
+	}
+	invites, err := ms.PendingInvitations(address)
+	if err != nil {
+		return fmt.Errorf("could not list invitations of org %s: %w", address, err)
+	}
+	fmt.Printf("    the organization and its voting history metadata (%d processes, %d bundles)\n",
+		processes, len(bundles))
+	fmt.Printf("    %d members in %d groups\n", members, groups)
+	fmt.Printf("    %d censuses with %d participants (incl. their CSP auth tokens)\n",
+		len(censuses), participants)
+	fmt.Printf("    %d pending invitations, plus import jobs\n", len(invites))
+	return nil
+}
+
+// resolveUser looks the user up by ID when provided, otherwise by email.
+func resolveUser(ms *db.MongoStorage, email string, id uint64) (*db.User, error) {
+	if id != 0 {
+		return ms.User(id)
+	}
+	return ms.UserByEmail(email)
+}
+
+// confirm asks the operator to type "yes" before proceeding.
+func confirm() bool {
+	fmt.Print("type 'yes' to proceed: ")
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(line) == "yes"
+}

--- a/db/organization_invites.go
+++ b/db/organization_invites.go
@@ -204,3 +204,29 @@ func (ms *MongoStorage) DeleteInvitationsByOrg(orgAddress common.Address) (int64
 	}
 	return res.DeletedCount, nil
 }
+
+// DeleteInvitationsByUser removes every invitation addressed to the given email
+// or issued by the given user ID. Used when erasing a user, so no invitation
+// keeps their personal data or a dangling issuer reference. Returns the number
+// of deleted invitations.
+func (ms *MongoStorage) DeleteInvitationsByUser(userID uint64, email string) (int64, error) {
+	var conditions []bson.M
+	if email != "" {
+		conditions = append(conditions, bson.M{"newUserEmail": email})
+	}
+	if userID != 0 {
+		conditions = append(conditions, bson.M{"currentUserID": userID})
+	}
+	if len(conditions) == 0 {
+		return 0, ErrInvalidData
+	}
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	res, err := ms.organizationInvites.DeleteMany(ctx, bson.M{"$or": conditions})
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete invitations by user: %w", err)
+	}
+	return res.DeletedCount, nil
+}

--- a/db/user_erase.go
+++ b/db/user_erase.go
@@ -1,0 +1,190 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/vocdoni/saas-backend/internal"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// UserErasureReport summarizes what EraseUser removed or kept, so the operator
+// running an erasure request has an audit trail of the outcome.
+type UserErasureReport struct {
+	UserID uint64
+	Email  string
+	// DeletedOrgs are organizations torn down entirely because the user was
+	// their sole admin.
+	DeletedOrgs []common.Address
+	// KeptOrgs are organizations that survive; only the user's membership was
+	// removed.
+	KeptOrgs []common.Address
+	// CreatorEmailRetained lists surviving organizations whose creator field
+	// still holds the erased user's email. It is retained deliberately: the
+	// organization signing key is derived from secret+creator+nonce (see
+	// account.OrganizationSigner), so redacting it would change the derived
+	// key and break the organization's on-chain account.
+	CreatorEmailRetained []common.Address
+}
+
+// IsSoleOrgAdmin reports whether the user holds the admin role in the
+// organization and no other user does.
+func (ms *MongoStorage) IsSoleOrgAdmin(address common.Address, userID uint64) (bool, error) {
+	users, err := ms.OrganizationUsers(address)
+	if err != nil {
+		return false, fmt.Errorf("could not get organization users: %w", err)
+	}
+	userIsAdmin, othersAreAdmin := false, false
+	for _, u := range users {
+		for _, o := range u.Organizations {
+			if o.Address == address && o.Role == AdminRole {
+				if u.ID == userID {
+					userIsAdmin = true
+				} else {
+					othersAreAdmin = true
+				}
+			}
+		}
+	}
+	return userIsAdmin && !othersAreAdmin, nil
+}
+
+// EraseUser removes a registered user and their personal data (right to
+// erasure). Organizations where the user is the sole admin are torn down
+// entirely (members, groups, censuses, participants, processes, bundles, CSP
+// tokens, jobs, invitations); in organizations with other admins only the
+// user's membership is removed. Invitations addressed to or issued by the
+// user, their verification codes and the user document itself are deleted.
+// Each step is best-effort: failures are accumulated and returned joined, so a
+// single stuck collection cannot leave the erasure silently half-done.
+func (ms *MongoStorage) EraseUser(userID uint64) (*UserErasureReport, error) {
+	user, err := ms.User(userID)
+	if err != nil {
+		return nil, fmt.Errorf("could not fetch user: %w", err)
+	}
+	report := &UserErasureReport{UserID: user.ID, Email: user.Email}
+	var errs []error
+	for _, userOrg := range user.Organizations {
+		soleAdmin, err := ms.IsSoleOrgAdmin(userOrg.Address, user.ID)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("classifying org %s: %w", userOrg.Address, err))
+			continue
+		}
+		if soleAdmin {
+			if err := ms.eraseOrgData(userOrg.Address); err != nil {
+				errs = append(errs, fmt.Errorf("tearing down org %s: %w", userOrg.Address, err))
+			}
+			report.DeletedOrgs = append(report.DeletedOrgs, userOrg.Address)
+			continue
+		}
+		if err := ms.RemoveOrganizationUser(userOrg.Address, user.ID); err != nil {
+			errs = append(errs, fmt.Errorf("removing membership in org %s: %w", userOrg.Address, err))
+		}
+		if err := ms.DecrementOrganizationUsersCounter(userOrg.Address); err != nil {
+			errs = append(errs, fmt.Errorf("decrementing users counter of org %s: %w", userOrg.Address, err))
+		}
+		report.KeptOrgs = append(report.KeptOrgs, userOrg.Address)
+		if org, err := ms.Organization(userOrg.Address); err == nil && org.Creator == user.Email {
+			report.CreatorEmailRetained = append(report.CreatorEmailRetained, userOrg.Address)
+		}
+	}
+	// invitations addressed to the user or issued by them
+	if _, err := ms.DeleteInvitationsByUser(user.ID, user.Email); err != nil {
+		errs = append(errs, fmt.Errorf("deleting invitations: %w", err))
+	}
+	// verification codes of any type
+	if err := ms.deleteAllVerificationCodes(user.ID); err != nil {
+		errs = append(errs, fmt.Errorf("deleting verification codes: %w", err))
+	}
+	// the user document itself (email, names, password hash, oauth data, roles)
+	if err := ms.DelUser(user); err != nil {
+		errs = append(errs, fmt.Errorf("deleting user document: %w", err))
+	}
+	return report, errors.Join(errs...)
+}
+
+// deleteAllVerificationCodes removes every verification code of the user,
+// regardless of type.
+func (ms *MongoStorage) deleteAllVerificationCodes(userID uint64) error {
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	_, err := ms.verifications.DeleteMany(ctx, bson.M{"_id": userID})
+	return err
+}
+
+// eraseOrgData tears down every collection owned by the organization and
+// finally the organization document itself. It mirrors the cascade used by the
+// managed-organization deletion handler, minus the on-chain election guards
+// (erasure is an operator decision, not an API call). Failures are accumulated
+// so one stuck collection does not abort the rest of the teardown.
+func (ms *MongoStorage) eraseOrgData(address common.Address) error {
+	var errs []error
+	bundles, err := ms.ProcessBundlesByOrg(address)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("listing process bundles: %w", err))
+	}
+	for _, b := range bundles {
+		// match the encoding used by csp/handlers parseBundleID (hex-decoded ObjectID bytes)
+		bundleID := new(internal.HexBytes)
+		if err := bundleID.ParseString(b.ID.Hex()); err != nil {
+			errs = append(errs, fmt.Errorf("encoding bundle id %s: %w", b.ID.Hex(), err))
+			continue
+		}
+		if _, err := ms.DeleteCSPAuthByBundle(*bundleID); err != nil {
+			errs = append(errs, fmt.Errorf("deleting CSP auth tokens of bundle %s: %w", b.ID.Hex(), err))
+		}
+	}
+	published, err := ms.AllProcessesByOrg(address, PublishedOnly)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("listing published processes: %w", err))
+	}
+	for _, p := range published {
+		if p.Address.Equals(nil) {
+			continue
+		}
+		if _, err := ms.DeleteCSPProcessByProcess(p.Address); err != nil {
+			errs = append(errs, fmt.Errorf("deleting CSP status of process %s: %w", p.Address.String(), err))
+		}
+	}
+	if _, err := ms.DeleteProcessBundlesByOrg(address); err != nil {
+		errs = append(errs, fmt.Errorf("deleting process bundles: %w", err))
+	}
+	censuses, err := ms.CensusesByOrg(address)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("listing censuses: %w", err))
+	}
+	for _, c := range censuses {
+		if _, err := ms.DeleteCensusParticipantsByCensus(c.ID.Hex()); err != nil {
+			errs = append(errs, fmt.Errorf("deleting participants of census %s: %w", c.ID.Hex(), err))
+		}
+		if err := ms.DelCensus(c.ID.Hex()); err != nil {
+			errs = append(errs, fmt.Errorf("deleting census %s: %w", c.ID.Hex(), err))
+		}
+	}
+	if _, err := ms.DeleteProcessesByOrg(address); err != nil {
+		errs = append(errs, fmt.Errorf("deleting processes: %w", err))
+	}
+	if _, err := ms.DeleteAllOrgMemberGroups(address); err != nil {
+		errs = append(errs, fmt.Errorf("deleting member groups: %w", err))
+	}
+	if _, err := ms.DeleteAllOrgMembers(address); err != nil {
+		errs = append(errs, fmt.Errorf("deleting members: %w", err))
+	}
+	if _, err := ms.DeleteJobsByOrg(address); err != nil {
+		errs = append(errs, fmt.Errorf("deleting jobs: %w", err))
+	}
+	if _, err := ms.DeleteInvitationsByOrg(address); err != nil {
+		errs = append(errs, fmt.Errorf("deleting invitations: %w", err))
+	}
+	if err := ms.RemoveOrganizationFromAllUsers(address); err != nil {
+		errs = append(errs, fmt.Errorf("unlinking organization from users: %w", err))
+	}
+	if err := ms.DelOrganization(&Organization{Address: address}); err != nil {
+		errs = append(errs, fmt.Errorf("deleting organization document: %w", err))
+	}
+	return errors.Join(errs...)
+}

--- a/db/user_erase_test.go
+++ b/db/user_erase_test.go
@@ -1,0 +1,102 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	qt "github.com/frankban/quicktest"
+)
+
+// TestEraseUser covers the right-to-erasure cascade: an org where the user is
+// the sole admin is torn down entirely, an org with another admin survives
+// with only the membership removed (creator email retained), and the user's
+// invitations, verification codes and document are deleted.
+func TestEraseUser(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	// target user and a second admin
+	target := &User{Email: "target@test.com", Password: "pass", FirstName: "Tar", LastName: "Get", Verified: true}
+	targetID, err := testDB.SetUser(target)
+	c.Assert(err, qt.IsNil)
+	target.ID = targetID
+	other := &User{Email: "other@test.com", Password: "pass", FirstName: "Oth", LastName: "Er", Verified: true}
+	otherID, err := testDB.SetUser(other)
+	c.Assert(err, qt.IsNil)
+
+	// orgA: target is creator and sole admin, with member, census, participant and invite
+	orgA := common.Address{0x0A}
+	c.Assert(testDB.SetOrganization(&Organization{Address: orgA, Creator: target.Email, Country: "ES"}), qt.IsNil)
+	memberID, censusID := seedMemberAndCensus(t, orgA, "erase-a")
+	c.Assert(testDB.SetCensusParticipant(&CensusParticipant{
+		ParticipantID: memberID.Hex(),
+		CensusID:      censusID.Hex(),
+		CreatedAt:     time.Now(),
+	}), qt.IsNil)
+	c.Assert(testDB.CreateInvitation(&OrganizationInvite{
+		InvitationCode:      "erasecodea",
+		OrganizationAddress: orgA,
+		CurrentUserID:       targetID,
+		NewUserEmail:        "newcomer@test.com",
+		Role:                AdminRole,
+		Expiration:          time.Now().Add(time.Hour),
+	}), qt.IsNil)
+
+	// orgB: target is creator and admin, but other is admin too
+	orgB := common.Address{0x0B}
+	c.Assert(testDB.SetOrganization(&Organization{Address: orgB, Creator: target.Email, Country: "ES"}), qt.IsNil)
+	other.ID = otherID
+	other.Organizations = []OrganizationUser{{Address: orgB, Role: AdminRole}}
+	_, err = testDB.SetUser(other)
+	c.Assert(err, qt.IsNil)
+	// an invitation addressed to the target
+	c.Assert(testDB.CreateInvitation(&OrganizationInvite{
+		InvitationCode:      "erasecodeb",
+		OrganizationAddress: orgB,
+		CurrentUserID:       otherID,
+		NewUserEmail:        target.Email,
+		Role:                ManagerRole,
+		Expiration:          time.Now().Add(time.Hour),
+	}), qt.IsNil)
+
+	// a pending verification code for the target
+	c.Assert(testDB.SetVerificationCode(target, []byte("sealed"), CodeTypePasswordReset, time.Now().Add(time.Hour)), qt.IsNil)
+
+	report, err := testDB.EraseUser(targetID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(report.DeletedOrgs, qt.DeepEquals, []common.Address{orgA})
+	c.Assert(report.KeptOrgs, qt.DeepEquals, []common.Address{orgB})
+	c.Assert(report.CreatorEmailRetained, qt.DeepEquals, []common.Address{orgB})
+
+	// the user and their verification code are gone
+	_, err = testDB.User(targetID)
+	c.Assert(err, qt.Equals, ErrNotFound)
+	_, err = testDB.UserVerificationCode(target, CodeTypePasswordReset)
+	c.Assert(err, qt.Equals, ErrNotFound)
+
+	// orgA and everything it owned are gone
+	_, err = testDB.Organization(orgA)
+	c.Assert(err, qt.Equals, ErrNotFound)
+	membersA, err := testDB.CountOrgMembers(orgA)
+	c.Assert(err, qt.IsNil)
+	c.Assert(membersA, qt.Equals, int64(0))
+	participantsA, err := testDB.CountCensusParticipants(censusID.Hex())
+	c.Assert(err, qt.IsNil)
+	c.Assert(participantsA, qt.Equals, int64(0))
+
+	// both invitations (issued by and addressed to the target) are gone
+	_, err = testDB.InvitationByCode("erasecodea")
+	c.Assert(err, qt.Equals, ErrNotFound)
+	_, err = testDB.InvitationByCode("erasecodeb")
+	c.Assert(err, qt.Equals, ErrNotFound)
+
+	// orgB survives with the other admin only, creator email retained
+	orgBDoc, err := testDB.Organization(orgB)
+	c.Assert(err, qt.IsNil)
+	c.Assert(orgBDoc.Creator, qt.Equals, target.Email)
+	usersB, err := testDB.OrganizationUsers(orgB)
+	c.Assert(err, qt.IsNil)
+	c.Assert(usersB, qt.HasLen, 1)
+	c.Assert(usersB[0].ID, qt.Equals, otherID)
+}


### PR DESCRIPTION
## What

Adds a standardized way to serve GDPR right-to-erasure requests for registered users, instead of ad-hoc manual Mongo surgery.

- **`db.EraseUser(userID)`** — the erasure cascade:
  - Organizations where the user is the **sole admin** are torn down entirely: members, groups, censuses, census participants, processes, bundles, CSP auth tokens/status, jobs, invitations, and finally the org document. Reuses the same per-collection delete methods as the managed-org deletion handler (`deleteManagedOrganizationHandler`), no new deletion logic.
  - Organizations with **other admins** survive: only the user's membership is removed and the org users counter decremented.
  - Always deleted: invitations addressed to or issued by the user (new `DeleteInvitationsByUser`), verification codes of any type, and the user document itself (email, names, password hash, OAuth data — org roles are embedded there too).
  - Every step is best-effort; failures are accumulated with `errors.Join` and returned, so one stuck collection can't leave the erasure silently half-done. Returns a `UserErasureReport` for auditing.
- **`cmd/userdel`** — operator CLI: resolves the user by `-email` or `-id`, prints the erasure plan (which orgs get deleted vs. kept), asks for confirmation (`-yes` to skip), runs the erasure and prints the report.

## ⚠️ Deliberate deviation: creator email is retained on surviving orgs

The original request included redacting `organizations.creator`. This PR intentionally does **not** do that for surviving organizations: the org signing key is derived as `SHA256(secret + creatorEmail + nonce)` (`account.OrganizationSigner`) from the **current** DB value at every signing call (e.g. `api/transaction.go:68`). Redacting the creator email would silently change the derived key and the organization would lose control of its on-chain account.

Instead, surviving orgs created by the erased user are listed in the report (`CreatorEmailRetained`) with a warning for manual follow-up. For sole-admin orgs this is moot — the org document is deleted.

Related pre-existing bug (not touched here, deserves its own issue): `updateUserInfoHandler` calls `ReplaceCreatorEmail` on email change (`api/users.go:499`), which already breaks org signing for the same reason.

## Out of scope (by agreement)

- Stripe customer data (external; handle per-case, billing records have their own retention rules)
- Database backups (covered by retention policy, not dump rewriting)
- Sub-organizations pointing at a deleted parent are not re-parented

## Testing

- `TestEraseUser` integration test: sole-admin org fully torn down (members, participants, invites), shared org survives with only the other admin, creator retained, verification codes and user doc gone.
- `go vet`, `gofumpt`, `scripts/check-qt-patterns.sh` clean. Local `golangci-lint` binary can't run against Go 1.26 — relying on CI for lint.