### PR TITLE
fix(processes)!: keep a question's ballot type and raw protocol in sync

### DIFF
--- a/account/ballot.go
+++ b/account/ballot.go
@@ -203,10 +203,15 @@ type BallotShape struct {
 // Either way the result round-trips — which is what lets a client edit a question through either
 // half alone, and what keeps the API's answer equal to what the election will be.
 //
-// MinChoices is the one thing that cannot be derived, having no on-chain counterpart. It is
-// carried over from the input only when the resolved type is the type the input asked for, and
-// clamped to the resolved MaxChoices; a minimum stated against a shape the caller did not get
-// would be a UI enforcing a rule the ballot does not have.
+// Supplying both halves is only allowed when they agree, or when the protocol has no named shape
+// (the ranked ballot a client may still label singlechoice). Two named shapes that disagree are an
+// error rather than a silent win for the protocol: a client editing a question through its
+// TypeSetup would otherwise get a 200 and none of its edit.
+//
+// MinChoices is the one thing that cannot be derived, having no on-chain counterpart, and is
+// carried over from the input for multichoice only, clamped to the resolved MaxChoices. A
+// singlechoice ballot is the single field a voter always fills, so its minimum is canonically 1;
+// storing the 0 a caller gets by omitting TypeSetup would state a rule the ballot does not have.
 //
 // A question with no choices yet is returned untouched: it cannot be published (publish
 // validation rejects it) and there is nothing to derive a protocol from.
@@ -226,7 +231,22 @@ func ResolveBallotShape(in BallotShapeInput) (BallotShape, error) {
 	if !ok {
 		return BallotShape{Protocol: protocol}, nil
 	}
-	if qType == in.Type {
+	// Both halves supplied and both name a ballot: they have to name the same one. The protocol
+	// wins, so without this a client that reads a draft, edits its typeSetup and PUTs the whole
+	// body back would lose the edit silently — responses always carry a protocol now.
+	if in.Protocol != nil && in.Type != "" {
+		stated, err := BallotProtocolFromType(in.Type, in.TypeSetup, in.Choices)
+		if err == nil && *stated != *in.Protocol {
+			return BallotShape{}, fmt.Errorf(
+				"ballotProtocol describes a %s ballot, which contradicts the stated type %q and its typeSetup; "+
+					"omit ballotProtocol to define the ballot through type/typeSetup", qType, in.Type,
+			)
+		}
+	}
+	// MinChoices is the client's alone — the protocol has no counterpart to check it against. It is
+	// only meaningful for multichoice: a singlechoice ballot is the one field a voter always fills,
+	// so its minimum is canonically 1 whatever the caller stated.
+	if qType == in.Type && qType == db.VotingTypeMultiChoice {
 		setup.MinChoices = min(in.TypeSetup.MinChoices, setup.MaxChoices)
 	}
 	return BallotShape{Type: qType, TypeSetup: setup, Protocol: protocol}, nil

--- a/account/ballot.go
+++ b/account/ballot.go
@@ -12,9 +12,14 @@ import (
 // BallotProtocolFromType is the single mapping table, and the reverse direction is defined as
 // equality against it — QuestionTypeFromBallotProtocol asks "which named type would produce
 // exactly this protocol?". So the two can never drift apart, and ResolveBallotShape can fill in
-// whichever half a client left out. What is stored obeys:
+// whichever half a client left out. What is stored obeys, for any question with choices:
 //
 //	Type != "" ⇒ BallotProtocolFromType(Type, TypeSetup, Choices) == *BallotProtocol
+//
+// A question with no choices yet is the one carve-out: there is no ballot to derive either half
+// from, so a draft can be stored with neither a protocol nor a satisfied invariant. It cannot be
+// published (publish validation rejects a choiceless question), and adding its choices reconciles
+// it.
 //
 // Which matters because a question is immutable once published: a stored shape that disagreed
 // with the election it minted would go on disagreeing forever, and the API would keep serving
@@ -189,6 +194,10 @@ type BallotShapeInput struct {
 
 // BallotShape is a reconciled ballot specification, safe to store: Protocol is set, and when Type
 // is non-empty it re-derives Protocol exactly.
+//
+// Both hold for every question that has choices. For a choiceless one there is nothing to derive a
+// ballot from, so ResolveBallotShape passes the input through and Protocol stays whatever the
+// caller had — nil, if they supplied none.
 type BallotShape struct {
 	Type      string
 	TypeSetup db.QuestionTypeSetup

--- a/account/ballot.go
+++ b/account/ballot.go
@@ -6,50 +6,230 @@ import (
 	"github.com/vocdoni/saas-backend/db"
 )
 
-// VoteTypeFromQuestion translates a voting-process question's friendly ballot type into
-// the on-chain vote options (db.VoteType). A non-nil BallotProtocol is a raw override and
-// takes priority over Type/TypeSetup. singlechoice picks one of N choices (one field,
-// value = chosen index); multichoice is approval-style (one field per choice, each 0/1,
-// with MaxTotalCost bounding the number of selections). minChoices is a validation hint
-// only — the current protocol has no on-chain minimum-count field.
+// A question describes its ballot twice: as a named type (singlechoice/multichoice) with its
+// TypeSetup, and as a raw BallotProtocol. This file keeps the two halves in step.
+//
+// BallotProtocolFromType is the single mapping table, and the reverse direction is defined as
+// equality against it — QuestionTypeFromBallotProtocol asks "which named type would produce
+// exactly this protocol?". So the two can never drift apart, and ResolveBallotShape can fill in
+// whichever half a client left out. What is stored obeys:
+//
+//	Type != "" ⇒ BallotProtocolFromType(Type, TypeSetup, Choices) == *BallotProtocol
+//
+// Which matters because a question is immutable once published: a stored shape that disagreed
+// with the election it minted would go on disagreeing forever, and the API would keep serving
+// the half that was not used.
+
+// VoteTypeFromQuestion translates a question's ballot specification into the on-chain vote
+// options (db.VoteType). Questions written since the two halves were reconciled always carry a
+// BallotProtocol, and it is authoritative; a legacy question carrying only Type/TypeSetup is
+// translated through BallotProtocolFromType.
+//
+// Note that path never turns TypeSetup.UniqueChoices into an on-chain uniqueValues flag, unlike
+// the mapping it replaces: on the dense multichoice layout that combination admits no valid
+// ballot at all and tallies silently to zero (issue #619).
 func VoteTypeFromQuestion(q *db.VotingProcessQuestion) (db.VoteType, error) {
-	if q.BallotProtocol != nil {
-		bp := q.BallotProtocol
-		return db.VoteType{
-			MaxCount:          bp.MaxCount,
-			MaxValue:          bp.MaxValue,
-			MaxVoteOverwrites: bp.MaxVoteOverwrites,
-			CostFromWeight:    bp.CostFromWeight,
-			CostExponent:      bp.CostExponent,
-			UniqueChoices:     bp.UniqueValues,
-			MaxTotalCost:      bp.MaxTotalCost,
-		}, nil
+	bp := q.BallotProtocol
+	if bp == nil {
+		derived, err := BallotProtocolFromType(q.Type, q.TypeSetup, q.Choices)
+		if err != nil {
+			return db.VoteType{}, err
+		}
+		bp = derived
 	}
-	if len(q.Choices) == 0 {
-		return db.VoteType{}, fmt.Errorf("question has no choices")
+	return db.VoteType{
+		MaxCount:          bp.MaxCount,
+		MaxValue:          bp.MaxValue,
+		MaxVoteOverwrites: bp.MaxVoteOverwrites,
+		CostFromWeight:    bp.CostFromWeight,
+		CostExponent:      bp.CostExponent,
+		UniqueChoices:     bp.UniqueValues,
+		MaxTotalCost:      bp.MaxTotalCost,
+	}, nil
+}
+
+// BallotProtocolFromType derives the canonical on-chain ballot parameters of a named question
+// type. singlechoice picks one of N choices (one field, value = the chosen Choice.Value);
+// multichoice is approval-style (one field per choice, each 0/1, with MaxTotalCost bounding the
+// number of selections).
+//
+// setup.MinChoices has no protocol counterpart and is ignored — the chain has no minimum-count
+// field. setup.UniqueChoices is ignored too: a named type never produces a unique-values ballot,
+// because on the multichoice layout it would admit no vote (#619) and on singlechoice it is
+// vacuous. Callers reject it at the API boundary rather than silently dropping it.
+//
+// MaxVoteOverwrites and CostFromWeight are always zero here: QuestionTypeSetup has no field that
+// could express them, so a protocol carrying either is simply not a named shape.
+func BallotProtocolFromType(
+	qType string, setup db.QuestionTypeSetup, choices []db.Choice,
+) (*db.BallotProtocol, error) {
+	if len(choices) == 0 {
+		return nil, fmt.Errorf("question has no choices")
 	}
-	switch q.Type {
+	switch qType {
 	case db.VotingTypeSingleChoice:
 		// MaxValue must cover the highest client-supplied Choice.Value, which need not be a
 		// contiguous 0..n-1 range, so derive it from the actual values rather than the count.
 		var maxValue uint32
-		for i := range q.Choices {
-			if v := q.Choices[i].Value; v > maxValue {
+		for i := range choices {
+			if v := choices[i].Value; v > maxValue {
 				maxValue = v
 			}
 		}
-		return db.VoteType{MaxCount: 1, MaxValue: maxValue}, nil
+		return &db.BallotProtocol{MaxCount: 1, MaxValue: maxValue}, nil
 	case db.VotingTypeMultiChoice:
-		return db.VoteType{
-			MaxCount:      uint32(len(q.Choices)),
-			MaxValue:      1,
-			CostExponent:  1,
-			MaxTotalCost:  q.TypeSetup.MaxChoices,
-			UniqueChoices: q.TypeSetup.UniqueChoices,
+		return &db.BallotProtocol{
+			MaxCount:     uint32(len(choices)),
+			MaxValue:     1,
+			CostExponent: 1,
+			MaxTotalCost: setup.MaxChoices,
 		}, nil
 	default:
-		return db.VoteType{}, fmt.Errorf("unsupported question type %q", q.Type)
+		return nil, fmt.Errorf("unsupported question type %q", qType)
 	}
+}
+
+// QuestionTypeFromBallotProtocol recognises the named question type, and the canonical TypeSetup
+// that goes with it, encoded by a raw ballot protocol over the given choices. A shape is
+// recognised only when BallotProtocolFromType reproduces the protocol exactly, so a recognised
+// type is guaranteed to re-derive the same on-chain parameters.
+//
+// ok is false for the shapes that have no named type — ranked, quadratic, anything using vote
+// overwrites or weighted cost — which stay expressible as a raw protocol.
+//
+// The choices are part of the question: a protocol whose MaxValue cannot carry the highest
+// Choice.Value is not singlechoice over those choices, however much it looks like one.
+func QuestionTypeFromBallotProtocol(
+	bp *db.BallotProtocol, choices []db.Choice,
+) (string, db.QuestionTypeSetup, bool) {
+	if bp == nil || len(choices) == 0 {
+		return "", db.QuestionTypeSetup{}, false
+	}
+	// At most one candidate can ever match, whatever the order: CostExponent is unconditionally
+	// 0 for singlechoice and 1 for multichoice, so their images are always distinct.
+	candidates := []struct {
+		qType string
+		setup db.QuestionTypeSetup
+	}{
+		{db.VotingTypeSingleChoice, db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1}},
+		{db.VotingTypeMultiChoice, db.QuestionTypeSetup{
+			MinChoices: minChoicesFor(bp.MaxTotalCost),
+			MaxChoices: bp.MaxTotalCost,
+		}},
+	}
+	for _, candidate := range candidates {
+		derived, err := BallotProtocolFromType(candidate.qType, candidate.setup, choices)
+		if err == nil && *derived == *bp {
+			return candidate.qType, candidate.setup, true
+		}
+	}
+	return "", db.QuestionTypeSetup{}, false
+}
+
+// minChoicesFor returns the canonical minimum for a bounded selection, keeping the invariant
+// MinChoices <= MaxChoices true for an unbounded (MaxChoices 0) multichoice.
+func minChoicesFor(maxChoices uint32) uint32 {
+	if maxChoices == 0 {
+		return 0
+	}
+	return 1
+}
+
+// ValidateBallotProtocol reports why a raw ballot protocol could never yield a countable ballot.
+//
+// It checks unsatisfiability only, never plausibility: shapes with no named type are exactly what
+// the raw protocol is for, so anything a voter could actually satisfy has to stay expressible. A
+// protocol that fails here mints an election that accepts votes and tallies them to zero, which
+// nothing downstream reports as an error.
+func ValidateBallotProtocol(bp *db.BallotProtocol) error {
+	if bp == nil {
+		return nil
+	}
+	if bp.MaxCount == 0 {
+		return fmt.Errorf("maxCount must be greater than zero")
+	}
+	// uniqueValues demands every field of the ballot hold a distinct value, so there have to be
+	// at least as many legal values (0..maxValue) as there are fields. A dense layout with
+	// maxValue 1 and more than two fields is the #619 shape: unsatisfiable by pigeonhole, for
+	// any ballot a voter could send. Widened to uint64 so maxValue = MaxUint32 does not wrap.
+	if bp.UniqueValues && uint64(bp.MaxValue)+1 < uint64(bp.MaxCount) {
+		return fmt.Errorf(
+			"uniqueValues requires maxValue+1 (%d) to be at least maxCount (%d): no ballot can "+
+				"fill %d fields with distinct values drawn from 0..%d",
+			uint64(bp.MaxValue)+1, bp.MaxCount, bp.MaxCount, bp.MaxValue,
+		)
+	}
+	return nil
+}
+
+// EffectiveQuestionType returns the named ballot type a stored question actually encodes: the one
+// inferred from its protocol when it has one — which is empty for a shape with no named type —
+// and otherwise its stored Type.
+//
+// A stored Type is only a label. Questions written before the two halves were reconciled may
+// carry one that contradicts their protocol, and it is the protocol that reaches the chain, so
+// anything deciding on the ballot's identity (the plan's voting-type gate) has to ask this rather
+// than read q.Type.
+func EffectiveQuestionType(q *db.VotingProcessQuestion) string {
+	if q.BallotProtocol == nil {
+		return q.Type
+	}
+	qType, _, _ := QuestionTypeFromBallotProtocol(q.BallotProtocol, q.Choices)
+	return qType
+}
+
+// BallotShapeInput is a question's ballot specification as a client supplied it: either half may
+// be missing, and when both are present they may disagree.
+type BallotShapeInput struct {
+	Type      string
+	TypeSetup db.QuestionTypeSetup
+	Protocol  *db.BallotProtocol
+	Choices   []db.Choice
+}
+
+// BallotShape is a reconciled ballot specification, safe to store: Protocol is set, and when Type
+// is non-empty it re-derives Protocol exactly.
+type BallotShape struct {
+	Type      string
+	TypeSetup db.QuestionTypeSetup
+	Protocol  *db.BallotProtocol
+}
+
+// ResolveBallotShape reconciles a question's named type with its raw ballot protocol so the two
+// halves cannot disagree in storage.
+//
+// A supplied protocol is authoritative: Type and TypeSetup are re-derived from it, and both go
+// empty when it encodes no named shape. Otherwise the protocol is derived from Type/TypeSetup.
+// Either way the result round-trips — which is what lets a client edit a question through either
+// half alone, and what keeps the API's answer equal to what the election will be.
+//
+// MinChoices is the one thing that cannot be derived, having no on-chain counterpart. It is
+// carried over from the input only when the resolved type is the type the input asked for, and
+// clamped to the resolved MaxChoices; a minimum stated against a shape the caller did not get
+// would be a UI enforcing a rule the ballot does not have.
+//
+// A question with no choices yet is returned untouched: it cannot be published (publish
+// validation rejects it) and there is nothing to derive a protocol from.
+func ResolveBallotShape(in BallotShapeInput) (BallotShape, error) {
+	if len(in.Choices) == 0 {
+		return BallotShape{Type: in.Type, TypeSetup: in.TypeSetup, Protocol: in.Protocol}, nil
+	}
+	protocol := in.Protocol
+	if protocol == nil {
+		derived, err := BallotProtocolFromType(in.Type, in.TypeSetup, in.Choices)
+		if err != nil {
+			return BallotShape{}, err
+		}
+		protocol = derived
+	}
+	qType, setup, ok := QuestionTypeFromBallotProtocol(protocol, in.Choices)
+	if !ok {
+		return BallotShape{Protocol: protocol}, nil
+	}
+	if qType == in.Type {
+		setup.MinChoices = min(in.TypeSetup.MinChoices, setup.MaxChoices)
+	}
+	return BallotShape{Type: qType, TypeSetup: setup, Protocol: protocol}, nil
 }
 
 // ElectionTypeFromQuestion builds the on-chain election flags for a question. autostart and

--- a/account/ballot_test.go
+++ b/account/ballot_test.go
@@ -1,6 +1,7 @@
 package account
 
 import (
+	"math"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -387,6 +388,8 @@ func TestValidateBallotProtocol(t *testing.T) {
 			"issue 619 in raw form":      {MaxCount: 4, MaxValue: 1, UniqueValues: true},
 			"two fields, one value":      {MaxCount: 2, MaxValue: 0, UniqueValues: true},
 			"one short of a permutation": {MaxCount: 4, MaxValue: 2, UniqueValues: true},
+			// one value short of a permutation, at the top of the uint32 range
+			"one short at the uint32 ceiling": {MaxCount: math.MaxUint32, MaxValue: math.MaxUint32 - 2, UniqueValues: true},
 		} {
 			c.Assert(ValidateBallotProtocol(bp), qt.Not(qt.IsNil), qt.Commentf("%s", name))
 		}
@@ -399,6 +402,9 @@ func TestValidateBallotProtocol(t *testing.T) {
 			"singlechoice":          {MaxCount: 1, MaxValue: 2},
 			"multichoice":           {MaxCount: 4, MaxValue: 1, CostExponent: 1, MaxTotalCost: 2},
 			"quadratic":             {MaxCount: 3, MaxValue: 4, CostExponent: 2, MaxTotalCost: 12},
+			// exactly enough values for the fields, where maxValue+1 overflows uint32: computed in
+			// uint32 it wraps to 0 and this permutation reads as unsatisfiable
+			"permutation at the uint32 ceiling": {MaxCount: math.MaxUint32, MaxValue: math.MaxUint32, UniqueValues: true},
 		} {
 			c.Assert(ValidateBallotProtocol(bp), qt.IsNil, qt.Commentf("%s", name))
 		}

--- a/account/ballot_test.go
+++ b/account/ballot_test.go
@@ -41,7 +41,11 @@ func TestVoteTypeFromQuestion(t *testing.T) {
 		c.Assert(vt.MaxValue, qt.Equals, uint32(1))
 		c.Assert(vt.CostExponent, qt.Equals, uint32(1))
 		c.Assert(vt.MaxTotalCost, qt.Equals, uint32(2)) // maxChoices
-		c.Assert(vt.UniqueChoices, qt.IsTrue)
+		// A legacy question stored before uniqueChoices was rejected keeps the flag in its
+		// TypeSetup, and publishing it must ignore it: one 0/1 field per choice plus
+		// uniqueValues is unsatisfiable, so the election would tally every vote to zero (#619).
+		// Everything else about the ballot is unchanged, which the assertions above pin.
+		c.Assert(vt.UniqueChoices, qt.IsFalse)
 	})
 
 	c.Run("ballotProtocol overrides type/typeSetup", func(c *qt.C) {
@@ -106,4 +110,294 @@ func TestVoteTypeSingleChoiceNonContiguousValues(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(vt.MaxCount, qt.Equals, uint32(1))
 	c.Assert(vt.MaxValue, qt.Equals, uint32(5))
+}
+
+// valuedChoices builds choices with the given explicit values, for the cases where the values are
+// not the contiguous 0..n-1 that choices() produces.
+func valuedChoices(values ...uint32) []db.Choice {
+	out := make([]db.Choice, len(values))
+	for i, v := range values {
+		out[i] = db.Choice{Value: v}
+	}
+	return out
+}
+
+// TestBallotProtocolFromType pins the one mapping table the whole reconciliation rests on: every
+// other direction is defined as equality against this function's output.
+func TestBallotProtocolFromType(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("singlechoice ignores typeSetup entirely", func(c *qt.C) {
+		want := db.BallotProtocol{MaxCount: 1, MaxValue: 2}
+		for _, setup := range []db.QuestionTypeSetup{
+			{},
+			{MinChoices: 1, MaxChoices: 1},
+			{MinChoices: 3, MaxChoices: 7, UniqueChoices: true},
+		} {
+			bp, err := BallotProtocolFromType(db.VotingTypeSingleChoice, setup, choices(3))
+			c.Assert(err, qt.IsNil)
+			c.Assert(*bp, qt.Equals, want, qt.Commentf("setup %+v", setup))
+		}
+	})
+
+	c.Run("singlechoice covers the highest choice value", func(c *qt.C) {
+		bp, err := BallotProtocolFromType(db.VotingTypeSingleChoice, db.QuestionTypeSetup{},
+			valuedChoices(0, 2, 5))
+		c.Assert(err, qt.IsNil)
+		c.Assert(*bp, qt.Equals, db.BallotProtocol{MaxCount: 1, MaxValue: 5})
+	})
+
+	c.Run("multichoice is the dense layout, never unique", func(c *qt.C) {
+		// the uniqueChoices in the setup is the #619 shape and must not reach the protocol
+		bp, err := BallotProtocolFromType(db.VotingTypeMultiChoice,
+			db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 2, UniqueChoices: true}, choices(4))
+		c.Assert(err, qt.IsNil)
+		c.Assert(*bp, qt.Equals, db.BallotProtocol{
+			MaxCount: 4, MaxValue: 1, CostExponent: 1, MaxTotalCost: 2,
+		})
+	})
+
+	c.Run("errors", func(c *qt.C) {
+		_, err := BallotProtocolFromType(db.VotingTypeSingleChoice, db.QuestionTypeSetup{}, nil)
+		c.Assert(err, qt.Not(qt.IsNil))
+		_, err = BallotProtocolFromType("", db.QuestionTypeSetup{}, choices(2))
+		c.Assert(err, qt.Not(qt.IsNil))
+		_, err = BallotProtocolFromType("quadratic", db.QuestionTypeSetup{}, choices(2))
+		c.Assert(err, qt.Not(qt.IsNil))
+	})
+}
+
+// TestQuestionTypeFromBallotProtocol covers the reverse direction: which named type a raw protocol
+// encodes, and — more importantly — which ones it does not, since a shape wrongly given a name
+// would be a question describing a ballot it does not have.
+func TestQuestionTypeFromBallotProtocol(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("recognises the named shapes", func(c *qt.C) {
+		qType, setup, ok := QuestionTypeFromBallotProtocol(
+			&db.BallotProtocol{MaxCount: 1, MaxValue: 2}, choices(3))
+		c.Assert(ok, qt.IsTrue)
+		c.Assert(qType, qt.Equals, db.VotingTypeSingleChoice)
+		c.Assert(setup, qt.Equals, db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1})
+
+		qType, setup, ok = QuestionTypeFromBallotProtocol(
+			&db.BallotProtocol{MaxCount: 4, MaxValue: 1, CostExponent: 1, MaxTotalCost: 2}, choices(4))
+		c.Assert(ok, qt.IsTrue)
+		c.Assert(qType, qt.Equals, db.VotingTypeMultiChoice)
+		c.Assert(setup, qt.Equals, db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 2})
+	})
+
+	c.Run("an unbounded approval ballot is still multichoice", func(c *qt.C) {
+		qType, setup, ok := QuestionTypeFromBallotProtocol(
+			&db.BallotProtocol{MaxCount: 3, MaxValue: 1, CostExponent: 1}, choices(3))
+		c.Assert(ok, qt.IsTrue)
+		c.Assert(qType, qt.Equals, db.VotingTypeMultiChoice)
+		c.Assert(setup, qt.Equals, db.QuestionTypeSetup{MinChoices: 0, MaxChoices: 0})
+	})
+
+	c.Run("shapes with no named type", func(c *qt.C) {
+		for name, bp := range map[string]*db.BallotProtocol{
+			// a ranking: n fields each holding a distinct rank 0..n-1
+			"ranked":            {MaxCount: 3, MaxValue: 2, UniqueValues: true},
+			"vote overwrites":   {MaxCount: 1, MaxValue: 2, MaxVoteOverwrites: 1},
+			"weighted cost":     {MaxCount: 1, MaxValue: 2, CostFromWeight: true},
+			"quadratic":         {MaxCount: 3, MaxValue: 4, CostExponent: 2, MaxTotalCost: 12},
+			"padded max count":  {MaxCount: 9, MaxValue: 1, CostExponent: 1, MaxTotalCost: 2},
+			"cost on a single":  {MaxCount: 1, MaxValue: 2, CostExponent: 1},
+			"single with total": {MaxCount: 1, MaxValue: 2, MaxTotalCost: 1},
+		} {
+			_, _, ok := QuestionTypeFromBallotProtocol(bp, choices(3))
+			c.Assert(ok, qt.IsFalse, qt.Commentf("%s was given a name it does not have", name))
+		}
+	})
+
+	c.Run("a protocol that cannot carry the choice values is not singlechoice", func(c *qt.C) {
+		// maxValue 2 admits values 0..2, but the question offers a choice valued 5
+		_, _, ok := QuestionTypeFromBallotProtocol(
+			&db.BallotProtocol{MaxCount: 1, MaxValue: 2}, valuedChoices(0, 2, 5))
+		c.Assert(ok, qt.IsFalse)
+	})
+
+	c.Run("nothing to recognise", func(c *qt.C) {
+		_, _, ok := QuestionTypeFromBallotProtocol(nil, choices(3))
+		c.Assert(ok, qt.IsFalse)
+		_, _, ok = QuestionTypeFromBallotProtocol(&db.BallotProtocol{MaxCount: 1}, nil)
+		c.Assert(ok, qt.IsFalse)
+	})
+}
+
+// TestBallotShapeUnambiguous guards the property the reverse direction rests on: the two named
+// types never produce the same protocol, so recognition is a function rather than a first-match
+// heuristic. If a future field change breaks this, recognition starts depending on candidate
+// order and this fails before anything subtler does.
+func TestBallotShapeUnambiguous(t *testing.T) {
+	c := qt.New(t)
+	for n := 1; n <= 8; n++ {
+		for _, cs := range [][]db.Choice{choices(n), valuedChoices(0, 2, 5)[:min(n, 3)]} {
+			for maxChoices := range uint32(n + 1) {
+				single, err := BallotProtocolFromType(db.VotingTypeSingleChoice,
+					db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1}, cs)
+				c.Assert(err, qt.IsNil)
+				multi, err := BallotProtocolFromType(db.VotingTypeMultiChoice,
+					db.QuestionTypeSetup{MaxChoices: maxChoices}, cs)
+				c.Assert(err, qt.IsNil)
+				c.Assert(*single, qt.Not(qt.Equals), *multi,
+					qt.Commentf("n=%d maxChoices=%d", n, maxChoices))
+			}
+		}
+	}
+}
+
+// TestResolveBallotShapeRoundTrip is the invariant the whole change exists to establish: a
+// question authored through its named type comes back describing the same type, and carries the
+// protocol that type derives. Nothing a client states about the ballot is lost or altered.
+func TestResolveBallotShapeRoundTrip(t *testing.T) {
+	c := qt.New(t)
+	for _, in := range []BallotShapeInput{
+		{Type: db.VotingTypeSingleChoice, TypeSetup: db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1}, Choices: choices(1)},
+		{Type: db.VotingTypeSingleChoice, TypeSetup: db.QuestionTypeSetup{MinChoices: 0, MaxChoices: 1}, Choices: choices(4)},
+		{
+			Type: db.VotingTypeSingleChoice, TypeSetup: db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1},
+			Choices: valuedChoices(0, 2, 5),
+		},
+		{Type: db.VotingTypeMultiChoice, TypeSetup: db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1}, Choices: choices(1)},
+		{Type: db.VotingTypeMultiChoice, TypeSetup: db.QuestionTypeSetup{MinChoices: 0, MaxChoices: 2}, Choices: choices(4)},
+		{Type: db.VotingTypeMultiChoice, TypeSetup: db.QuestionTypeSetup{MinChoices: 4, MaxChoices: 4}, Choices: choices(4)},
+	} {
+		shape, err := ResolveBallotShape(in)
+		c.Assert(err, qt.IsNil)
+		c.Assert(shape.Type, qt.Equals, in.Type, qt.Commentf("%+v", in))
+		c.Assert(shape.TypeSetup, qt.Equals, in.TypeSetup, qt.Commentf("%+v", in))
+		want, err := BallotProtocolFromType(in.Type, in.TypeSetup, in.Choices)
+		c.Assert(err, qt.IsNil)
+		c.Assert(*shape.Protocol, qt.Equals, *want, qt.Commentf("%+v", in))
+	}
+}
+
+// TestResolveBallotShapeProtocolWins covers the half of the reconciliation a client can be
+// surprised by: a supplied protocol is what the election will be, so the named type is rewritten
+// to match it — and emptied when the protocol has no name.
+func TestResolveBallotShapeProtocolWins(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("an unnamed protocol empties the type", func(c *qt.C) {
+		// the shape saas-integrator-demo sends for a ranked question: a permutation ballot,
+		// labelled singlechoice because the API demanded some type
+		ranked := &db.BallotProtocol{MaxCount: 3, MaxValue: 2, UniqueValues: true}
+		shape, err := ResolveBallotShape(BallotShapeInput{
+			Type:      db.VotingTypeSingleChoice,
+			TypeSetup: db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1},
+			Protocol:  ranked,
+			Choices:   choices(3),
+		})
+		c.Assert(err, qt.IsNil)
+		c.Assert(shape.Type, qt.Equals, "")
+		c.Assert(shape.TypeSetup, qt.Equals, db.QuestionTypeSetup{})
+		c.Assert(*shape.Protocol, qt.Equals, *ranked)
+	})
+
+	c.Run("a named protocol rewrites a disagreeing type", func(c *qt.C) {
+		shape, err := ResolveBallotShape(BallotShapeInput{
+			Type:      db.VotingTypeMultiChoice,
+			TypeSetup: db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 2},
+			Protocol:  &db.BallotProtocol{MaxCount: 1, MaxValue: 2},
+			Choices:   choices(3),
+		})
+		c.Assert(err, qt.IsNil)
+		c.Assert(shape.Type, qt.Equals, db.VotingTypeSingleChoice)
+		// the caller's minChoices described a shape they did not get, so it goes with it
+		c.Assert(shape.TypeSetup, qt.Equals, db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1})
+	})
+
+	c.Run("the type is inferred from a protocol alone", func(c *qt.C) {
+		shape, err := ResolveBallotShape(BallotShapeInput{
+			Protocol: &db.BallotProtocol{MaxCount: 4, MaxValue: 1, CostExponent: 1, MaxTotalCost: 2},
+			Choices:  choices(4),
+		})
+		c.Assert(err, qt.IsNil)
+		c.Assert(shape.Type, qt.Equals, db.VotingTypeMultiChoice)
+		c.Assert(shape.TypeSetup, qt.Equals, db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 2})
+	})
+
+	c.Run("minChoices is clamped to the resolved maximum", func(c *qt.C) {
+		shape, err := ResolveBallotShape(BallotShapeInput{
+			Type:      db.VotingTypeMultiChoice,
+			TypeSetup: db.QuestionTypeSetup{MinChoices: 4, MaxChoices: 2},
+			Choices:   choices(4),
+		})
+		c.Assert(err, qt.IsNil)
+		c.Assert(shape.TypeSetup, qt.Equals, db.QuestionTypeSetup{MinChoices: 2, MaxChoices: 2})
+	})
+
+	c.Run("a question with no choices is left alone", func(c *qt.C) {
+		shape, err := ResolveBallotShape(BallotShapeInput{Type: db.VotingTypeSingleChoice})
+		c.Assert(err, qt.IsNil)
+		c.Assert(shape.Type, qt.Equals, db.VotingTypeSingleChoice)
+		c.Assert(shape.Protocol, qt.IsNil)
+	})
+
+	c.Run("an unnamed type with no protocol is an error", func(c *qt.C) {
+		_, err := ResolveBallotShape(BallotShapeInput{Type: "quadratic", Choices: choices(2)})
+		c.Assert(err, qt.Not(qt.IsNil))
+	})
+}
+
+// TestValidateBallotProtocol pins that the guard rejects exactly the ballots no voter could
+// satisfy, and nothing else — a raw protocol exists to express shapes that have no name, so
+// over-validating it would close the door this API deliberately leaves open.
+func TestValidateBallotProtocol(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("unsatisfiable", func(c *qt.C) {
+		for name, bp := range map[string]*db.BallotProtocol{
+			"empty":                      {},
+			"issue 619 in raw form":      {MaxCount: 4, MaxValue: 1, UniqueValues: true},
+			"two fields, one value":      {MaxCount: 2, MaxValue: 0, UniqueValues: true},
+			"one short of a permutation": {MaxCount: 4, MaxValue: 2, UniqueValues: true},
+		} {
+			c.Assert(ValidateBallotProtocol(bp), qt.Not(qt.IsNil), qt.Commentf("%s", name))
+		}
+	})
+
+	c.Run("satisfiable", func(c *qt.C) {
+		for name, bp := range map[string]*db.BallotProtocol{
+			"ranked (the demo)":     {MaxCount: 3, MaxValue: 2, UniqueValues: true},
+			"unique over one field": {MaxCount: 1, MaxValue: 0, UniqueValues: true},
+			"singlechoice":          {MaxCount: 1, MaxValue: 2},
+			"multichoice":           {MaxCount: 4, MaxValue: 1, CostExponent: 1, MaxTotalCost: 2},
+			"quadratic":             {MaxCount: 3, MaxValue: 4, CostExponent: 2, MaxTotalCost: 12},
+		} {
+			c.Assert(ValidateBallotProtocol(bp), qt.IsNil, qt.Commentf("%s", name))
+		}
+		c.Assert(ValidateBallotProtocol(nil), qt.IsNil)
+	})
+}
+
+// TestEffectiveQuestionType covers the question the plan gate has to ask: not what a stored
+// question calls itself, but what its ballot actually is.
+func TestEffectiveQuestionType(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("no protocol falls back to the stored type", func(c *qt.C) {
+		c.Assert(EffectiveQuestionType(&db.VotingProcessQuestion{
+			Type: db.VotingTypeMultiChoice, Choices: choices(3),
+		}), qt.Equals, db.VotingTypeMultiChoice)
+	})
+
+	c.Run("a legacy question whose type contradicts its protocol", func(c *qt.C) {
+		// stored before the halves were reconciled: labelled singlechoice, mints a ranking
+		c.Assert(EffectiveQuestionType(&db.VotingProcessQuestion{
+			Type:           db.VotingTypeSingleChoice,
+			Choices:        choices(3),
+			BallotProtocol: &db.BallotProtocol{MaxCount: 3, MaxValue: 2, UniqueValues: true},
+		}), qt.Equals, "")
+	})
+
+	c.Run("a raw protocol that is a named shape", func(c *qt.C) {
+		// the case the plan gate stops missing: no type stated, but this is a singlechoice
+		c.Assert(EffectiveQuestionType(&db.VotingProcessQuestion{
+			Choices:        choices(3),
+			BallotProtocol: &db.BallotProtocol{MaxCount: 1, MaxValue: 2},
+		}), qt.Equals, db.VotingTypeSingleChoice)
+	})
 }

--- a/account/ballot_test.go
+++ b/account/ballot_test.go
@@ -255,7 +255,6 @@ func TestResolveBallotShapeRoundTrip(t *testing.T) {
 	c := qt.New(t)
 	for _, in := range []BallotShapeInput{
 		{Type: db.VotingTypeSingleChoice, TypeSetup: db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1}, Choices: choices(1)},
-		{Type: db.VotingTypeSingleChoice, TypeSetup: db.QuestionTypeSetup{MinChoices: 0, MaxChoices: 1}, Choices: choices(4)},
 		{
 			Type: db.VotingTypeSingleChoice, TypeSetup: db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1},
 			Choices: valuedChoices(0, 2, 5),
@@ -272,11 +271,24 @@ func TestResolveBallotShapeRoundTrip(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 		c.Assert(*shape.Protocol, qt.Equals, *want, qt.Commentf("%+v", in))
 	}
+
+	// singlechoice is the exception: typeSetup is optional for it, and a ballot of one field the
+	// voter always fills has no minimum a client can state, so the stored setup is canonical
+	// whatever came in — never the {minChoices: 0} an omitted typeSetup would otherwise leave.
+	for _, setup := range []db.QuestionTypeSetup{{}, {MinChoices: 0, MaxChoices: 1}, {MinChoices: 1, MaxChoices: 1}} {
+		shape, err := ResolveBallotShape(BallotShapeInput{
+			Type: db.VotingTypeSingleChoice, TypeSetup: setup, Choices: choices(4),
+		})
+		c.Assert(err, qt.IsNil)
+		c.Assert(shape.Type, qt.Equals, db.VotingTypeSingleChoice)
+		c.Assert(shape.TypeSetup, qt.Equals, db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1}, qt.Commentf("%+v", setup))
+	}
 }
 
 // TestResolveBallotShapeProtocolWins covers the half of the reconciliation a client can be
-// surprised by: a supplied protocol is what the election will be, so the named type is rewritten
-// to match it — and emptied when the protocol has no name.
+// surprised by: a supplied protocol is what the election will be, so the type is derived from it
+// and emptied when the protocol has no name. Where both halves name a ballot and disagree there is
+// nothing to prefer, so the request is refused instead of the edit being dropped.
 func TestResolveBallotShapeProtocolWins(t *testing.T) {
 	c := qt.New(t)
 
@@ -296,17 +308,38 @@ func TestResolveBallotShapeProtocolWins(t *testing.T) {
 		c.Assert(*shape.Protocol, qt.Equals, *ranked)
 	})
 
-	c.Run("a named protocol rewrites a disagreeing type", func(c *qt.C) {
-		shape, err := ResolveBallotShape(BallotShapeInput{
+	c.Run("two named halves that disagree are refused", func(c *qt.C) {
+		_, err := ResolveBallotShape(BallotShapeInput{
 			Type:      db.VotingTypeMultiChoice,
 			TypeSetup: db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 2},
 			Protocol:  &db.BallotProtocol{MaxCount: 1, MaxValue: 2},
 			Choices:   choices(3),
 		})
+		c.Assert(err, qt.Not(qt.IsNil))
+	})
+
+	c.Run("the stale-echo edit is refused rather than dropped", func(c *qt.C) {
+		// a client reads a draft, raises maxChoices and PUTs the whole body back: the protocol it
+		// echoes still encodes the old maximum, and used to win in silence
+		_, err := ResolveBallotShape(BallotShapeInput{
+			Type:      db.VotingTypeMultiChoice,
+			TypeSetup: db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 3},
+			Protocol:  &db.BallotProtocol{MaxCount: 4, MaxValue: 1, CostExponent: 1, MaxTotalCost: 2},
+			Choices:   choices(4),
+		})
+		c.Assert(err, qt.Not(qt.IsNil))
+	})
+
+	c.Run("an honest echo of both halves is accepted", func(c *qt.C) {
+		shape, err := ResolveBallotShape(BallotShapeInput{
+			Type:      db.VotingTypeMultiChoice,
+			TypeSetup: db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 2},
+			Protocol:  &db.BallotProtocol{MaxCount: 4, MaxValue: 1, CostExponent: 1, MaxTotalCost: 2},
+			Choices:   choices(4),
+		})
 		c.Assert(err, qt.IsNil)
-		c.Assert(shape.Type, qt.Equals, db.VotingTypeSingleChoice)
-		// the caller's minChoices described a shape they did not get, so it goes with it
-		c.Assert(shape.TypeSetup, qt.Equals, db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1})
+		c.Assert(shape.Type, qt.Equals, db.VotingTypeMultiChoice)
+		c.Assert(shape.TypeSetup, qt.Equals, db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 2})
 	})
 
 	c.Run("the type is inferred from a protocol alone", func(c *qt.C) {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -680,6 +680,7 @@ func waitUntilElectionKeys(t *testing.T, c *apiclient.HTTPclient, electionID []b
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	startTime := time.Now()
+	var lastErr error
 	for {
 		ek, err := c.ElectionKeys(electionID)
 		if err == nil && len(ek.PublicKeys) > 0 {
@@ -687,12 +688,13 @@ func waitUntilElectionKeys(t *testing.T, c *apiclient.HTTPclient, electionID []b
 				hex.EncodeToString(electionID), "duration", time.Since(startTime).String())
 			return ek
 		}
+		lastErr = err // nil while the node answers but has no keys yet; set on a transport failure
 		select {
 		case <-time.After(time.Second * 1):
 			continue
 		case <-ctx.Done():
-			t.Fatalf("election %s keys never published after %s: %v",
-				hex.EncodeToString(electionID), time.Since(startTime).String(), ctx.Err())
+			t.Fatalf("election %s keys never published after %s: %v (last fetch error: %v)",
+				hex.EncodeToString(electionID), time.Since(startTime).String(), ctx.Err(), lastErr)
 		}
 	}
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -37,6 +37,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	dvoteapi "go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/apiclient"
 	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/log"
@@ -666,6 +667,32 @@ func waitUntilTxIsMined(ctx context.Context, txHash []byte, c *apiclient.HTTPcli
 		case <-ctx.Done():
 			return fmt.Errorf("transaction %s never mined after %s: %w",
 				hex.EncodeToString(txHash), time.Since(startTime).String(), ctx.Err())
+		}
+	}
+}
+
+// waitUntilElectionKeys waits until the keykeepers have actually published the encryption keys of
+// the given election. apiclient.WaitUntilElectionKeys is not enough on its own: it returns as soon
+// as the keys endpoint answers without an HTTP error, which the node does with an empty body a
+// block before the ADD_PROCESS_KEYS tx is committed.
+func waitUntilElectionKeys(t *testing.T, c *apiclient.HTTPclient, electionID []byte) *dvoteapi.ElectionKeys {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	startTime := time.Now()
+	for {
+		ek, err := c.ElectionKeys(electionID)
+		if err == nil && len(ek.PublicKeys) > 0 {
+			log.Infow("election keys published", "election",
+				hex.EncodeToString(electionID), "duration", time.Since(startTime).String())
+			return ek
+		}
+		select {
+		case <-time.After(time.Second * 1):
+			continue
+		case <-ctx.Done():
+			t.Fatalf("election %s keys never published after %s: %v",
+				hex.EncodeToString(electionID), time.Since(startTime).String(), ctx.Err())
 		}
 	}
 }

--- a/api/process_encryption_keys_test.go
+++ b/api/process_encryption_keys_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -98,11 +97,7 @@ func TestProcessEncryptionKeys(t *testing.T) {
 	encObjID, encAddr := newProcess(true)
 
 	// wait until the keykeepers publish the election encryption keys on chain
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	nodeKeys, err := vocdoniClient.WaitUntilElectionKeys(ctx, encAddr.Bytes())
-	cancel()
-	c.Assert(err, qt.IsNil)
-	c.Assert(nodeKeys.PublicKeys, qt.Not(qt.HasLen), 0)
+	nodeKeys := waitUntilElectionKeys(t, vocdoniClient, encAddr.Bytes())
 
 	info := requestAndParse[apicommon.ProcessInfo](t, http.MethodGet, token, nil, "process", encObjID)
 	c.Assert(info.EncryptionKeys, qt.HasLen, len(nodeKeys.PublicKeys))

--- a/api/processes.go
+++ b/api/processes.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-chi/chi/v5"
+	"github.com/vocdoni/saas-backend/account"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
@@ -142,8 +143,9 @@ func (a *API) buildQuestions(
 ) ([]*db.VotingProcessQuestion, error) {
 	built := make([]*db.VotingProcessQuestion, 0, len(questions))
 	for i, q := range questions {
-		// ballot shape: a question must define EITHER a named type OR a raw BallotProtocol
-		// override; if both are set the BallotProtocol wins (VoteTypeFromQuestion uses it). For a
+		// ballot shape: a question must define a named type, a raw BallotProtocol, or both. The
+		// two halves are reconciled below so they describe the same ballot; a supplied protocol
+		// is what the election will be, so it wins and the type is re-derived from it. For a
 		// named type, typeSetup is required for every type except singlechoice (which ignores it
 		// on chain); a multichoice maps MaxChoices onto MaxTotalCost so it must be bounded.
 		if q.BallotProtocol == nil {
@@ -161,9 +163,29 @@ func (a *API) buildQuestions(
 				if q.TypeSetup.MinChoices > q.TypeSetup.MaxChoices {
 					return nil, errors.ErrInvalidData.Withf("question %d: minChoices cannot exceed maxChoices", i)
 				}
+				if q.TypeSetup.UniqueChoices {
+					// multichoice gives every choice its own 0/1 field, so a voter already cannot
+					// select one twice — and a unique-values ballot over those fields admits no
+					// vote at all: the election would accept every envelope and tally zero.
+					return nil, errors.ErrInvalidData.Withf(
+						"question %d: uniqueChoices is not supported for multichoice, where each choice is an "+
+							"independent yes/no field; use a ballotProtocol for a ranked ballot", i,
+					)
+				}
 			default:
 				return nil, errors.ErrInvalidData.Withf("question %d: unsupported type %q", i, q.Type)
 			}
+		} else if err := account.ValidateBallotProtocol(q.BallotProtocol); err != nil {
+			return nil, errors.ErrInvalidData.Withf("question %d: invalid ballotProtocol: %v", i, err)
+		}
+		shape, err := account.ResolveBallotShape(account.BallotShapeInput{
+			Type:      q.Type,
+			TypeSetup: q.TypeSetup,
+			Protocol:  q.BallotProtocol,
+			Choices:   q.Choices,
+		})
+		if err != nil {
+			return nil, errors.ErrInvalidData.Withf("question %d: %v", i, err)
 		}
 		eligible, err := a.resolveEligibleMemberIDs(q.Eligibility, census, orgAddress)
 		if err != nil {
@@ -175,9 +197,9 @@ func (a *API) buildQuestions(
 			Title:             q.Title,
 			Description:       q.Description,
 			Choices:           q.Choices,
-			Type:              q.Type,
-			TypeSetup:         q.TypeSetup,
-			BallotProtocol:    q.BallotProtocol,
+			Type:              shape.Type,
+			TypeSetup:         shape.TypeSetup,
+			BallotProtocol:    shape.Protocol,
 			SecretUntilTheEnd: q.SecretUntilTheEnd,
 			EligibleMemberIDs: eligible,
 			Metadata:          q.Metadata,

--- a/api/processes.go
+++ b/api/processes.go
@@ -942,6 +942,12 @@ func validateVotingProcessForPublish(
 		if q.BallotProtocol == nil && q.Type != db.VotingTypeSingleChoice && q.Type != db.VotingTypeMultiChoice {
 			problems = append(problems, fmt.Sprintf("question %d has an unsupported type %q", i, q.Type))
 		}
+		// A question stored before authoring rejected these can still hold a ballot no voter can
+		// satisfy. Publishing it would mint an election that accepts every vote and tallies zero,
+		// with nothing on the way reporting a problem, so stop it at the last point that can.
+		if err := account.ValidateBallotProtocol(q.BallotProtocol); err != nil {
+			problems = append(problems, fmt.Sprintf("question %d has an invalid ballotProtocol: %v", i, err))
+		}
 	}
 	return problems
 }

--- a/api/processes.go
+++ b/api/processes.go
@@ -51,9 +51,15 @@ func parseProcessDates(req *apicommon.CreateVotingProcessRequest) (start, end ti
 //	@Description	is derived, so the stored question always describes the election it will mint. A
 //	@Description	supplied `ballotProtocol` is authoritative — it is what reaches the chain — so `type`
 //	@Description	and `typeSetup` are re-derived from it, and come back empty when it encodes a shape
-//	@Description	with no named type (ranked, quadratic). **Omit `ballotProtocol` to author or edit a
-//	@Description	question through its `typeSetup`**: sending back a response body unchanged will
-//	@Description	otherwise re-apply the protocol it carries.
+//	@Description	with no named type (ranked, quadratic). Sending both halves is fine when they agree;
+//	@Description	when they describe two different named ballots it is a 400 rather than a silent win
+//	@Description	for the protocol. **Omit `ballotProtocol` to author or edit a question through its
+//	@Description	`typeSetup`** — responses always carry a protocol, so echoing one back unchanged
+//	@Description	re-applies it.
+//	@Description
+//	@Description	`typeSetup.minChoices` has no on-chain counterpart and is a validation hint for
+//	@Description	clients. It is stored as sent for multichoice, and is always `1` for singlechoice,
+//	@Description	whose ballot is the single field a voter fills.
 //	@Description
 //	@Description	`typeSetup.uniqueChoices` is rejected for multichoice: every choice is an independent
 //	@Description	yes/no field, so a unique-values ballot admits no vote and the election would tally
@@ -279,8 +285,9 @@ func (a *API) storeUpdatedProcess(vp *db.VotingProcess, seen time.Time) error {
 //	@Summary		Update a voting process draft
 //	@Description	Update a voting process while it is still a draft (not published). 409 if already published.
 //	@Description	The questions are replaced wholesale, and each one's ballot shape is reconciled exactly
-//	@Description	as on create — so omit `ballotProtocol` when editing a question through its `typeSetup`,
-//	@Description	or the protocol carried in the body wins and the edit is not applied.
+//	@Description	as on create. Reading a question and PUTting it back unchanged is a no-op; editing its
+//	@Description	`typeSetup` while echoing the `ballotProtocol` that still encodes the old shape is a
+//	@Description	400 — omit `ballotProtocol` to edit a question through its `typeSetup`.
 //	@Description
 //	@Description	Send the updatedAt read from GET /processes/{processId} to make the update conditional: it is
 //	@Description	rejected with 409 (40171) if anything wrote the process in between, so two editors cannot

--- a/api/processes.go
+++ b/api/processes.go
@@ -430,6 +430,9 @@ func (a *API) votingProcessInfoHandler(w http.ResponseWriter, r *http.Request) {
 	// each needs a Vochain round-trip, so bounded pools keep this read fast for a many-question process.
 	a.resolveQuestionEncryptionKeysBatch(questions)
 	a.resolveQuestionResultsBatch(questions)
+	// a draft written before the two ballot halves were reconciled is served reconciled, so the
+	// body a client echoes back is one authoring still accepts.
+	reconcileDraftQuestionShapes(questions)
 	// non-managers must not see the per-question eligibility member ids (who can vote).
 	if !isManager {
 		redactQuestionsForPublic(questions)
@@ -437,6 +440,42 @@ func (a *API) votingProcessInfoHandler(w http.ResponseWriter, r *http.Request) {
 	resp := apicommon.VotingProcessResponseFromDB(vp, questions, census, a.account.ChainID())
 	resp.Census.TotalWeight = a.censusTotalWeight(census)
 	apicommon.HTTPWriteJSON(w, resp)
+}
+
+// reconcileDraftQuestionShapes serves the reconciled ballot shape of the questions that have not
+// minted an election yet, mutating the passed slice in place.
+//
+// Questions stored before the two halves were reconciled can carry anything the old code accepted:
+// a typeSetup.uniqueChoices no named type supports, no ballotProtocol at all, or two halves that
+// contradict each other. Authoring now refuses all three, so a client that reads such a draft and
+// PUTs the question array back — the only way to edit one, since update replaces them wholesale —
+// would be refused for a lie it did not write. Serving the shape a publish would actually use makes
+// that round-trip work and makes the read consistent with the invariant.
+//
+// Only unminted questions: a published legacy question's election really does carry the parameters
+// it was minted with (the #619 elections have uniqueValues set on chain), so deriving a clean shape
+// for it would misreport the chain — and it cannot be edited anyway. Nothing is written back; the
+// first update persists it.
+func reconcileDraftQuestionShapes(questions []db.VotingProcessQuestion) {
+	for i := range questions {
+		q := &questions[i]
+		if len(q.UpstreamID) > 0 || len(q.Choices) == 0 {
+			continue
+		}
+		in := account.BallotShapeInput{
+			Type: q.Type, TypeSetup: q.TypeSetup, Protocol: q.BallotProtocol, Choices: q.Choices,
+		}
+		// a stored protocol is what publish would mint, so it wins over a stored type outright —
+		// asking to reconcile both halves would only reject a contradiction nobody can edit away.
+		if in.Protocol != nil {
+			in.Type, in.TypeSetup = "", db.QuestionTypeSetup{}
+		}
+		shape, err := account.ResolveBallotShape(in)
+		if err != nil {
+			continue // an unusable stored shape is publish's problem to report, not a read's
+		}
+		q.Type, q.TypeSetup, q.BallotProtocol = shape.Type, shape.TypeSetup, shape.Protocol
+	}
 }
 
 // redactQuestionsForPublic strips manager-only fields from questions before serving them to a
@@ -542,6 +581,7 @@ func (a *API) listVotingProcessesHandler(w http.ResponseWriter, r *http.Request)
 			return
 		}
 		census, _ := a.db.Census(vp.CensusID.Hex())
+		reconcileDraftQuestionShapes(questions)
 		if !isManager {
 			redactQuestionsForPublic(questions)
 		}
@@ -969,7 +1009,7 @@ func validateVotingProcessForPublish(
 		// satisfy. Publishing it would mint an election that accepts every vote and tallies zero,
 		// with nothing on the way reporting a problem, so stop it at the last point that can.
 		if err := account.ValidateBallotProtocol(q.BallotProtocol); err != nil {
-			problems = append(problems, fmt.Sprintf("question %d has an invalid ballotProtocol: %v", i, err))
+			problems = append(problems, fmt.Sprintf("question %d: invalid ballotProtocol: %v", i, err))
 		}
 	}
 	return problems

--- a/api/processes.go
+++ b/api/processes.go
@@ -45,8 +45,20 @@ func parseProcessDates(req *apicommon.CreateVotingProcessRequest) (start, end ti
 //	@Summary		Create a voting process draft
 //	@Description	Create a multi-question voting process draft. Requires Manager/Admin role of the org
 //	@Description	(or a scoped API key with `voting:write`). Creates the inline census unpublished.
-//	@Description	Each question must define either a named `type` (with `typeSetup` for multichoice)
-//	@Description	or a raw `ballotProtocol` override; if both are given the `ballotProtocol` wins.
+//	@Description
+//	@Description	Each question must define a named `type` (with `typeSetup` for multichoice), a raw
+//	@Description	`ballotProtocol`, or both. The two are kept in sync: whichever is supplied, the other
+//	@Description	is derived, so the stored question always describes the election it will mint. A
+//	@Description	supplied `ballotProtocol` is authoritative — it is what reaches the chain — so `type`
+//	@Description	and `typeSetup` are re-derived from it, and come back empty when it encodes a shape
+//	@Description	with no named type (ranked, quadratic). **Omit `ballotProtocol` to author or edit a
+//	@Description	question through its `typeSetup`**: sending back a response body unchanged will
+//	@Description	otherwise re-apply the protocol it carries.
+//	@Description
+//	@Description	`typeSetup.uniqueChoices` is rejected for multichoice: every choice is an independent
+//	@Description	yes/no field, so a unique-values ballot admits no vote and the election would tally
+//	@Description	every vote to zero. A `ballotProtocol` whose `uniqueValues` cannot be satisfied
+//	@Description	(fewer legal values than fields) is rejected for the same reason.
 //	@Tags			processes
 //	@Accept			json
 //	@Produce		json
@@ -266,6 +278,10 @@ func (a *API) storeUpdatedProcess(vp *db.VotingProcess, seen time.Time) error {
 //
 //	@Summary		Update a voting process draft
 //	@Description	Update a voting process while it is still a draft (not published). 409 if already published.
+//	@Description	The questions are replaced wholesale, and each one's ballot shape is reconciled exactly
+//	@Description	as on create — so omit `ballotProtocol` when editing a question through its `typeSetup`,
+//	@Description	or the protocol carried in the body wins and the edit is not applied.
+//	@Description
 //	@Description	Send the updatedAt read from GET /processes/{processId} to make the update conditional: it is
 //	@Description	rejected with 409 (40171) if anything wrote the process in between, so two editors cannot
 //	@Description	overwrite each other. Omitting updatedAt opts out of that guarantee and keeps last-writer-wins.

--- a/api/processes_encryption_keys_test.go
+++ b/api/processes_encryption_keys_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -75,11 +74,7 @@ func TestProcessesEncryptionKeys(t *testing.T) {
 	encElection := internal.HexBytes(signRemoteSignerAndSendVocdoniTx(t, processTx, token, vocdoniClient, orgAddress))
 
 	// wait until the keykeepers publish the election encryption keys on chain
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	nodeKeys, err := vocdoniClient.WaitUntilElectionKeys(ctx, encElection.Bytes())
-	cancel()
-	c.Assert(err, qt.IsNil)
-	c.Assert(nodeKeys.PublicKeys, qt.Not(qt.HasLen), 0)
+	nodeKeys := waitUntilElectionKeys(t, vocdoniClient, encElection.Bytes())
 
 	// seed a published voting process with an encrypted question (points at the election above) and a
 	// non-encrypted one; the plain question keeps a distinct upstreamId to prove the secretUntilTheEnd

--- a/api/processes_publish.go
+++ b/api/processes_publish.go
@@ -105,12 +105,13 @@ func (a *API) publishPreflightProblems(
 	if !user.HasRoleFor(vp.OrgAddress, db.AdminRole) {
 		problems = append(problems, "publishing requires the admin role")
 	}
-	// per-question plan voting-type gate (skipped for raw ballot-protocol overrides)
+	// Per-question plan voting-type gate, on the ballot each question actually encodes rather
+	// than the type it is labelled with: a stored type is only a label, and a question written
+	// before the two halves were reconciled may carry one its protocol contradicts. Shapes with
+	// no named type (ranked, quadratic) resolve to an empty type and are not gated here; their
+	// plan limits ride on the built transaction instead.
 	for i := range questions {
-		if questions[i].BallotProtocol != nil {
-			continue
-		}
-		if err := a.subscriptions.OrgAllowsVotingType(vp.OrgAddress, questions[i].Type); err != nil {
+		if err := a.subscriptions.OrgAllowsVotingType(vp.OrgAddress, account.EffectiveQuestionType(&questions[i])); err != nil {
 			problems = append(problems, err.Error())
 		}
 	}

--- a/api/processes_publish.go
+++ b/api/processes_publish.go
@@ -107,9 +107,13 @@ func (a *API) publishPreflightProblems(
 	}
 	// Per-question plan voting-type gate, on the ballot each question actually encodes rather
 	// than the type it is labelled with: a stored type is only a label, and a question written
-	// before the two halves were reconciled may carry one its protocol contradicts. Shapes with
-	// no named type (ranked, quadratic) resolve to an empty type and are not gated here; their
-	// plan limits ride on the built transaction instead.
+	// before the two halves were reconciled may carry one its protocol contradicts.
+	//
+	// Shapes with no named type (ranked, quadratic) resolve to an empty type and are gated
+	// nowhere: not here, and not on the build path either — hasElectionMetadataPermissions still
+	// carries the TODO for it, and plan.VotingTypes has no flag anything can resolve to (see the
+	// TODO on OrgAllowsVotingType's allowed map). That is pre-existing, and unchanged by this
+	// gate, but it is not "gated elsewhere".
 	//
 	// This tightens what main did — which skipped the gate for every raw protocol — but does not
 	// close it. EffectiveQuestionType recognises a shape only when it is exactly canonical, which

--- a/api/processes_publish.go
+++ b/api/processes_publish.go
@@ -110,6 +110,14 @@ func (a *API) publishPreflightProblems(
 	// before the two halves were reconciled may carry one its protocol contradicts. Shapes with
 	// no named type (ranked, quadratic) resolve to an empty type and are not gated here; their
 	// plan limits ride on the built transaction instead.
+	//
+	// This tightens what main did — which skipped the gate for every raw protocol — but does not
+	// close it. EffectiveQuestionType recognises a shape only when it is exactly canonical, which
+	// is what storage needs and what authorization does not: {maxCount:2, maxValue:1,
+	// maxTotalCost:2} is the same ballot as the multichoice one field-for-field bar costExponent,
+	// and stays ungated. Actually holding the gate needs a deliberately loose classifier
+	// (maxValue == 1 && maxCount > 1 ⇒ effectively multiple-choice, whatever else is set), not
+	// this one.
 	for i := range questions {
 		if err := a.subscriptions.OrgAllowsVotingType(vp.OrgAddress, account.EffectiveQuestionType(&questions[i])); err != nil {
 			problems = append(problems, err.Error())

--- a/api/processes_tally_test.go
+++ b/api/processes_tally_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"encoding/hex"
+	"net/http"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/api/apicommon"
+	"github.com/vocdoni/saas-backend/csp/handlers"
+	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/internal"
+	"go.vocdoni.io/dvote/crypto/ethereum"
+	"go.vocdoni.io/dvote/types"
+)
+
+// TestVotingProcessMultichoiceTally is the regression test issue #619 needed and did not have: it
+// casts a real multichoice ballot on chain and reads the tally back.
+//
+// The bug was invisible through the API. A multichoice question mapped typeSetup.uniqueChoices onto
+// the on-chain uniqueValues, which the dense layout (one 0/1 field per choice) can never satisfy —
+// so the election accepted every envelope, voteCount rose, and the scrutinizer discarded them all.
+// Every assertion an authoring test could make still passed; only the tally showed it, as zeros.
+//
+// So this test votes {1,0,1,0} over four choices and asserts the matrix that implies: the selected
+// fields tallied, the unselected ones not.
+func TestVotingProcessMultichoiceTally(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateProvisionedOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	choices := make([]db.Choice, 4)
+	for i := range choices {
+		choices[i] = db.Choice{Title: db.MultiLangString{"default": string(rune('A' + i))}, Value: uint32(i)}
+	}
+	req := &apicommon.CreateVotingProcessRequest{
+		OrgAddress: orgAddress.Bytes(),
+		Census: apicommon.CensusSpec{
+			AuthFields:  db.OrgMemberAuthFields{db.OrgMemberAuthFieldsName, db.OrgMemberAuthFieldsSurname},
+			TwoFaFields: db.OrgMemberTwoFaFields{db.OrgMemberTwoFaFieldEmail},
+			MemberIDs:   ids,
+			Weighted:    true,
+		},
+		Title:   db.MultiLangString{"default": "Multichoice tally"},
+		EndDate: time.Now().Add(48 * time.Hour).UTC().Format(time.RFC3339),
+		Questions: []apicommon.VotingProcessQuestionRequest{{
+			Title:     db.MultiLangString{"default": "Pick up to two"},
+			Choices:   choices,
+			Type:      db.VotingTypeMultiChoice,
+			TypeSetup: db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 2},
+		}},
+	}
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, req, processesCreateEndpoint)
+	pid := created.ProcessID
+
+	job := enqueueAndPollJob(t, http.MethodPost, token, nil, "processes", pid, "publish")
+	c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("job error: %s", job.Errors))
+
+	got := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	c.Assert(got.Questions, qt.HasLen, 1)
+	election := got.Questions[0].UpstreamID
+	c.Assert(election, qt.Not(qt.HasLen), 0)
+	c.Assert(*got.Questions[0].BallotProtocol, qt.Equals, db.BallotProtocol{
+		MaxCount: 4, MaxValue: 1, CostExponent: 1, MaxTotalCost: 2,
+	})
+
+	// what actually reached the chain: four 0/1 fields, and uniqueValues off. This is the #619
+	// assertion at its only authoritative source — the election's own vote options.
+	onChain, err := testNewVocdoniClient(t).Election(types.HexBytes(election))
+	c.Assert(err, qt.IsNil)
+	c.Assert(onChain.VoteMode.UniqueValues, qt.IsFalse, qt.Commentf("a dense layout with unique values takes no vote"))
+	c.Assert(onChain.TallyMode.MaxCount, qt.Equals, uint32(4))
+	c.Assert(onChain.TallyMode.MaxValue, qt.Equals, uint32(1))
+
+	// one member authenticates, gets the CSP signature for this election and relays the ballot
+	authToken := authProcessCSP(t, pid, &handlers.AuthRequest{
+		Name: members[0].Name, Surname: members[0].Surname, Email: members[0].Email,
+	})
+	voter := ethereum.SignKeys{}
+	c.Assert(voter.Generate(), qt.IsNil)
+	voterAddr := internal.HexBytes(voter.Address().Bytes())
+	sign := requestAndParse[handlers.AuthResponse](t, http.MethodPost, "",
+		&handlers.SignRequest{AuthToken: authToken, ProcessID: election, Payload: hex.EncodeToString(voterAddr)},
+		"processes", pid, "sign")
+	c.Assert(sign.Signature, qt.Not(qt.HasLen), 0)
+
+	nullifier := testRelayVoteRequest(t, &voter, election,
+		testGenerateVoteProof(election, voterAddr, sign.Signature, 1), []byte(`{"votes":[1,0,1,0]}`))
+	c.Assert(nullifier, qt.Not(qt.HasLen), 0)
+
+	// live results (the election is not secretUntilTheEnd, so no need to end it first)
+	var res apicommon.VotingProcessResultsResponse
+	for i := 0; i < 20; i++ {
+		res = requestAndParse[apicommon.VotingProcessResultsResponse](
+			t, http.MethodGet, "", nil, "processes", pid, "results")
+		if len(res.Questions) > 0 && res.Questions[0].VoteCount > 0 {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	c.Assert(res.Questions, qt.HasLen, 1)
+	c.Assert(res.Questions[0].VoteCount, qt.Equals, uint64(1))
+	// one row per choice, each [not selected, selected]: the ballot picked choices A and C. Before
+	// the fix this was four rows of {"0","0"} — a counted vote that tallied to nothing.
+	c.Assert(res.Questions[0].Results, qt.DeepEquals, [][]string{
+		{"0", "1"}, {"1", "0"}, {"0", "1"}, {"1", "0"},
+	})
+}

--- a/api/processes_test.go
+++ b/api/processes_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/account"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
@@ -175,16 +176,41 @@ func TestVotingProcessAuthoringErrors(t *testing.T) {
 	badType.Questions[0].Type = "quadratic"
 	requestAndAssertError(errors.ErrInvalidData, t, http.MethodPost, adminToken, badType, processesCreateEndpoint)
 
+	// multichoice + uniqueChoices -> 400. Each choice is its own 0/1 field, so a unique-values
+	// ballot over them admits no vote: the election used to be accepted and then tally every
+	// vote to zero, reporting nothing anywhere (issue #619).
+	uniqueMulti := newVotingProcessRequest(orgAddress, ids)
+	uniqueMulti.Questions[1].TypeSetup.UniqueChoices = true
+	requestAndAssertError(errors.ErrInvalidData, t, http.MethodPost, adminToken, uniqueMulti, processesCreateEndpoint)
+
+	// the same ballot reached through the raw protocol is refused too: two fields cannot hold
+	// distinct values drawn from {0}
+	uniqueProto := newVotingProcessRequest(orgAddress, ids)
+	uniqueProto.Questions[0].BallotProtocol = &db.BallotProtocol{MaxCount: 2, MaxValue: 0, UniqueValues: true}
+	requestAndAssertError(errors.ErrInvalidData, t, http.MethodPost, adminToken, uniqueProto, processesCreateEndpoint)
+
+	// an empty ballotProtocol describes an election with no fields at all
+	emptyProto := newVotingProcessRequest(orgAddress, ids)
+	emptyProto.Questions[0].BallotProtocol = &db.BallotProtocol{}
+	requestAndAssertError(errors.ErrInvalidData, t, http.MethodPost, adminToken, emptyProto, processesCreateEndpoint)
+
 	// every create above failed, so no orphaned draft was left behind (they roll back)
 	count, err := testDB.CountVotingProcesses(orgAddress, db.AllProcesses)
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, count, qt.Equals, int64(0))
 
-	// a raw ballotProtocol override satisfies the ballot-shape requirement even without a type
+	// a raw ballotProtocol override satisfies the ballot-shape requirement even without a type,
+	// and the type is inferred back from it: one field valued 0..1 over two choices is a
+	// singlechoice, so that is what the question reads as
 	rawProto := newVotingProcessRequest(orgAddress, ids)
 	rawProto.Questions[0].Type = ""
 	rawProto.Questions[0].BallotProtocol = &db.BallotProtocol{MaxCount: 1, MaxValue: 1}
-	requestAndAssertCode(http.StatusOK, t, http.MethodPost, adminToken, rawProto, processesCreateEndpoint)
+	inferred := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, adminToken, rawProto, processesCreateEndpoint)
+	got := requestAndParse[apicommon.VotingProcessResponse](
+		t, http.MethodGet, adminToken, nil, "processes", inferred.ProcessID)
+	qt.Assert(t, got.Questions[0].Type, qt.Equals, db.VotingTypeSingleChoice)
+	qt.Assert(t, got.Questions[0].TypeSetup, qt.Equals, db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1})
 
 	// a user with no role on the org -> 401
 	otherToken := testCreateUser(t, "otherpassword123")
@@ -442,6 +468,11 @@ func TestVotingProcessResults(t *testing.T) {
 		t, http.MethodGet, "", nil, "processes", created.ProcessID, "questions", info.Questions[0].ID.Hex())
 	c.Assert(pub.Results, qt.Not(qt.IsNil))
 	c.Assert(pub.Results.FinalResults, qt.IsFalse)
+	// the voter-facing read describes the same ballot as the election that was minted: both
+	// halves are there and they agree
+	c.Assert(pub.Type, qt.Equals, db.VotingTypeSingleChoice)
+	c.Assert(pub.BallotProtocol, qt.Not(qt.IsNil))
+	c.Assert(*pub.BallotProtocol, qt.Equals, db.BallotProtocol{MaxCount: 1, MaxValue: 1})
 }
 
 // TestVotingProcessPublicReads verifies the process list and single read are public for published
@@ -817,4 +848,87 @@ func TestVotingProcessConditionalUpdate(t *testing.T) {
 	bad := newVotingProcessRequest(orgAddress, ids)
 	bad.UpdatedAt = "not-a-timestamp"
 	requestAndAssertError(errors.ErrMalformedBody, t, http.MethodPut, adminToken, bad, "processes", pid)
+}
+
+// TestVotingProcessBallotShapeConsistency pins what a stored question says about its ballot: both
+// halves are present and describe the same thing, whichever half the author supplied. Before this,
+// a question could carry a typeSetup that no code ever read and an election it did not describe.
+func TestVotingProcessBallotShapeConsistency(t *testing.T) {
+	c := qt.New(t)
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, adminToken, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, adminToken, newVotingProcessRequest(orgAddress, ids), processesCreateEndpoint)
+	got := requestAndParse[apicommon.VotingProcessResponse](
+		t, http.MethodGet, adminToken, nil, "processes", created.ProcessID)
+	c.Assert(got.Questions, qt.HasLen, 2)
+
+	// Q1 singlechoice over two choices valued 0 and 1: one field holding the chosen value
+	c.Assert(got.Questions[0].Type, qt.Equals, db.VotingTypeSingleChoice)
+	c.Assert(got.Questions[0].TypeSetup, qt.Equals, db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1})
+	c.Assert(got.Questions[0].BallotProtocol, qt.Not(qt.IsNil))
+	c.Assert(*got.Questions[0].BallotProtocol, qt.Equals, db.BallotProtocol{MaxCount: 1, MaxValue: 1})
+
+	// Q2 multichoice over the same two: one 0/1 field per choice, at most maxChoices selected,
+	// and — the point of #619 — never uniqueValues
+	c.Assert(got.Questions[1].Type, qt.Equals, db.VotingTypeMultiChoice)
+	c.Assert(got.Questions[1].TypeSetup, qt.Equals, db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 2})
+	c.Assert(got.Questions[1].BallotProtocol, qt.Not(qt.IsNil))
+	c.Assert(*got.Questions[1].BallotProtocol, qt.Equals, db.BallotProtocol{
+		MaxCount: 2, MaxValue: 1, CostExponent: 1, MaxTotalCost: 2,
+	})
+
+	// each half re-derives the other, so a client can edit through either one
+	for i := range got.Questions {
+		q := got.Questions[i]
+		derived, err := account.BallotProtocolFromType(q.Type, q.TypeSetup, q.Choices)
+		c.Assert(err, qt.IsNil)
+		c.Assert(*derived, qt.Equals, *q.BallotProtocol, qt.Commentf("question %d", i))
+	}
+}
+
+// TestVotingProcessRankedBallotProtocol covers the shape saas-integrator-demo sends for a ranked
+// question: a permutation ballot (n fields, values 0..n-1, all distinct) carried by a raw protocol,
+// labelled singlechoice because the API used to demand a type. That ballot is satisfiable and must
+// keep working — the type it was labelled with is what goes, since it was never true.
+func TestVotingProcessRankedBallotProtocol(t *testing.T) {
+	c := qt.New(t)
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, adminToken, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	ranked := &db.BallotProtocol{MaxCount: 3, MaxValue: 2, UniqueValues: true}
+	req := newVotingProcessRequest(orgAddress, ids)
+	req.Questions = req.Questions[:1]
+	req.Questions[0].Choices = []db.Choice{
+		{Title: db.MultiLangString{"default": "A"}, Value: 0},
+		{Title: db.MultiLangString{"default": "B"}, Value: 1},
+		{Title: db.MultiLangString{"default": "C"}, Value: 2},
+	}
+	req.Questions[0].Type = db.VotingTypeSingleChoice
+	req.Questions[0].TypeSetup = db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1}
+	req.Questions[0].BallotProtocol = ranked
+
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, adminToken, req, processesCreateEndpoint)
+	got := requestAndParse[apicommon.VotingProcessResponse](
+		t, http.MethodGet, adminToken, nil, "processes", created.ProcessID)
+	c.Assert(got.Questions, qt.HasLen, 1)
+	c.Assert(*got.Questions[0].BallotProtocol, qt.Equals, *ranked)
+	// a ranking has no named type, so the question stops claiming one rather than claiming a
+	// wrong one
+	c.Assert(got.Questions[0].Type, qt.Equals, "")
+	c.Assert(got.Questions[0].TypeSetup, qt.Equals, db.QuestionTypeSetup{})
+
+	// and it is still publishable: the plan's voting-type gate gates named types, and this shape
+	// has none (mockEssentialPlan does not grant Ranked either way)
+	validation := requestAndParse[apicommon.VotingProcessValidateResponse](
+		t, http.MethodGet, adminToken, nil, "processes", created.ProcessID, "validation")
+	c.Assert(validation.Valid, qt.IsTrue, qt.Commentf("errors: %v", validation.Errors))
 }

--- a/api/processes_test.go
+++ b/api/processes_test.go
@@ -139,6 +139,74 @@ func TestVotingProcessUpdate(t *testing.T) {
 	c.Assert(got.Title["default"], qt.Equals, "Updated title")
 }
 
+// TestVotingProcessUpdateBallotShapeEcho covers the PUT path a client actually takes: read a
+// draft, change one field, send the whole body back. Responses always carry a ballotProtocol and a
+// supplied one is authoritative, so the echoed protocol has to either agree with the typeSetup
+// beside it or be refused — silently overriding the edit would be the same lie as #619, applied to
+// the client's intent instead of the ballot.
+func TestVotingProcessUpdateBallotShapeEcho(t *testing.T) {
+	c := qt.New(t)
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, adminToken, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, adminToken, newVotingProcessRequest(orgAddress, ids), processesCreateEndpoint,
+	)
+	pid := created.ProcessID
+	before := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, adminToken, nil, "processes", pid)
+	c.Assert(before.Questions, qt.HasLen, 2)
+
+	// rebuild the request body out of the response, the way a UI holding the fetched draft does.
+	// Fresh each time so the mutations below cannot leak into one another.
+	echo := func() *apicommon.CreateVotingProcessRequest {
+		req := newVotingProcessRequest(orgAddress, ids)
+		req.Questions = make([]apicommon.VotingProcessQuestionRequest, len(before.Questions))
+		for i, q := range before.Questions {
+			req.Questions[i] = apicommon.VotingProcessQuestionRequest{
+				Title:             q.Title,
+				Description:       q.Description,
+				Choices:           q.Choices,
+				Type:              q.Type,
+				TypeSetup:         q.TypeSetup,
+				BallotProtocol:    q.BallotProtocol,
+				SecretUntilTheEnd: q.SecretUntilTheEnd,
+			}
+		}
+		return req
+	}
+
+	// echoing the draft back unchanged changes nothing: both halves agree, so both survive
+	requestAndAssertCode(http.StatusOK, t, http.MethodPut, adminToken, echo(), "processes", pid)
+	after := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, adminToken, nil, "processes", pid)
+	c.Assert(after.Questions, qt.HasLen, len(before.Questions))
+	for i := range after.Questions {
+		c.Assert(after.Questions[i].Type, qt.Equals, before.Questions[i].Type, qt.Commentf("question %d", i))
+		c.Assert(after.Questions[i].TypeSetup, qt.Equals, before.Questions[i].TypeSetup, qt.Commentf("question %d", i))
+		c.Assert(*after.Questions[i].BallotProtocol, qt.Equals, *before.Questions[i].BallotProtocol,
+			qt.Commentf("question %d", i))
+	}
+
+	// editing the multichoice maxChoices while echoing the protocol that still encodes the old one
+	// is refused: it used to return 200 with the edit dropped
+	stale := echo()
+	stale.Questions[1].TypeSetup.MaxChoices = 1
+	requestAndAssertError(errors.ErrInvalidData, t, http.MethodPut, adminToken, stale, "processes", pid)
+
+	// the documented way to make that edit: drop the protocol and let it be re-derived
+	edit := echo()
+	edit.Questions[1].TypeSetup.MaxChoices = 1
+	edit.Questions[1].BallotProtocol = nil
+	requestAndAssertCode(http.StatusOK, t, http.MethodPut, adminToken, edit, "processes", pid)
+	edited := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, adminToken, nil, "processes", pid)
+	c.Assert(edited.Questions[1].TypeSetup, qt.Equals, db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1})
+	c.Assert(*edited.Questions[1].BallotProtocol, qt.Equals, db.BallotProtocol{
+		MaxCount: 2, MaxValue: 1, CostExponent: 1, MaxTotalCost: 1,
+	})
+}
+
 func TestVotingProcessAuthoringErrors(t *testing.T) {
 	adminToken := testCreateUser(t, "adminpassword123")
 	orgAddress := testCreateOrganization(t, adminToken)
@@ -927,7 +995,10 @@ func TestVotingProcessRankedBallotProtocol(t *testing.T) {
 	c.Assert(got.Questions[0].TypeSetup, qt.Equals, db.QuestionTypeSetup{})
 
 	// and it is still publishable: the plan's voting-type gate gates named types, and this shape
-	// has none (mockEssentialPlan does not grant Ranked either way)
+	// has none (mockEssentialPlan does not grant Ranked either way).
+	// NOTE: ungated is today's behaviour, not a guarantee — plan.VotingTypes.Ranked is enforced
+	// nowhere (see the TODO in subscriptions.OrgAllowsVotingType). This assertion has to flip for
+	// a plan without Ranked once it is.
 	validation := requestAndParse[apicommon.VotingProcessValidateResponse](
 		t, http.MethodGet, adminToken, nil, "processes", created.ProcessID, "validation")
 	c.Assert(validation.Valid, qt.IsTrue, qt.Commentf("errors: %v", validation.Errors))

--- a/api/processes_test.go
+++ b/api/processes_test.go
@@ -139,6 +139,79 @@ func TestVotingProcessUpdate(t *testing.T) {
 	c.Assert(got.Title["default"], qt.Equals, "Updated title")
 }
 
+// TestVotingProcessLegacyDraftShapeRoundTrip covers a draft written before the two ballot halves
+// were reconciled. The old code stored whatever a client sent, so such a draft can hold shapes
+// authoring now refuses — and replacing the question array is the only way to edit one, so a read
+// that served them verbatim would freeze the draft with a 400 for a lie it did not write.
+func TestVotingProcessLegacyDraftShapeRoundTrip(t *testing.T) {
+	c := qt.New(t)
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, adminToken, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, adminToken, newVotingProcessRequest(orgAddress, ids), processesCreateEndpoint,
+	)
+	pid := created.ProcessID
+	oid, err := primitive.ObjectIDFromHex(pid)
+	c.Assert(err, qt.IsNil)
+
+	// rewrite the stored questions as the pre-reconciliation code left them: Q1 carries the #619
+	// flag and no protocol at all, Q2 a type its protocol contradicts.
+	stored, err := testDB.QuestionsByProcess(oid)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stored, qt.HasLen, 2)
+	stored[0].Type = db.VotingTypeMultiChoice
+	stored[0].TypeSetup = db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 2, UniqueChoices: true}
+	stored[0].BallotProtocol = nil
+	stored[1].Type = db.VotingTypeMultiChoice
+	stored[1].TypeSetup = db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 2}
+	stored[1].BallotProtocol = &db.BallotProtocol{MaxCount: 1, MaxValue: 1} // in fact a singlechoice
+	for i := range stored {
+		_, err := testDB.SetQuestion(&stored[i])
+		c.Assert(err, qt.IsNil)
+	}
+
+	// the read serves the shape a publish would use: the unsupported flag gone, the missing
+	// protocol derived, and the contradicted label replaced by the one the protocol encodes
+	got := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, adminToken, nil, "processes", pid)
+	c.Assert(got.Questions, qt.HasLen, 2)
+	c.Assert(got.Questions[0].Type, qt.Equals, db.VotingTypeMultiChoice)
+	c.Assert(got.Questions[0].TypeSetup, qt.Equals, db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 2})
+	c.Assert(*got.Questions[0].BallotProtocol, qt.Equals, db.BallotProtocol{
+		MaxCount: 2, MaxValue: 1, CostExponent: 1, MaxTotalCost: 2,
+	})
+	c.Assert(got.Questions[1].Type, qt.Equals, db.VotingTypeSingleChoice)
+	c.Assert(got.Questions[1].TypeSetup, qt.Equals, db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1})
+	c.Assert(*got.Questions[1].BallotProtocol, qt.Equals, db.BallotProtocol{MaxCount: 1, MaxValue: 1})
+
+	// the read reconciles what it serves, not what is stored
+	unchanged, err := testDB.QuestionsByProcess(oid)
+	c.Assert(err, qt.IsNil)
+	c.Assert(unchanged[0].TypeSetup.UniqueChoices, qt.IsTrue)
+	c.Assert(unchanged[0].BallotProtocol, qt.IsNil)
+
+	// and echoing that read back is accepted — the draft is editable again, and the update is what
+	// persists the reconciliation
+	echo := newVotingProcessRequest(orgAddress, ids)
+	echo.Questions = make([]apicommon.VotingProcessQuestionRequest, len(got.Questions))
+	for i, q := range got.Questions {
+		echo.Questions[i] = apicommon.VotingProcessQuestionRequest{
+			Title: q.Title, Choices: q.Choices, Type: q.Type, TypeSetup: q.TypeSetup, BallotProtocol: q.BallotProtocol,
+		}
+	}
+	requestAndAssertCode(http.StatusOK, t, http.MethodPut, adminToken, echo, "processes", pid)
+	persisted, err := testDB.QuestionsByProcess(oid)
+	c.Assert(err, qt.IsNil)
+	c.Assert(persisted, qt.HasLen, 2)
+	for i := range persisted {
+		c.Assert(persisted[i].TypeSetup.UniqueChoices, qt.IsFalse, qt.Commentf("question %d", i))
+		c.Assert(persisted[i].BallotProtocol, qt.Not(qt.IsNil), qt.Commentf("question %d", i))
+	}
+}
+
 // TestVotingProcessUpdateBallotShapeEcho covers the PUT path a client actually takes: read a
 // draft, change one field, send the whole body back. Responses always carry a ballotProtocol and a
 // supplied one is authoritative, so the echoed protocol has to either agree with the typeSetup

