### PR TITLE
feat(api): verify vote nullifiers at POST /votes/verify

### DIFF
--- a/account/process.go
+++ b/account/process.go
@@ -2,15 +2,18 @@ package account
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math"
+	"net/http"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/internal"
 	"go.vocdoni.io/dvote/api"
+	"go.vocdoni.io/dvote/apiclient"
 	"go.vocdoni.io/proto/build/go/models"
 )
 
@@ -265,6 +268,35 @@ func (a *Account) Election(processID []byte) (*api.Election, error) {
 		return nil, fmt.Errorf("could not fetch election %x: %w", processID, err)
 	}
 	return election, nil
+}
+
+// ErrVoteNotFound is returned by VoteByNullifier when the chain has no vote with the
+// given nullifier. It is a distinct sentinel because "the chain does not know this vote"
+// is an answer, while any other failure means the chain could not be asked.
+var ErrVoteNotFound = fmt.Errorf("vote not found")
+
+// VoteByNullifier fetches an on-chain vote by its nullifier (voteID) from the Vochain,
+// returning ErrVoteNotFound when the chain does not know it. The node keys this lookup on
+// the nullifier alone — unlike its /votes/verify route, which also needs the election id —
+// so a caller holding only a nullifier can still resolve the vote and the election it
+// belongs to. There is no apiclient wrapper for it, hence the raw request.
+func (a *Account) VoteByNullifier(nullifier []byte) (*api.Vote, error) {
+	resp, code, err := a.client.Request(apiclient.HTTPGET, nil, "votes", hex.EncodeToString(nullifier))
+	if err != nil {
+		return nil, fmt.Errorf("could not fetch vote %x: %w", nullifier, err)
+	}
+	switch code {
+	case http.StatusOK:
+		vote := &api.Vote{}
+		if err := json.Unmarshal(resp, vote); err != nil {
+			return nil, fmt.Errorf("could not decode vote %x: %w", nullifier, err)
+		}
+		return vote, nil
+	case http.StatusNotFound:
+		return nil, ErrVoteNotFound
+	default:
+		return nil, fmt.Errorf("could not fetch vote %x: status %d (%s)", nullifier, code, resp)
+	}
 }
 
 // ElectionEncryptionKeys fetches the encryption public keys of the on-chain election with

--- a/account/vote_test.go
+++ b/account/vote_test.go
@@ -1,0 +1,64 @@
+package account
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"go.vocdoni.io/dvote/api"
+	"go.vocdoni.io/dvote/apiclient"
+)
+
+// TestVoteByNullifier exercises the three answers a node can give — a vote, a 404, and any
+// other status — against a fake node, since the containerized chain cannot be made to fail
+// on demand. The failure case uses 500, not 503: apiclient retries 503 waiting for a block.
+func TestVoteByNullifier(t *testing.T) {
+	c := qt.New(t)
+
+	known := []byte(strings.Repeat("k", 32))
+	knownVote := &api.Vote{
+		ElectionID:  []byte(strings.Repeat("e", 32)),
+		TxHash:      []byte(strings.Repeat("t", 32)),
+		BlockHeight: 42,
+	}
+	broken := []byte(strings.Repeat("b", 32))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/votes/" + hex.EncodeToString(known):
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(knownVote); err != nil {
+				t.Errorf("encoding vote: %v", err)
+			}
+		case "/votes/" + hex.EncodeToString(broken):
+			http.Error(w, "boom", http.StatusInternalServerError)
+		default: // including the /chain/info probe apiclient.New makes
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// the trailing slash matters: apiclient joins paths onto the base URL's path, and an
+	// empty base path would yield a request line without a leading slash (a 400 from net/http)
+	client, err := apiclient.New(srv.URL + "/")
+	c.Assert(err, qt.IsNil)
+	a := &Account{client: client}
+
+	vote, err := a.VoteByNullifier(known)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]byte(vote.ElectionID), qt.DeepEquals, []byte(knownVote.ElectionID))
+	c.Assert([]byte(vote.TxHash), qt.DeepEquals, []byte(knownVote.TxHash))
+	c.Assert(vote.BlockHeight, qt.Equals, knownVote.BlockHeight)
+
+	_, err = a.VoteByNullifier([]byte(strings.Repeat("u", 32)))
+	c.Assert(err, qt.ErrorIs, ErrVoteNotFound)
+
+	_, err = a.VoteByNullifier(broken)
+	c.Assert(err, qt.Not(qt.ErrorIs), ErrVoteNotFound, qt.Commentf("a node failure must not read as not-found"))
+	c.Assert(err, qt.ErrorMatches, fmt.Sprintf("(?s)could not fetch vote %x: status 500.*", broken))
+}

