### PR TITLE
fix(db): stop a same-millisecond reclaim from reporting a lost publish claim

### DIFF
--- a/db/voting_processes.go
+++ b/db/voting_processes.go
@@ -250,7 +250,11 @@ func (ms *MongoStorage) ClaimVotingProcessForPublish(id primitive.ObjectID) (boo
 	if err != nil {
 		return false, fmt.Errorf("failed to claim voting process for publish: %w", err)
 	}
-	return res.ModifiedCount == 1, nil
+	// The filter is what decides the claim, so matching it is winning it. ModifiedCount would not
+	// be: Mongo stores dates to the millisecond, so reclaiming a stale marker inside the same
+	// millisecond writes the value already there and the server reports nothing modified — a won
+	// claim reported as lost.
+	return res.MatchedCount == 1, nil
 }
 
 // StaleVotingProcesses returns the ids of processes whose publishing marker is stale (older

--- a/db/voting_processes_test.go
+++ b/db/voting_processes_test.go
@@ -99,6 +99,30 @@ func TestClaimVotingProcessForPublish(t *testing.T) {
 	c.Assert(claimed, qt.IsTrue)
 }
 
+// TestReclaimVotingProcessInSameMillisecond pins that reclaiming a stale marker reports the win it
+// actually was. Mongo stores dates to the millisecond, so a reclaim landing in the same millisecond
+// as the marker it replaces writes an identical value and the server reports nothing modified —
+// while the filter, which is what decides the claim, matched. Claiming in a tight loop lands inside
+// one millisecond within a few iterations.
+func TestReclaimVotingProcessInSameMillisecond(t *testing.T) {
+	c := qt.New(t)
+	org := common.Address{0x12, 0x9a}
+	setupVotingProcessOrg(c, org)
+	id, err := testDB.SetVotingProcess(&VotingProcess{OrgAddress: org})
+	c.Assert(err, qt.IsNil)
+
+	// every marker is stale, so every claim must win
+	restore := PublishStaleAfter
+	PublishStaleAfter = -time.Minute
+	defer func() { PublishStaleAfter = restore }()
+
+	for i := range 200 {
+		claimed, err := testDB.ClaimVotingProcessForPublish(id)
+		c.Assert(err, qt.IsNil)
+		c.Assert(claimed, qt.IsTrue, qt.Commentf("reclaim %d of a stale marker must win", i))
+	}
+}
+
 // TestQuestionStatusSyncMethods covers the status-syncer DB methods: the org-scoped syncable-
 // candidate projection (only {READY,PAUSED,ENDED} with an upstreamId, backing the delete guard) and
 // the conditional reconcile write (status + syncedAt, applied only while the stored status still


### PR DESCRIPTION
## Problem

`ClaimVotingProcessForPublish` (`db/voting_processes.go`) decided the outcome of the claim on the
update's `ModifiedCount`:

```go
res, err := ms.votingProcesses.UpdateOne(ctx, filter, bson.M{"$set": bson.M{"publishing": now}})
return res.ModifiedCount == 1, nil
```

Mongo stores dates to the millisecond. Reclaiming a stale marker inside the same millisecond as the
marker it replaces therefore writes the value that is already there, and the server reports **nothing
modified** — even though the filter, which is what actually decides the claim, matched. The caller is
told it lost a claim it won.

## Effect

In production: a stale publish marker (crashed worker, service restart mid-publish) is not reclaimed
on an attempt that happens to race its own marker's millisecond. The startup/periodic reconciliation
retries, so a process does not get stuck — the attempt is just silently wasted.

In tests it is a flake. `TestVotingProcessStalePublishReclaim` does claim → claim → one read →
reclaim, which fits comfortably inside one millisecond against a local Mongo, so it fails a few
percent of local runs (measured on `main`: 1 in 24 runs here, and it hit twice while I was verifying
an unrelated branch, which is how it surfaced).

## Fix

Decide the claim on `MatchedCount`. Matching the filter *is* winning the claim — the filter encodes
the whole precondition (`published: false` **and** the marker is absent or stale), and the `$set` is
just how the win is recorded.

## Not changed

`ClaimProcessForPublish` (`db/process.go`, the older `/process` model) sets `status: "PUBLISHING"`
under a filter that excludes that same status, so its `$set` always changes the document and
`ModifiedCount` cannot disagree with `MatchedCount`. Left alone rather than churned.

## Verification

`TestReclaimVotingProcessInSameMillisecond` reclaims in a tight loop with `PublishStaleAfter`
negative, so consecutive claims land in one millisecond within a couple of iterations:

- before the fix it fails at **reclaim 1** (deterministically, in every run I tried)
- after the fix, 200 reclaims all win

Also: `go build ./...`, `go vet ./...` clean; `golangci-lint run ./db/...` 0 issues;
`scripts/check-qt-patterns.sh` clean; full `./db/` package green (236 tests); and the previously
flaky `TestVotingProcessStalePublishReclaim` now passes **12/12** consecutive runs.