--- a/api/processes_test.go
+++ b/api/processes_test.go
@@ -932,3 +932,52 @@ func TestVotingProcessRankedBallotProtocol(t *testing.T) {
 		t, http.MethodGet, adminToken, nil, "processes", created.ProcessID, "validation")
 	c.Assert(validation.Valid, qt.IsTrue, qt.Commentf("errors: %v", validation.Errors))
 }
+
+// TestVotingProcessPlanGateOnEffectiveType covers the gate a raw ballotProtocol used to walk past:
+// the plan's voting-type limits apply to the ballot a question encodes, not to the label it
+// carries, so an org whose plan forbids multiple-choice cannot mint one by describing it in raw
+// terms. A shape with no named type stays ungated — that is what the raw protocol is for.
+func TestVotingProcessPlanGateOnEffectiveType(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, token)
+
+	singleOnlyPlan := *mockEssentialPlan
+	singleOnlyPlan.ID = "prod_test_single_only"
+	singleOnlyPlan.Name = "Single Choice Only Plan"
+	singleOnlyPlan.StripeMonthlyPriceID = "price_month_test_single_only"
+	singleOnlyPlan.StripeYearlyPriceID = "price_year_test_single_only"
+	singleOnlyPlan.Public = false
+	singleOnlyPlan.VotingTypes.Multiple = false
+	c.Assert(testDB.SetPlan(&singleOnlyPlan), qt.IsNil)
+	setOrganizationSubscription(t, orgAddress, singleOnlyPlan.ID)
+
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	// a multichoice ballot, stated in raw terms and with no type at all
+	rawMulti := newVotingProcessRequest(orgAddress, ids)
+	rawMulti.Questions = rawMulti.Questions[:1]
+	rawMulti.Questions[0].Type = ""
+	rawMulti.Questions[0].TypeSetup = db.QuestionTypeSetup{}
+	rawMulti.Questions[0].BallotProtocol = &db.BallotProtocol{
+		MaxCount: 2, MaxValue: 1, CostExponent: 1, MaxTotalCost: 2,
+	}
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, rawMulti, processesCreateEndpoint)
+	val := requestAndParse[apicommon.VotingProcessValidateResponse](
+		t, http.MethodGet, token, nil, "processes", created.ProcessID, "validation")
+	c.Assert(val.Valid, qt.IsFalse, qt.Commentf("a plan without multiple-choice must not mint one"))
+
+	// the same org can still publish a ranked ballot: it has no named type to gate
+	ranked := newVotingProcessRequest(orgAddress, ids)
+	ranked.Questions = ranked.Questions[:1]
+	ranked.Questions[0].Type = ""
+	ranked.Questions[0].TypeSetup = db.QuestionTypeSetup{}
+	ranked.Questions[0].BallotProtocol = &db.BallotProtocol{MaxCount: 2, MaxValue: 1, UniqueValues: true}
+	created = requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, ranked, processesCreateEndpoint)
+	val = requestAndParse[apicommon.VotingProcessValidateResponse](
+		t, http.MethodGet, token, nil, "processes", created.ProcessID, "validation")
+	c.Assert(val.Valid, qt.IsTrue, qt.Commentf("errors: %v", val.Errors))
+}