--- a/api/api.go
+++ b/api/api.go
@@ -462,6 +462,7 @@ func (a *API) initRouter() http.Handler {
 		handle(r, http.MethodGet, processEndpoint, a.processInfoHandler)
 		handle(r, http.MethodPost, voteEndpoint, a.relayVoteHandler)
 		handle(r, http.MethodPost, votesEndpoint, a.relayVotesHandler)
+		handle(r, http.MethodPost, votesVerifyEndpoint, a.verifyVotesHandler)
 		handle(r, http.MethodGet, processResultsEndpoint, a.processResultsHandler)
 		handle(r, http.MethodGet, processMetadataEndpoint, a.processMetadataHandler)
 		handle(r, http.MethodPost, processSignInfoEndpoint, cspHandlers.ConsumedAddressHandler)

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -1327,7 +1327,8 @@ type RelayVotesRequest struct {
 // voting process.
 // swagger:model VerifyVotesRequest
 type VerifyVotesRequest struct {
-	// Vote nullifiers (32 bytes each), at most 100
+	// Vote nullifiers (up to 32 bytes each — anonymous ones may be shorter), capped at the
+	// shared vote batch limit (100)
 	Nullifiers []internal.HexBytes `json:"nullifiers" swaggertype:"array,string"`
 }
 

--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -1322,6 +1322,40 @@ type RelayVotesRequest struct {
 	Votes []RelayVoteRequest `json:"votes"`
 }
 
+// VerifyVotesRequest is the body of POST /votes/verify: the vote nullifiers a voter wants
+// checked against the chain, typically the one nullifier per question of a multi-question
+// voting process.
+// swagger:model VerifyVotesRequest
+type VerifyVotesRequest struct {
+	// Vote nullifiers (32 bytes each), at most 100
+	Nullifiers []internal.HexBytes `json:"nullifiers" swaggertype:"array,string"`
+}
+
+// VerifiedVote is the outcome of checking one nullifier against the chain. Everything
+// beyond Verified comes from the on-chain vote and is absent when it was not found.
+// swagger:model VerifiedVote
+type VerifiedVote struct {
+	// The nullifier that was checked, echoed back
+	Nullifier internal.HexBytes `json:"nullifier" swaggertype:"string" format:"hex" example:"deadbeef"`
+	// Whether the chain has a vote with this nullifier
+	Verified bool `json:"verified"`
+	// On-chain election id the vote belongs to
+	ProcessID internal.HexBytes `json:"processId,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`
+	// Hash of the transaction that carried the vote
+	TxHash internal.HexBytes `json:"txHash,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`
+	// Block the vote was registered in
+	BlockHeight uint32 `json:"blockHeight,omitempty"`
+	// When the vote was registered on chain
+	Date *time.Time `json:"date,omitempty"`
+}
+
+// VerifyVotesResponse is returned by POST /votes/verify, one entry per requested
+// nullifier in the order they were given.
+// swagger:model VerifyVotesResponse
+type VerifyVotesResponse struct {
+	Votes []VerifiedVote `json:"votes"`
+}
+
 // RelayVoteResponse is returned by POST /vote with the vote nullifier (voteID)
 // assigned on chain.
 // swagger:model RelayVoteResponse

--- a/api/process_vote.go
+++ b/api/process_vote.go
@@ -257,7 +257,8 @@ const (
 //	@Description	public on chain. Several nullifiers are accepted in one call because a multi-question
 //	@Description	voting process is one on-chain election per question, so a voter holds one nullifier
 //	@Description	per question. The response has one entry per requested nullifier, in the same order;
-//	@Description	an unknown nullifier is reported as verified=false rather than as an error, while a
+//	@Description	a repeated nullifier is looked up only once and every copy gets the same answer.
+//	@Description	An unknown nullifier is reported as verified=false rather than as an error, while a
 //	@Description	chain that cannot be reached fails the whole call so a voter is never told their vote
 //	@Description	is missing when it merely could not be looked up.
 //	@Tags			vote
@@ -292,17 +293,31 @@ func (a *API) verifyVotesHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// one chain read per nullifier, fanned out with the same bounded pool the per-question
-	// resolvers use: a vote lookup costs ~250ms against a remote node, so at the batch cap a
-	// sequential loop would be a ~25s request. Each callback writes only its own index, so
-	// the result slices need no locking.
+	// a repeated nullifier is asked to the chain only once: the endpoint is public, so a
+	// caller must not be able to multiply chain reads by repeating one value. firstOf maps
+	// each nullifier to the index of its first occurrence, and after the fan-out every
+	// duplicate copies that occurrence's answer.
+	firstOf := make(map[string]int, len(req.Nullifiers))
+	var distinct []int
+	for i, nullifier := range req.Nullifiers {
+		if _, seen := firstOf[string(nullifier)]; !seen {
+			firstOf[string(nullifier)] = i
+			distinct = append(distinct, i)
+		}
+	}
+
+	// one chain read per distinct nullifier, fanned out with the same bounded pool the
+	// per-question resolvers use: a vote lookup costs ~250ms against a remote node, so at
+	// the batch cap a sequential loop would be a ~25s request. Each callback writes only
+	// its own index, so the result slices need no locking.
 	votes := make([]apicommon.VerifiedVote, len(req.Nullifiers))
-	errs := make([]error, len(req.Nullifiers))
-	parallelForEach(len(req.Nullifiers), func(i int) {
+	errs := make([]error, len(distinct))
+	parallelForEach(len(distinct), func(d int) {
+		i := distinct[d]
 		votes[i].Nullifier = req.Nullifiers[i]
 		// nobody is left to read the answer: stop asking the node for the rest of the batch.
 		if err := r.Context().Err(); err != nil {
-			errs[i] = err
+			errs[d] = err
 			return
 		}
 		vote, err := a.account.VoteByNullifier(req.Nullifiers[i])
@@ -310,7 +325,7 @@ func (a *API) verifyVotesHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err != nil {
-			errs[i] = err
+			errs[d] = err
 			return
 		}
 		votes[i].Verified = true
@@ -324,6 +339,10 @@ func (a *API) verifyVotesHandler(w http.ResponseWriter, r *http.Request) {
 	if err := stderrors.Join(errs...); err != nil {
 		errors.ErrVochainRequestFailed.WithErr(err).Write(w)
 		return
+	}
+	// fan the answers back out to the duplicates (self-assignment for first occurrences).
+	for i, nullifier := range req.Nullifiers {
+		votes[i] = votes[firstOf[string(nullifier)]]
 	}
 
 	apicommon.HTTPWriteJSON(w, &apicommon.VerifyVotesResponse{Votes: votes})

--- a/api/process_vote.go
+++ b/api/process_vote.go
@@ -238,8 +238,10 @@ func (a *API) relayVotesHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 const (
-	// nullifierSize is the length of a vote nullifier, which the chain derives as a hash
-	// (see state.GenerateNullifier), so anything else cannot name a vote.
+	// nullifierSize is the maximum length of a vote nullifier. Regular nullifiers are
+	// 32-byte hashes (see state.GenerateNullifier), but anonymous (ZK) ones are the minimal
+	// big-endian bytes of a field element (zk.Proof.Nullifier), so shorter values are valid
+	// too — only empty or longer than 32 bytes cannot name a vote.
 	nullifierSize = 32
 	// maxVerifyVotesBodyBytes bounds a POST /votes/verify body: a hex nullifier is 64
 	// characters, so 80 leaves room for the JSON quoting and separator around each, plus
@@ -247,6 +249,14 @@ const (
 	// to be bounded before it is buffered.
 	maxVerifyVotesBodyBytes = maxVotesPerBatch*80 + 4<<10
 )
+
+// verifyLookupSem bounds concurrent node reads across every POST /votes/verify request.
+// Each request fans out through its own 8-worker parallelForEach pool, so without a shared
+// ceiling the node load scales with request concurrency on a public endpoint (the global
+// middleware.Throttle admits 100 requests → up to 800 concurrent reads). 32 lets four
+// fully-fanned batches run against the node; the typical single-nullifier request never
+// notices it.
+var verifyLookupSem = make(chan struct{}, 32)
 
 // verifyVotesHandler godoc
 //
@@ -286,8 +296,8 @@ func (a *API) verifyVotesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for i, nullifier := range req.Nullifiers {
-		if len(nullifier) != nullifierSize {
-			errors.ErrMalformedBody.Withf("the nullifier at index %d is %d bytes, expected %d",
+		if len(nullifier) == 0 || len(nullifier) > nullifierSize {
+			errors.ErrMalformedBody.Withf("the nullifier at index %d is %d bytes, expected 1..%d",
 				i, len(nullifier), nullifierSize).Write(w)
 			return
 		}
@@ -315,9 +325,12 @@ func (a *API) verifyVotesHandler(w http.ResponseWriter, r *http.Request) {
 	parallelForEach(len(distinct), func(d int) {
 		i := distinct[d]
 		votes[i].Nullifier = req.Nullifiers[i]
-		// nobody is left to read the answer: stop asking the node for the rest of the batch.
-		if err := r.Context().Err(); err != nil {
-			errs[d] = err
+		// wait for a cross-request lookup slot, unless nobody is left to read the answer.
+		select {
+		case verifyLookupSem <- struct{}{}:
+			defer func() { <-verifyLookupSem }()
+		case <-r.Context().Done():
+			errs[d] = r.Context().Err()
 			return
 		}
 		vote, err := a.account.VoteByNullifier(req.Nullifiers[i])
@@ -335,9 +348,12 @@ func (a *API) verifyVotesHandler(w http.ResponseWriter, r *http.Request) {
 		votes[i].Date = vote.Date
 	})
 	// a nullifier the chain could not be asked about is not a verified=false: nothing is
-	// known about that vote, and reporting it as missing would be a lie to the voter.
+	// known about that vote, and reporting it as missing would be a lie to the voter. The
+	// per-nullifier detail carries raw node responses, so it goes to the log, not to the
+	// unauthenticated caller.
 	if err := stderrors.Join(errs...); err != nil {
-		errors.ErrVochainRequestFailed.WithErr(err).Write(w)
+		log.Warnw("vote verification failed", "error", err)
+		errors.ErrVochainRequestFailed.Write(w)
 		return
 	}
 	// fan the answers back out to the duplicates (self-assignment for first occurrences).

--- a/api/process_vote.go
+++ b/api/process_vote.go
@@ -237,6 +237,98 @@ func (a *API) relayVotesHandler(w http.ResponseWriter, r *http.Request) {
 	apicommon.HTTPWriteJSONStatus(w, http.StatusAccepted, &apicommon.EnqueuedResponse{JobID: jobID})
 }
 
+const (
+	// nullifierSize is the length of a vote nullifier, which the chain derives as a hash
+	// (see state.GenerateNullifier), so anything else cannot name a vote.
+	nullifierSize = 32
+	// maxVerifyVotesBodyBytes bounds a POST /votes/verify body: a hex nullifier is 64
+	// characters, so 80 leaves room for the JSON quoting and separator around each, plus
+	// slack for the framing. Like the relay endpoints this one is public, so the body has
+	// to be bounded before it is buffered.
+	maxVerifyVotesBodyBytes = maxVotesPerBatch*80 + 4<<10
+)
+
+// verifyVotesHandler godoc
+//
+//	@Summary		Verify vote nullifiers against the Vochain
+//	@Description	Checks whether the Vochain has a vote for each of the given nullifiers, so a voter
+//	@Description	can confirm that the ballots relayed on their behalf are registered on chain. Public
+//	@Description	endpoint: no authentication is required, and it exposes only data that is already
+//	@Description	public on chain. Several nullifiers are accepted in one call because a multi-question
+//	@Description	voting process is one on-chain election per question, so a voter holds one nullifier
+//	@Description	per question. The response has one entry per requested nullifier, in the same order;
+//	@Description	an unknown nullifier is reported as verified=false rather than as an error, while a
+//	@Description	chain that cannot be reached fails the whole call so a voter is never told their vote
+//	@Description	is missing when it merely could not be looked up.
+//	@Tags			vote
+//	@Accept			json
+//	@Produce		json
+//	@Param			request	body		apicommon.VerifyVotesRequest	true	"Vote nullifiers to verify"
+//	@Success		200		{object}	apicommon.VerifyVotesResponse	"Verification outcome per nullifier"
+//	@Failure		400		{object}	errors.Error					"Invalid input data"
+//	@Failure		413		{object}	errors.Error					"Request body too large"
+//	@Failure		500		{object}	errors.Error					"Blockchain request failed"
+//	@Router			/votes/verify [post]
+func (a *API) verifyVotesHandler(w http.ResponseWriter, r *http.Request) {
+	var req apicommon.VerifyVotesRequest
+	if err := decodeCappedJSON(w, r, &req, maxVerifyVotesBodyBytes); err != nil {
+		err.Write(w)
+		return
+	}
+	switch {
+	case len(req.Nullifiers) == 0:
+		errors.ErrVoteBatchEmpty.Write(w)
+		return
+	case len(req.Nullifiers) > maxVotesPerBatch:
+		errors.ErrVoteBatchTooLarge.Withf("%d nullifiers, the maximum is %d",
+			len(req.Nullifiers), maxVotesPerBatch).Write(w)
+		return
+	}
+	for i, nullifier := range req.Nullifiers {
+		if len(nullifier) != nullifierSize {
+			errors.ErrMalformedBody.Withf("the nullifier at index %d is %d bytes, expected %d",
+				i, len(nullifier), nullifierSize).Write(w)
+			return
+		}
+	}
+
+	// one chain read per nullifier, fanned out with the same bounded pool the per-question
+	// resolvers use: a vote lookup costs ~250ms against a remote node, so at the batch cap a
+	// sequential loop would be a ~25s request. Each callback writes only its own index, so
+	// the result slices need no locking.
+	votes := make([]apicommon.VerifiedVote, len(req.Nullifiers))
+	errs := make([]error, len(req.Nullifiers))
+	parallelForEach(len(req.Nullifiers), func(i int) {
+		votes[i].Nullifier = req.Nullifiers[i]
+		// nobody is left to read the answer: stop asking the node for the rest of the batch.
+		if err := r.Context().Err(); err != nil {
+			errs[i] = err
+			return
+		}
+		vote, err := a.account.VoteByNullifier(req.Nullifiers[i])
+		if stderrors.Is(err, account.ErrVoteNotFound) {
+			return
+		}
+		if err != nil {
+			errs[i] = err
+			return
+		}
+		votes[i].Verified = true
+		votes[i].ProcessID = internal.HexBytes(vote.ElectionID)
+		votes[i].TxHash = internal.HexBytes(vote.TxHash)
+		votes[i].BlockHeight = vote.BlockHeight
+		votes[i].Date = vote.Date
+	})
+	// a nullifier the chain could not be asked about is not a verified=false: nothing is
+	// known about that vote, and reporting it as missing would be a lie to the voter.
+	if err := stderrors.Join(errs...); err != nil {
+		errors.ErrVochainRequestFailed.WithErr(err).Write(w)
+		return
+	}
+
+	apicommon.HTTPWriteJSON(w, &apicommon.VerifyVotesResponse{Votes: votes})
+}
+
 // parsedVote is one validated vote envelope: the payload to relay plus everything the
 // job needs to describe it before the chain has said anything about it.
 type parsedVote struct {

--- a/api/process_vote_test.go
+++ b/api/process_vote_test.go
@@ -339,23 +339,35 @@ func TestRelayVote(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(orgAfter.Counters.SentVotes, qt.Equals, 1)
 
-	// the voter can now verify that nullifier against the chain, and an unknown one is
-	// reported as unverified rather than failing the call
+	// the voter can now verify that nullifier against the chain: an unknown one is reported
+	// as unverified rather than failing the call, and a repeated one gets the same answer
+	// (looked up only once)
 	unknown := internal.HexBytes(internal.RandomBytes(nullifierSize))
 	verified := requestAndParse[apicommon.VerifyVotesResponse](t, http.MethodPost, "",
-		&apicommon.VerifyVotesRequest{Nullifiers: []internal.HexBytes{nullifier, unknown}},
+		&apicommon.VerifyVotesRequest{Nullifiers: []internal.HexBytes{nullifier, unknown, nullifier}},
 		"votes", "verify")
-	c.Assert(verified.Votes, qt.HasLen, 2)
+	c.Assert(verified.Votes, qt.HasLen, 3)
 	c.Assert(verified.Votes[0].Nullifier, qt.DeepEquals, nullifier)
 	c.Assert(verified.Votes[0].Verified, qt.IsTrue)
 	c.Assert(verified.Votes[0].ProcessID, qt.DeepEquals, processID)
 	c.Assert(verified.Votes[0].TxHash, qt.Not(qt.HasLen), 0)
 	c.Assert(verified.Votes[1].Nullifier, qt.DeepEquals, unknown)
 	c.Assert(verified.Votes[1].Verified, qt.IsFalse)
+	c.Assert(verified.Votes[2], qt.DeepEquals, verified.Votes[0])
 
 	// a nullifier that cannot name a vote is rejected outright, not looked up
 	requestAndAssertError(errors.ErrMalformedBody, t, http.MethodPost, "",
 		&apicommon.VerifyVotesRequest{Nullifiers: []internal.HexBytes{{0xde, 0xad}}}, "votes", "verify")
+
+	// an empty batch and one over the cap are rejected before any chain read
+	requestAndAssertError(errors.ErrVoteBatchEmpty, t, http.MethodPost, "",
+		&apicommon.VerifyVotesRequest{}, "votes", "verify")
+	tooMany := make([]internal.HexBytes, maxVotesPerBatch+1)
+	for i := range tooMany {
+		tooMany[i] = internal.RandomBytes(nullifierSize)
+	}
+	requestAndAssertError(errors.ErrVoteBatchTooLarge, t, http.MethodPost, "",
+		&apicommon.VerifyVotesRequest{Nullifiers: tooMany}, "votes", "verify")
 }
 
 // TestRelayVotesBatch relays the votes of a multi-question process in a single call and

--- a/api/process_vote_test.go
+++ b/api/process_vote_test.go
@@ -338,6 +338,24 @@ func TestRelayVote(t *testing.T) {
 	orgAfter, err := testDB.Organization(f.orgAddress)
 	c.Assert(err, qt.IsNil)
 	c.Assert(orgAfter.Counters.SentVotes, qt.Equals, 1)
+
+	// the voter can now verify that nullifier against the chain, and an unknown one is
+	// reported as unverified rather than failing the call
+	unknown := internal.HexBytes(internal.RandomBytes(nullifierSize))
+	verified := requestAndParse[apicommon.VerifyVotesResponse](t, http.MethodPost, "",
+		&apicommon.VerifyVotesRequest{Nullifiers: []internal.HexBytes{nullifier, unknown}},
+		"votes", "verify")
+	c.Assert(verified.Votes, qt.HasLen, 2)
+	c.Assert(verified.Votes[0].Nullifier, qt.DeepEquals, nullifier)
+	c.Assert(verified.Votes[0].Verified, qt.IsTrue)
+	c.Assert(verified.Votes[0].ProcessID, qt.DeepEquals, processID)
+	c.Assert(verified.Votes[0].TxHash, qt.Not(qt.HasLen), 0)
+	c.Assert(verified.Votes[1].Nullifier, qt.DeepEquals, unknown)
+	c.Assert(verified.Votes[1].Verified, qt.IsFalse)
+
+	// a nullifier that cannot name a vote is rejected outright, not looked up
+	requestAndAssertError(errors.ErrMalformedBody, t, http.MethodPost, "",
+		&apicommon.VerifyVotesRequest{Nullifiers: []internal.HexBytes{{0xde, 0xad}}}, "votes", "verify")
 }
 
 // TestRelayVotesBatch relays the votes of a multi-question process in a single call and

--- a/api/process_vote_test.go
+++ b/api/process_vote_test.go
@@ -340,13 +340,15 @@ func TestRelayVote(t *testing.T) {
 	c.Assert(orgAfter.Counters.SentVotes, qt.Equals, 1)
 
 	// the voter can now verify that nullifier against the chain: an unknown one is reported
-	// as unverified rather than failing the call, and a repeated one gets the same answer
-	// (looked up only once)
+	// as unverified rather than failing the call, a repeated one gets the same answer
+	// (looked up only once), and a short one is accepted — anonymous (ZK) nullifiers are
+	// minimal big-endian field elements, so they may be under 32 bytes
 	unknown := internal.HexBytes(internal.RandomBytes(nullifierSize))
+	short := internal.HexBytes{0xde, 0xad}
 	verified := requestAndParse[apicommon.VerifyVotesResponse](t, http.MethodPost, "",
-		&apicommon.VerifyVotesRequest{Nullifiers: []internal.HexBytes{nullifier, unknown, nullifier}},
+		&apicommon.VerifyVotesRequest{Nullifiers: []internal.HexBytes{nullifier, unknown, nullifier, short}},
 		"votes", "verify")
-	c.Assert(verified.Votes, qt.HasLen, 3)
+	c.Assert(verified.Votes, qt.HasLen, 4)
 	c.Assert(verified.Votes[0].Nullifier, qt.DeepEquals, nullifier)
 	c.Assert(verified.Votes[0].Verified, qt.IsTrue)
 	c.Assert(verified.Votes[0].ProcessID, qt.DeepEquals, processID)
@@ -354,10 +356,17 @@ func TestRelayVote(t *testing.T) {
 	c.Assert(verified.Votes[1].Nullifier, qt.DeepEquals, unknown)
 	c.Assert(verified.Votes[1].Verified, qt.IsFalse)
 	c.Assert(verified.Votes[2], qt.DeepEquals, verified.Votes[0])
+	c.Assert(verified.Votes[3].Nullifier, qt.DeepEquals, short)
+	c.Assert(verified.Votes[3].Verified, qt.IsFalse)
 
-	// a nullifier that cannot name a vote is rejected outright, not looked up
+	// a nullifier that cannot name a vote — empty or over 32 bytes — is rejected outright,
+	// not looked up
 	requestAndAssertError(errors.ErrMalformedBody, t, http.MethodPost, "",
-		&apicommon.VerifyVotesRequest{Nullifiers: []internal.HexBytes{{0xde, 0xad}}}, "votes", "verify")
+		&apicommon.VerifyVotesRequest{Nullifiers: []internal.HexBytes{{}}}, "votes", "verify")
+	requestAndAssertError(errors.ErrMalformedBody, t, http.MethodPost, "",
+		&apicommon.VerifyVotesRequest{
+			Nullifiers: []internal.HexBytes{internal.RandomBytes(nullifierSize + 1)},
+		}, "votes", "verify")
 
 	// an empty batch and one over the cap are rejected before any chain read
 	requestAndAssertError(errors.ErrVoteBatchEmpty, t, http.MethodPost, "",

--- a/api/routes.go
+++ b/api/routes.go
@@ -179,6 +179,10 @@ const (
 	// whole batch is validated and enqueued all or nothing, under a single job.
 	votesEndpoint = "/votes"
 
+	// POST /votes/verify to check whether the Vochain knows the given vote nullifiers
+	// (public), so a voter can confirm on chain the ballots relayed on their behalf.
+	votesVerifyEndpoint = "/votes/verify"
+
 	// GET /process/{processId}/results to get the trimmed on-chain election results (public).
 	// {processId} is the 24-hex ProcessID (not the on-chain election id).
 	processResultsEndpoint = "/process/{processId}/results"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1840,6 +1840,48 @@ definitions:
         format: hex
         type: string
     type: object
+  apicommon.VerifiedVote:
+    properties:
+      blockHeight:
+        description: Block the vote was registered in
+        type: integer
+      date:
+        description: When the vote was registered on chain
+        type: string
+      nullifier:
+        description: The nullifier that was checked, echoed back
+        example: deadbeef
+        format: hex
+        type: string
+      processId:
+        description: On-chain election id the vote belongs to
+        example: deadbeef
+        format: hex
+        type: string
+      txHash:
+        description: Hash of the transaction that carried the vote
+        example: deadbeef
+        format: hex
+        type: string
+      verified:
+        description: Whether the chain has a vote with this nullifier
+        type: boolean
+    type: object
+  apicommon.VerifyVotesRequest:
+    properties:
+      nullifiers:
+        description: Vote nullifiers (32 bytes each), at most 100
+        items:
+          type: string
+        type: array
+    type: object
+  apicommon.VerifyVotesResponse:
+    properties:
+      votes:
+        items:
+          $ref: '#/definitions/apicommon.VerifiedVote'
+        type: array
+    type: object
   apicommon.VotingProcessListResponse:
     properties:
       pagination:
@@ -7506,6 +7548,49 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
       summary: Relay a batch of already-signed votes to the Vochain
+      tags:
+      - vote
+  /votes/verify:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Checks whether the Vochain has a vote for each of the given nullifiers, so a voter
+        can confirm that the ballots relayed on their behalf are registered on chain. Public
+        endpoint: no authentication is required, and it exposes only data that is already
+        public on chain. Several nullifiers are accepted in one call because a multi-question
+        voting process is one on-chain election per question, so a voter holds one nullifier
+        per question. The response has one entry per requested nullifier, in the same order;
+        an unknown nullifier is reported as verified=false rather than as an error, while a
+        chain that cannot be reached fails the whole call so a voter is never told their vote
+        is missing when it merely could not be looked up.
+      parameters:
+      - description: Vote nullifiers to verify
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/apicommon.VerifyVotesRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Verification outcome per nullifier
+          schema:
+            $ref: '#/definitions/apicommon.VerifyVotesResponse'
+        "400":
+          description: Invalid input data
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "413":
+          description: Request body too large
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Blockchain request failed
+          schema:
+            $ref: '#/definitions/errors.Error'
+      summary: Verify vote nullifiers against the Vochain
       tags:
       - vote
 schemes:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1870,7 +1870,9 @@ definitions:
   apicommon.VerifyVotesRequest:
     properties:
       nullifiers:
-        description: Vote nullifiers (32 bytes each), at most 100
+        description: |-
+          Vote nullifiers (up to 32 bytes each — anonymous ones may be shorter), capped at the
+          shared vote batch limit (100)
         items:
           type: string
         type: array

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -7561,7 +7561,8 @@ paths:
         public on chain. Several nullifiers are accepted in one call because a multi-question
         voting process is one on-chain election per question, so a voter holds one nullifier
         per question. The response has one entry per requested nullifier, in the same order;
-        an unknown nullifier is reported as verified=false rather than as an error, while a
+        a repeated nullifier is looked up only once and every copy gets the same answer.
+        An unknown nullifier is reported as verified=false rather than as an error, while a
         chain that cannot be reached fails the whole call so a voter is never told their vote
         is missing when it merely could not be looked up.
       parameters:


### PR DESCRIPTION
## Why

A voter relaying through `POST /vote` or `POST /votes` gets a nullifier back on the job, but had no way to confirm the ballot actually landed on chain. The SaaS API is the remote signer and otherwise hides the Vochain, so a voter-facing receipt / "verify my vote" screen had no endpoint to call.

## What

`POST /votes/verify` (public):

```jsonc
// request
{ "nullifiers": ["a1b2…", "c3d4…"] }

// 200
{ "votes": [
  { "nullifier": "a1b2…", "verified": true,
    "processId": "0f…", "txHash": "9e…", "blockHeight": 1423, "date": "2026-07-30T…" },
  { "nullifier": "c3d4…", "verified": false }
] }
```

One entry per requested nullifier, in request order. Several per call because a multi-question voting process is one on-chain election per question, so a voter holds one nullifier per question — the same reason `POST /votes` exists. The cap is the shared `maxVotesPerBatch`, so a voter can always verify in one call exactly what they were allowed to cast.

## Notes for review

- **Which node route.** `Account.VoteByNullifier` wraps the node's `GET /votes/{voteId}`, which is keyed on the nullifier alone — unlike its `/votes/verify/{electionId}/{voteId}`, which also needs the election id a caller holding only a nullifier does not have. It returns the receipt metadata as a bonus. No `apiclient` wrapper exists for it, hence the raw `Request`; a 404 becomes the `ErrVoteNotFound` sentinel.
- **Unknown vs. unreachable.** An unknown nullifier is `verified: false`. A chain that cannot be asked fails the whole call with 50004 — a voter must never be told their vote is missing when it merely could not be looked up.
- **No job, deliberately.** It answers synchronously and takes no `txQueue` slot. Those 16 workers block until a tx is *mined*; spending them on reads would let verification traffic starve real vote submissions. It also keeps a public unauthenticated endpoint from writing a job document per call.
- **Latency.** A vote lookup measures ~250ms against `api-dev.vocdoni.net`, so at the batch cap a sequential loop would be a ~25s request. The reads fan out through the existing `parallelForEach` (8 workers, `api/processes.go`) → ~3.2s worst case, ~250ms for the typical single nullifier. A cancelled request context stops the remaining reads.
- **Public group**, like `/vote`, `/votes` and `GET /jobs/{jobId}`: it exposes only data already public on chain.
- No new error codes and no new dependency — reuses `decodeCappedJSON`, `ErrVoteBatchEmpty`/`TooLarge`, `ErrMalformedBody`, `ErrVochainRequestFailed`.

## Test

`TestRelayVote` is extended: it already casts a real CSP-proofed vote on the containerized Vocone chain through `POST /vote`, and now verifies that nullifier (expects `verified`, matching `processId`, non-empty `txHash`), a random one (expects `verified: false`), and a 2-byte one (expects 400).

```
go test -race -run 'TestRelayVote$' ./api/   # pass
make lint                                    # clean
make swagger                                 # regenerated
```