--- a/db/types.go
+++ b/db/types.go
@@ -638,20 +638,29 @@ type ProcessesBundle struct {
 	Processes  []internal.HexBytes `json:"processes" bson:"processes" swaggertype:"array,string" format:"hex" example:"deadbeef"` // Array of process addresses included in this bundle
 }
 
-// QuestionTypeSetup carries the friendly ballot-type parameters for a
-// VotingProcessQuestion. It is translated into on-chain vote options at publish
-// time (see account.VoteTypeFromQuestion). MinChoices is a validation hint only
-// (the current protocol has no on-chain minimum-count field).
+// QuestionTypeSetup carries the friendly ballot-type parameters for a VotingProcessQuestion, and
+// is kept in step with its BallotProtocol: whichever half is supplied, the other is derived
+// (account.ResolveBallotShape), so the two always describe the same ballot.
+//
+// MinChoices is a validation hint only — the protocol has no on-chain minimum-count field, so it
+// is the one value that cannot be derived. UniqueChoices is not supported by either named type
+// and requests setting it on a multichoice are rejected: with one 0/1 field per choice, a
+// unique-values ballot admits no vote at all (issue #619), while a voter already cannot select
+// the same choice twice. A ranked ballot is expressed as a BallotProtocol instead.
 type QuestionTypeSetup struct {
 	MinChoices    uint32 `json:"minChoices" bson:"minChoices"`
 	MaxChoices    uint32 `json:"maxChoices" bson:"maxChoices"`
 	UniqueChoices bool   `json:"uniqueChoices" bson:"uniqueChoices"`
 }
 
-// BallotProtocol is an optional raw override of the on-chain ballot parameters. When
-// set on a VotingProcessQuestion it takes priority over Type/TypeSetup and is mapped
-// directly onto the election envelope and vote options, enabling ballot shapes
-// (approval, ranked, quadratic) before named types exist for them.
+// BallotProtocol is the on-chain ballot parameters of a VotingProcessQuestion, mapped directly
+// onto the election envelope and vote options. Every question written since the two halves were
+// reconciled carries one, derived from Type/TypeSetup when the client did not supply it.
+//
+// A client may supply it instead of a named type, which is what enables the ballot shapes that
+// have no name yet (ranked, quadratic). Supplying it alongside a type makes it authoritative —
+// it is what reaches the chain — so the type is re-derived from it, and emptied when it encodes
+// no named shape.
 type BallotProtocol struct {
 	MaxCount          uint32 `json:"maxCount" bson:"maxCount"`
 	MaxValue          uint32 `json:"maxValue" bson:"maxValue"`

--- a/db/types.go
+++ b/db/types.go
@@ -643,7 +643,10 @@ type ProcessesBundle struct {
 // (account.ResolveBallotShape), so the two always describe the same ballot.
 //
 // MinChoices is a validation hint only — the protocol has no on-chain minimum-count field, so it
-// is the one value that cannot be derived. UniqueChoices is not supported by either named type
+// is the one value that cannot be derived. It is kept as sent for multichoice (clamped to
+// MaxChoices), where a voter may legitimately be asked for at least N; for singlechoice it is
+// always 1, that ballot being the single field a voter fills, so a stated 0 would describe a
+// submission the chain cannot express. UniqueChoices is not supported by either named type
 // and requests setting it on a multichoice are rejected: with one 0/1 field per choice, a
 // unique-values ballot admits no vote at all (issue #619), while a voter already cannot select
 // the same choice twice. A ranked ballot is expressed as a BallotProtocol instead.

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -5954,9 +5954,15 @@ paths:
         is derived, so the stored question always describes the election it will mint. A
         supplied `ballotProtocol` is authoritative — it is what reaches the chain — so `type`
         and `typeSetup` are re-derived from it, and come back empty when it encodes a shape
-        with no named type (ranked, quadratic). **Omit `ballotProtocol` to author or edit a
-        question through its `typeSetup`**: sending back a response body unchanged will
-        otherwise re-apply the protocol it carries.
+        with no named type (ranked, quadratic). Sending both halves is fine when they agree;
+        when they describe two different named ballots it is a 400 rather than a silent win
+        for the protocol. **Omit `ballotProtocol` to author or edit a question through its
+        `typeSetup`** — responses always carry a protocol, so echoing one back unchanged
+        re-applies it.
+
+        `typeSetup.minChoices` has no on-chain counterpart and is a validation hint for
+        clients. It is stored as sent for multichoice, and is always `1` for singlechoice,
+        whose ballot is the single field a voter fills.
 
         `typeSetup.uniqueChoices` is rejected for multichoice: every choice is an independent
         yes/no field, so a unique-values ballot admits no vote and the election would tally
@@ -6065,8 +6071,9 @@ paths:
       description: |-
         Update a voting process while it is still a draft (not published). 409 if already published.
         The questions are replaced wholesale, and each one's ballot shape is reconciled exactly
-        as on create — so omit `ballotProtocol` when editing a question through its `typeSetup`,
-        or the protocol carried in the body wins and the edit is not applied.
+        as on create. Reading a question and PUTting it back unchanged is a no-op; editing its
+        `typeSetup` while echoing the `ballotProtocol` that still encodes the old shape is a
+        400 — omit `ballotProtocol` to edit a question through its `typeSetup`.
 
         Send the updatedAt read from GET /processes/{processId} to make the update conditional: it is
         rejected with 409 (40171) if anything wrote the process in between, so two editors cannot

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -5948,8 +5948,20 @@ paths:
       description: |-
         Create a multi-question voting process draft. Requires Manager/Admin role of the org
         (or a scoped API key with `voting:write`). Creates the inline census unpublished.
-        Each question must define either a named `type` (with `typeSetup` for multichoice)
-        or a raw `ballotProtocol` override; if both are given the `ballotProtocol` wins.
+
+        Each question must define a named `type` (with `typeSetup` for multichoice), a raw
+        `ballotProtocol`, or both. The two are kept in sync: whichever is supplied, the other
+        is derived, so the stored question always describes the election it will mint. A
+        supplied `ballotProtocol` is authoritative — it is what reaches the chain — so `type`
+        and `typeSetup` are re-derived from it, and come back empty when it encodes a shape
+        with no named type (ranked, quadratic). **Omit `ballotProtocol` to author or edit a
+        question through its `typeSetup`**: sending back a response body unchanged will
+        otherwise re-apply the protocol it carries.
+
+        `typeSetup.uniqueChoices` is rejected for multichoice: every choice is an independent
+        yes/no field, so a unique-values ballot admits no vote and the election would tally
+        every vote to zero. A `ballotProtocol` whose `uniqueValues` cannot be satisfied
+        (fewer legal values than fields) is rejected for the same reason.
       parameters:
       - description: Voting process
         in: body
@@ -6052,6 +6064,10 @@ paths:
       - application/json
       description: |-
         Update a voting process while it is still a draft (not published). 409 if already published.
+        The questions are replaced wholesale, and each one's ballot shape is reconciled exactly
+        as on create — so omit `ballotProtocol` when editing a question through its `typeSetup`,
+        or the protocol carried in the body wins and the edit is not applied.
+
         Send the updatedAt read from GET /processes/{processId} to make the update conditional: it is
         rejected with 409 (40171) if anything wrote the process in between, so two editors cannot
         overwrite each other. Omitting updatedAt opts out of that guarantee and keeps last-writer-wins.

--- a/subscriptions/subscriptions.go
+++ b/subscriptions/subscriptions.go
@@ -336,6 +336,13 @@ func (p *Subscriptions) OrgAllowsVotingType(orgAddress common.Address, voteType 
 	if err != nil {
 		return err
 	}
+	// TODO:future the remaining plan.VotingTypes flags (Ranked, Approval, Cumulative) have no
+	// entry here because db has no type constant for them, so nothing can ever resolve to one and
+	// the flags are permissive by omission: an org whose plan lacks Ranked can still mint a ranked
+	// ballot through a raw ballotProtocol. Same gap as the type check noted in
+	// hasElectionMetadataPermissions above. Approval may not belong here at all — the multichoice
+	// dense layout is an approval ballot, so that flag may be subsumed by Multiple rather than
+	// missing; worth settling with whoever defined the plan tiers before adding it.
 	allowed := map[string]bool{
 		db.VotingTypeSingleChoice: plan.VotingTypes.Single,
 		db.VotingTypeMultiChoice:  plan.VotingTypes.Multiple,

--- a/subscriptions/subscriptions.go
+++ b/subscriptions/subscriptions.go
@@ -319,9 +319,11 @@ func (p *Subscriptions) OrgCanCreateVotingProcessDraft(orgAddress common.Address
 
 // OrgAllowsVotingType checks that the organization's plan permits the given question ballot
 // type. It maps the friendly type to the plan's VotingTypes feature flags. An empty type is
-// allowed (it is validated elsewhere); a raw ballotProtocol override skips this check by
-// passing an empty voteType. Weighted elections stay gated separately via CostFromWeight in
-// hasElectionMetadataPermissions.
+// allowed (it is validated elsewhere), which is also how a ballot shape with no named type —
+// ranked, quadratic, expressed as a raw ballotProtocol — passes: there is no flag for it.
+// Callers pass account.EffectiveQuestionType, so a question is gated on the ballot it encodes
+// rather than the type it is labelled with. Weighted elections stay gated separately via
+// CostFromWeight in hasElectionMetadataPermissions.
 func (p *Subscriptions) OrgAllowsVotingType(orgAddress common.Address, voteType string) error {
 	if voteType == "" {
 		return nil


### PR DESCRIPTION
Closes #619.

## Problem

A question describes its ballot twice — as a named `type` with its `typeSetup`, and as a raw
`ballotProtocol` — and nothing related the two. `buildQuestions` stored whichever halves the client
sent, verbatim and uncrossed; at publish, `VoteTypeFromQuestion` silently preferred the protocol. So
a stored question could describe one ballot to every reader (manager API, voter API) and mint a
different one on chain — permanently, since questions are immutable after publish.

#619 is the worst instance of that gap being *inside* one half. `multichoice` derives the dense
layout (`maxCount = len(choices)`, `maxValue = 1`: one 0/1 field per choice) and **also** mapped
`typeSetup.uniqueChoices` onto the on-chain `uniqueValues`. The two cannot both hold: with only `0`
and `1` available, any ballot over ≥3 fields must repeat a value, so the scrutinizer rejects every
envelope. Votes reach the chain, `voteCount` rises, `finalResults` flips, and every choice tallies
**zero** — with no error at create, publish, vote or read time.

## The model

One canonical direction, with recognition defined **as** equality against it, so the two halves
cannot drift:

```
forward(type, typeSetup, choices) -> ballotProtocol          # the only mapping table
reverse(ballotProtocol, choices)  -> (type, typeSetup, ok)   # "which named type produces exactly this?"
```

Stored invariant, asserted directly in a test:

> `Type != "" ⇒ BallotProtocolFromType(Type, TypeSetup, Choices) == *BallotProtocol`

| field | `singlechoice` | `multichoice` |
|---|---|---|
| `MaxCount` | `1` | `len(choices)` |
| `MaxValue` | `max(choices[i].Value)` | `1` |
| `MaxVoteOverwrites` | `0` | `0` |
| `CostExponent` | `0` | `1` |
| `MaxTotalCost` | `0` | `typeSetup.MaxChoices` |
| `UniqueValues` | `false` | **`false`** ← the fix |
| `CostFromWeight` | `false` | `false` |

Identical to the previous derivation **field for field except `UniqueValues`**, so no already-working
election changes its on-chain parameters.

Recognition is a function, not a first-match heuristic: the two named types never share an image,
because `CostExponent` is unconditionally `0` for singlechoice and `1` for multichoice.
`TestBallotShapeUnambiguous` pins that for every choice count 1..8, so a future field change fails
there before it fails somewhere subtler. `reverse` takes the choices too — a raw
`{maxCount: 1, maxValue: 2}` over choices valued `{0, 2, 5}` is **not** singlechoice, because that
protocol cannot carry value 5, and labelling it so would be exactly the class of lie being fixed.

`minChoices` has no protocol counterpart and is enforced nowhere. It is carried over from the request
only when the resolved type is the type the request asked for, clamped to the resolved `maxChoices`;
otherwise it takes the canonical value. Keeping a client's minimum against a shape they did not get
would leave the rejected half alive as a number a UI enforces — #619 one field smaller.

## Behaviour

**A supplied `ballotProtocol` is authoritative** — it is what reaches the chain — so `type` and
`typeSetup` are re-derived from it, and go empty when it encodes a shape with no named type (ranked,
quadratic). With no protocol, one is derived from the type. Either way both halves are stored, and
each re-derives the other.

**Two ballots no voter can satisfy are now refused at authoring time** instead of accepted and
silently discarded:

- `multichoice` + `typeSetup.uniqueChoices` → `400`. Each choice is its own 0/1 field, so demanding
  distinct field values admits no vote at all. Uniqueness is already structural there, which is what
  makes the flag look reasonable and be fatal — normalising it away would leave the author believing
  they had set something.
- a raw protocol with fewer legal values than fields (`uniqueValues && maxValue+1 < maxCount`), or
  none at all (`maxCount == 0`, the empty object a client sends by always including the key).

`singlechoice` + `uniqueChoices` stays accepted: with one field it is vacuous rather than
unsatisfiable, and the reconciliation normalises it away.

**The plan's voting-type gate now applies to the inferred type.** A raw protocol used to skip
`OrgAllowsVotingType` entirely, so a plan without `multiple` could mint a multichoice election by
describing it in raw terms. Publish now gates on `account.EffectiveQuestionType`, which reads the
ballot rather than the label — so a legacy document whose stored type contradicts its protocol is
gated by the protocol. Shapes with no named type stay ungated, exactly as before.

## No migration

Questions stored before this keep working. `VoteTypeFromQuestion` derives a protocol from
`type`/`typeSetup` when a question has none — and that path no longer reads `uniqueChoices`, so a
draft carrying the #619 shape now publishes as the plain approval ballot its author meant. Nothing is
rewritten; the flag is simply not read. A legacy draft is reconciled the first time it is PUT.

Publish also rejects a *stored* protocol that is unsatisfiable, since a question written before this
cannot be edited once published and `GET /processes/{id}/validation` should say so.

## Breaking changes

- **A question carrying a protocol with no named shape reads back with an empty `type`.** This is
  what `saas-integrator-demo` sends for its ranked ballots (`type: "singlechoice"` plus
  `ballotProtocol{maxCount: n, maxValue: n-1, uniqueValues: true}`). Its ballot is unaffected and it
  never reads `type` back (checked), but any client rendering by `type` on such a question breaks.
- **`singlechoice` `typeSetup` is normalised** to `{minChoices: 1, maxChoices: 1, uniqueChoices: false}`.
  The document stops lying; the echo changes.
- **Responses always carry `ballotProtocol` now.** A client that reads a draft and PUTs the whole
  object back therefore sends both halves, and the protocol wins — **omit `ballotProtocol` to edit a
  question through its `typeSetup`**. This is stated in the swagger description of both create and
  update. If it bites the UI, the cheap follow-up is an explicit re-derive signal.
- Closing the plan-gate bypass can refuse a previously publishable draft, but only for an org whose
  plan lacks Single/Multiple with a raw protocol that resolves to a named type.

## Already-published elections are not repaired

On-chain vote options are immutable, so the processes already minted with `uniqueValues: true` on a
dense layout stay dead — their votes are on chain, never aggregated, `finalResults` stamped,
nullifiers consumed. Known affected on dev: `6a69c4ea06ae8a7235e3183b`, `6a6912fef6bfe54e0369bc3a`,
`6a69e32a06ae8a7235e318ef`. They have to be re-created.

## Verification

- `go build ./...`, `go vet ./...` clean; `golangci-lint` **0 issues**; `scripts/check-qt-patterns.sh`
  clean; `make swagger` regenerated.
- `go test ./account/` — 11 tests, all passing, verified per-test with `-v`. Includes the inverted
  assertion in `TestVoteTypeFromQuestion/multichoice`: the input still carries `uniqueChoices: true`,
  and now asserts the derived `UniqueChoices` is **false**, pinning that a legacy flag is ignored
  rather than honoured. Every other assertion in that subtest is unchanged, which is what proves the
  fix alters nothing else on chain.
- New unit coverage: `TestBallotProtocolFromType`, `TestQuestionTypeFromBallotProtocol`,
  `TestBallotShapeUnambiguous`, `TestResolveBallotShapeRoundTrip`, `TestResolveBallotShapeProtocolWins`,
  `TestValidateBallotProtocol`, `TestEffectiveQuestionType`.
- Full `./api/` passes (480 s). Full `./db/` passes.
  - `TestVotingProcessAuthoringErrors` gains the #619 regression (`multichoice` + `uniqueChoices` →
    400) and both raw-protocol refusals.
  - `TestVotingProcessBallotShapeConsistency` asserts both halves agree on the manager read and that
    each re-derives the other; the voter-facing read is asserted in `TestVotingProcessResults`.
  - `TestVotingProcessRankedBallotProtocol` is the downstream-integrator regression: the demo's exact
    shape still creates, still validates for publish under a plan without `Ranked`, and reads back
    with the protocol verbatim.
  - `TestVotingProcessPlanGateOnEffectiveType` covers the closed bypass and that unnamed shapes stay
    ungated.

The one thing the suite cannot prove is the tally itself — the failure mode is invisible in the API.
Worth running once by hand against `docker compose --profile with-vocone`: publish a `multichoice`
question, cast `[1,0,1,0]`, and read `GET /processes/{id}/results` expecting a non-zero matrix.
