### PR TITLE
fix(api)!: remove the organization `active` flag

### DIFF
--- a/api/apicommon/types.go
+++ b/api/apicommon/types.go
@@ -168,9 +168,6 @@ type OrganizationInfo struct {
 	// The organization's timezone
 	Timezone string `json:"timezone"`
 
-	// Whether the organization is active
-	Active bool `json:"active"`
-
 	// Whether the organization has enabled communications
 	Communications bool `json:"communications"`
 
@@ -612,7 +609,6 @@ func OrganizationFromDB(dbOrg, parent *db.Organization) *OrganizationInfo {
 		Subdomain:      dbOrg.Subdomain,
 		Country:        dbOrg.Country,
 		Timezone:       dbOrg.Timezone,
-		Active:         dbOrg.Active,
 		Communications: dbOrg.Communications,
 		Meta:           meta,
 		Name:           multilingualFromAny(meta["name"]),

--- a/api/docs.md
+++ b/api/docs.md
@@ -407,7 +407,6 @@ This endpoint only returns the addresses of the organizations where the current 
         "logo": "https://[...].png",
         "subdomain": "mysubdomain",
         "timezone": "GMT+2",
-        "active": true,
         "communications": false,
         "parent": {
           "...": "..."
@@ -561,8 +560,6 @@ This method invalidates any previous JWT token for the user, so it returns a new
   "communication": true
 }
 ```
-By default, the organization is created with `activated: true`.
-
 If the user want to create a sub org, the address of the root organization must be provided inside an organization object in `parent` param. The creator must be admin of the parent organization to be able to create suborganizations. Example:
 ```json
 {
@@ -584,7 +581,6 @@ If the user want to create a sub org, the address of the root organization must 
   "subdomain": "mysubdomain",
   "country": "Spain",
   "timezone": "GMT+2",
-  "active": true,
   "communications": false,
   "parent": {
     "...": {}
@@ -640,7 +636,6 @@ Only the following parameters can be changed. Every parameter is optional.
   "country": "Germany",
   "timezone": "GMT+2",
   "Language": "EN",
-  "active": true,
   "communication": false
 }
 ```
@@ -671,7 +666,6 @@ Only the following parameters can be changed. Every parameter is optional.
   "subdomain": "mysubdomain",
   "country": "Spain",
   "timezone": "GMT+2",
-  "active": true,
   "communications": false,
   "parent": {
     "...": {}

--- a/api/docs.md
+++ b/api/docs.md
@@ -557,7 +557,7 @@ This method invalidates any previous JWT token for the user, so it returns a new
   "country": "Germany",
   "timezone": "GMT+2",
   "language": "EN",
-  "communication": true
+  "communications": true
 }
 ```
 If the user want to create a sub org, the address of the root organization must be provided inside an organization object in `parent` param. The creator must be admin of the parent organization to be able to create suborganizations. Example:
@@ -635,8 +635,7 @@ Only the following parameters can be changed. Every parameter is optional.
   "subdomain": "mysubdomain",
   "country": "Germany",
   "timezone": "GMT+2",
-  "Language": "EN",
-  "communication": false
+  "Language": "EN"
 }
 ```
 

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -143,7 +143,6 @@ func (a *API) createOrganizationHandler(w http.ResponseWriter, r *http.Request) 
 		Country:         orgInfo.Country,
 		Subdomain:       orgInfo.Subdomain,
 		Timezone:        orgInfo.Timezone,
-		Active:          true,
 		Communications:  orgInfo.Communications,
 		Meta:            apicommon.BuildOrgMeta(nil, orgInfo.Name, orgInfo.Logo, orgInfo.Description, orgInfo.Meta),
 		TokensPurchased: 0,
@@ -280,10 +279,6 @@ func (a *API) updateOrganizationHandler(w http.ResponseWriter, r *http.Request) 
 	}
 	if newOrgInfo.Timezone != "" {
 		org.Timezone = newOrgInfo.Timezone
-		updateOrg = true
-	}
-	if newOrgInfo.Active != org.Active {
-		org.Active = newOrgInfo.Active
 		updateOrg = true
 	}
 	if newOrgInfo.Name != nil || newOrgInfo.Logo != nil || newOrgInfo.Description != nil || len(newOrgInfo.Meta) > 0 {

--- a/api/organizations_managed.go
+++ b/api/organizations_managed.go
@@ -164,7 +164,6 @@ func (a *API) createManagedOrganizationHandler(w http.ResponseWriter, r *http.Re
 		Country:        req.Country,
 		Subdomain:      req.Subdomain,
 		Timezone:       req.Timezone,
-		Active:         true,
 		Communications: req.Communications,
 		Meta:           apicommon.BuildOrgMeta(nil, req.Name, req.Logo, req.Description, req.Meta),
 		ManagedBy:      integratorAddr,

--- a/api/organizations_test.go
+++ b/api/organizations_test.go
@@ -166,19 +166,15 @@ func TestUpdateOrganizationHandler(t *testing.T) {
 	_, code = testRequest(t, http.MethodPut, token, updateInfo, "organizations", nonExistentAddr.String())
 	c.Assert(code, qt.Equals, http.StatusBadRequest)
 
-	// Test updating active status
-	activeUpdateInfo := &apicommon.OrganizationInfo{
-		Active: false,
-	}
-	resp, code = testRequest(t, http.MethodPut, token, activeUpdateInfo, "organizations", orgAddress.String())
-	c.Assert(code, qt.Equals, http.StatusOK, qt.Commentf("response: %s", resp))
-
-	// Verify active status update
+	// The organization payload must not expose an `active` flag (issue #625): nothing enforced
+	// it, and because it was a plain bool on a partial update, any request omitting it silently
+	// deactivated the organization.
 	resp, code = testRequest(t, http.MethodGet, token, nil, "organizations", orgAddress.String())
 	c.Assert(code, qt.Equals, http.StatusOK)
-	var orgWithUpdatedStatus apicommon.OrganizationInfo
-	c.Assert(json.Unmarshal(resp, &orgWithUpdatedStatus), qt.IsNil)
-	c.Assert(orgWithUpdatedStatus.Active, qt.IsFalse)
+	rawOrg := map[string]any{}
+	c.Assert(json.Unmarshal(resp, &rawOrg), qt.IsNil)
+	_, hasActive := rawOrg["active"]
+	c.Assert(hasActive, qt.IsFalse, qt.Commentf("response: %s", resp))
 }
 
 func TestOrganizationsTypesHandler(t *testing.T) {
@@ -487,7 +483,6 @@ func TestOrganizationWithOptionalFields(t *testing.T) {
 		Country:        "ES",
 		Subdomain:      "fullexample",
 		Timezone:       "Europe/Madrid",
-		Active:         true,
 		Communications: true,
 	}
 	resp, code := testRequest(t, http.MethodPost, token, orgInfo, organizationsEndpoint)
@@ -503,7 +498,6 @@ func TestOrganizationWithOptionalFields(t *testing.T) {
 	c.Assert(createdOrg.Country, qt.Equals, "ES")
 	c.Assert(createdOrg.Subdomain, qt.Equals, "fullexample")
 	c.Assert(createdOrg.Timezone, qt.Equals, "Europe/Madrid")
-	c.Assert(createdOrg.Active, qt.IsTrue)
 	c.Assert(createdOrg.Communications, qt.IsTrue)
 }
 

--- a/api/organizations_test.go
+++ b/api/organizations_test.go
@@ -148,6 +148,12 @@ func TestUpdateOrganizationHandler(t *testing.T) {
 	c.Assert(updatedOrg.Color, qt.Equals, "#FF5733")
 	c.Assert(updatedOrg.Size, qt.Equals, "medium")
 
+	// The payload must not expose an `active` flag (issue #625).
+	rawOrg := map[string]any{}
+	c.Assert(json.Unmarshal(resp, &rawOrg), qt.IsNil)
+	_, hasActive := rawOrg["active"]
+	c.Assert(hasActive, qt.IsFalse, qt.Commentf("response: %s", resp))
+
 	// Test updating without authentication
 	_, code = testRequest(t, http.MethodPut, "", updateInfo, "organizations", orgAddress.String())
 	c.Assert(code, qt.Equals, http.StatusUnauthorized)
@@ -165,16 +171,6 @@ func TestUpdateOrganizationHandler(t *testing.T) {
 	nonExistentAddr := common.HexToAddress("0x0000000000000000000000000000000000000001")
 	_, code = testRequest(t, http.MethodPut, token, updateInfo, "organizations", nonExistentAddr.String())
 	c.Assert(code, qt.Equals, http.StatusBadRequest)
-
-	// The organization payload must not expose an `active` flag (issue #625): nothing enforced
-	// it, and because it was a plain bool on a partial update, any request omitting it silently
-	// deactivated the organization.
-	resp, code = testRequest(t, http.MethodGet, token, nil, "organizations", orgAddress.String())
-	c.Assert(code, qt.Equals, http.StatusOK)
-	rawOrg := map[string]any{}
-	c.Assert(json.Unmarshal(resp, &rawOrg), qt.IsNil)
-	_, hasActive := rawOrg["active"]
-	c.Assert(hasActive, qt.IsFalse, qt.Commentf("response: %s", resp))
 }
 
 func TestOrganizationsTypesHandler(t *testing.T) {

--- a/csp/handlers/handlers_test.go
+++ b/csp/handlers/handlers_test.go
@@ -26,7 +26,6 @@ func TestHandlePhoneContact(t *testing.T) {
 
 	org := &db.Organization{
 		Address:   common.Address{0x01, 0x23, 0x45, 0x67, 0x89},
-		Active:    true,
 		CreatedAt: time.Now(),
 	}
 	org.Country = "ES"

--- a/db/census_participant_test.go
+++ b/db/census_participant_test.go
@@ -19,7 +19,6 @@ func setupTestCensusParticipantPrerequisites(t *testing.T, memberSuffix string) 
 	// Create test organization
 	org := &Organization{
 		Address:   testOrgAddress,
-		Active:    true,
 		CreatedAt: time.Now(),
 	}
 
@@ -577,7 +576,6 @@ func TestCensusParticipant(t *testing.T) {
 		// Create organization and census
 		org := &Organization{
 			Address:   testOrgAddress,
-			Active:    true,
 			CreatedAt: time.Now(),
 		}
 		err := testDB.SetOrganization(org)
@@ -729,7 +727,6 @@ func setupCensusParticipantsByMemberIDsFixtureForTrackedTests(t *testing.T) *cen
 
 	org := &Organization{
 		Address:   testOrgAddress,
-		Active:    true,
 		CreatedAt: time.Now(),
 	}
 	c.Assert(testDB.SetOrganization(org), qt.IsNil)
@@ -864,7 +861,6 @@ func TestCreateCensusParticipantBulkOperationsFiltering(t *testing.T) {
 	// Create organization
 	org := &Organization{
 		Address:   testOrgAddress,
-		Active:    true,
 		CreatedAt: time.Now(),
 	}
 	err := testDB.SetOrganization(org)

--- a/db/census_revocation_test.go
+++ b/db/census_revocation_test.go
@@ -29,7 +29,7 @@ func setupRevocationFixture(t *testing.T) *revocationFixture {
 	c := qt.New(t)
 
 	c.Assert(testDB.SetOrganization(&Organization{
-		Address: testOrgAddress, Active: true, CreatedAt: time.Now(),
+		Address: testOrgAddress, CreatedAt: time.Now(),
 	}), qt.IsNil)
 
 	newMember := func(number, email string) *OrgMember {
@@ -339,7 +339,7 @@ func TestDeleteOrgMembersScopesToOrg(t *testing.T) {
 	// a second organization deletes, by id, a member it does not own
 	otherOrg := common.Address{0x77, 0x88, 0x99}
 	c.Assert(testDB.SetOrganization(&Organization{
-		Address: otherOrg, Active: true, CreatedAt: time.Now(),
+		Address: otherOrg, CreatedAt: time.Now(),
 	}), qt.IsNil)
 
 	deleted, emptied, err := testDB.DeleteOrgMembers(otherOrg, []string{f.alice.ID.Hex()})

--- a/db/census_test.go
+++ b/db/census_test.go
@@ -18,7 +18,6 @@ func TestPopulateGroupCensus(t *testing.T) {
 		// Create test organization first
 		org := &Organization{
 			Address:   testOrgAddress,
-			Active:    true,
 			CreatedAt: time.Now(),
 		}
 		err := testDB.SetOrganization(org)
@@ -73,7 +72,6 @@ func TestPopulateGroupCensus(t *testing.T) {
 		// Create test organizations
 		org1 := &Organization{
 			Address:   testOrgAddress,
-			Active:    true,
 			CreatedAt: time.Now(),
 		}
 		err := testDB.SetOrganization(org1)
@@ -81,7 +79,6 @@ func TestPopulateGroupCensus(t *testing.T) {
 
 		org2 := &Organization{
 			Address:   testAnotherOrgAddress,
-			Active:    true,
 			CreatedAt: time.Now(),
 		}
 		err = testDB.SetOrganization(org2)
@@ -171,7 +168,6 @@ func TestPopulateGroupCensus(t *testing.T) {
 		// Create test organizations
 		org1 := &Organization{
 			Address:   testOrgAddress,
-			Active:    true,
 			CreatedAt: time.Now(),
 		}
 		err := testDB.SetOrganization(org1)
@@ -220,7 +216,6 @@ func TestPopulateGroupCensus(t *testing.T) {
 		// Create test organization
 		org := &Organization{
 			Address:   testOrgAddress,
-			Active:    true,
 			CreatedAt: time.Now(),
 		}
 		err := testDB.SetOrganization(org)
@@ -296,7 +291,6 @@ func TestPopulateGroupCensus(t *testing.T) {
 		// Create test organization
 		org := &Organization{
 			Address:   testOrgAddress,
-			Active:    true,
 			CreatedAt: time.Now(),
 		}
 		err := testDB.SetOrganization(org)
@@ -406,7 +400,6 @@ func TestCensus(t *testing.T) {
 		// Create test organization first
 		org := &Organization{
 			Address:   testOrgAddress,
-			Active:    true,
 			CreatedAt: time.Now(),
 		}
 		err = testDB.SetOrganization(org)
@@ -469,7 +462,6 @@ func TestCensus(t *testing.T) {
 		// Create test organization first
 		org := &Organization{
 			Address:   testOrgAddress,
-			Active:    true,
 			CreatedAt: time.Now(),
 		}
 		err := testDB.SetOrganization(org)
@@ -508,7 +500,6 @@ func TestCensus(t *testing.T) {
 		// Create test organization first
 		org := &Organization{
 			Address:   testOrgAddress,
-			Active:    true,
 			CreatedAt: time.Now(),
 		}
 		err := testDB.SetOrganization(org)
@@ -551,7 +542,6 @@ func TestCensus(t *testing.T) {
 		// Create test organization first
 		org := &Organization{
 			Address:   testOrgAddress,
-			Active:    true,
 			CreatedAt: time.Now(),
 		}
 		err := testDB.SetOrganization(org)

--- a/db/migration_drop_org_active_test.go
+++ b/db/migration_drop_org_active_test.go
@@ -9,7 +9,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-// TestDropOrganizationActiveMigration asserts migration 0019 strips the organizations' `active`
+// TestDropOrganizationActiveMigration asserts migration 0020 strips the organizations' `active`
 // field, and that the rollback restores it as true (issue #625).
 func TestDropOrganizationActiveMigration(t *testing.T) {
 	c := qt.New(t)
@@ -25,7 +25,7 @@ func TestDropOrganizationActiveMigration(t *testing.T) {
 		bson.M{"_id": testOrgAddress}, bson.M{"$set": bson.M{"active": false}})
 	c.Assert(err, qt.IsNil)
 
-	mig := migrationByVersion(c, 19)
+	mig := migrationByVersion(c, 20)
 	c.Assert(mig.Up(ctx, database), qt.IsNil)
 
 	raw := bson.M{}

--- a/db/migration_drop_org_active_test.go
+++ b/db/migration_drop_org_active_test.go
@@ -6,12 +6,11 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/vocdoni/saas-backend/migrations"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-// TestDropOrganizationActiveMigration checks that migration 0019 removes the `active` field left
-// behind by pre-#625 writers, including the false values a partial update wrote by accident.
+// TestDropOrganizationActiveMigration asserts migration 0019 strips the organizations' `active`
+// field, and that the rollback restores it as true (issue #625).
 func TestDropOrganizationActiveMigration(t *testing.T) {
 	c := qt.New(t)
 	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
@@ -26,8 +25,7 @@ func TestDropOrganizationActiveMigration(t *testing.T) {
 		bson.M{"_id": testOrgAddress}, bson.M{"$set": bson.M{"active": false}})
 	c.Assert(err, qt.IsNil)
 
-	mig, ok := migrations.AsMap()[19]
-	c.Assert(ok, qt.IsTrue)
+	mig := migrationByVersion(c, 19)
 	c.Assert(mig.Up(ctx, database), qt.IsNil)
 
 	raw := bson.M{}
@@ -36,6 +34,16 @@ func TestDropOrganizationActiveMigration(t *testing.T) {
 	c.Assert(hasActive, qt.IsFalse)
 
 	// The rollback restores the only value the code ever wrote deliberately.
+	c.Assert(mig.Down(ctx, database), qt.IsNil)
+	raw = bson.M{}
+	c.Assert(testDB.organizations.FindOne(ctx, bson.M{"_id": testOrgAddress}).Decode(&raw), qt.IsNil)
+	c.Assert(raw["active"], qt.IsTrue)
+
+	// A false surviving a partial up, or written by an old binary mid-deploy, is overwritten too:
+	// the rollback restores true unconditionally, not only where the field is missing.
+	_, err = testDB.organizations.UpdateOne(ctx,
+		bson.M{"_id": testOrgAddress}, bson.M{"$set": bson.M{"active": false}})
+	c.Assert(err, qt.IsNil)
 	c.Assert(mig.Down(ctx, database), qt.IsNil)
 	raw = bson.M{}
 	c.Assert(testDB.organizations.FindOne(ctx, bson.M{"_id": testOrgAddress}).Decode(&raw), qt.IsNil)

--- a/db/migration_drop_org_active_test.go
+++ b/db/migration_drop_org_active_test.go
@@ -1,0 +1,43 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/migrations"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// TestDropOrganizationActiveMigration checks that migration 0019 removes the `active` field left
+// behind by pre-#625 writers, including the false values a partial update wrote by accident.
+func TestDropOrganizationActiveMigration(t *testing.T) {
+	c := qt.New(t)
+	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+
+	ctx := context.Background()
+	database := testDB.DBClient.Database(testDB.database)
+
+	c.Assert(testDB.SetOrganization(&Organization{Address: testOrgAddress, CreatedAt: time.Now()}), qt.IsNil)
+	// Seed the field the way a database written before this migration holds it: the model no
+	// longer carries it, so it has to be set directly.
+	_, err := testDB.organizations.UpdateOne(ctx,
+		bson.M{"_id": testOrgAddress}, bson.M{"$set": bson.M{"active": false}})
+	c.Assert(err, qt.IsNil)
+
+	mig, ok := migrations.AsMap()[19]
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(mig.Up(ctx, database), qt.IsNil)
+
+	raw := bson.M{}
+	c.Assert(testDB.organizations.FindOne(ctx, bson.M{"_id": testOrgAddress}).Decode(&raw), qt.IsNil)
+	_, hasActive := raw["active"]
+	c.Assert(hasActive, qt.IsFalse)
+
+	// The rollback restores the only value the code ever wrote deliberately.
+	c.Assert(mig.Down(ctx, database), qt.IsNil)
+	raw = bson.M{}
+	c.Assert(testDB.organizations.FindOne(ctx, bson.M{"_id": testOrgAddress}).Decode(&raw), qt.IsNil)
+	c.Assert(raw["active"], qt.Equals, true)
+}

--- a/db/migration_drop_org_active_test.go
+++ b/db/migration_drop_org_active_test.go
@@ -39,5 +39,5 @@ func TestDropOrganizationActiveMigration(t *testing.T) {
 	c.Assert(mig.Down(ctx, database), qt.IsNil)
 	raw = bson.M{}
 	c.Assert(testDB.organizations.FindOne(ctx, bson.M{"_id": testOrgAddress}).Decode(&raw), qt.IsNil)
-	c.Assert(raw["active"], qt.Equals, true)
+	c.Assert(raw["active"], qt.IsTrue)
 }

--- a/db/migration_normalize_emails_test.go
+++ b/db/migration_normalize_emails_test.go
@@ -25,7 +25,7 @@ func TestNormalizeMemberEmailsMigration(t *testing.T) {
 	c := qt.New(t)
 	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
 
-	org := &Organization{Address: testOrgAddress, Active: true, CreatedAt: time.Now()}
+	org := &Organization{Address: testOrgAddress, CreatedAt: time.Now()}
 	c.Assert(testDB.SetOrganization(org), qt.IsNil)
 
 	t.Run("normalizes email and recomputes login hashes", func(_ *testing.T) {

--- a/db/migration_normalize_emails_test.go
+++ b/db/migration_normalize_emails_test.go
@@ -6,19 +6,15 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/vocdoni/saas-backend/migrations"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 // runNormalizeEmailsMigration invokes migration 0015's Up function directly
 // against the current test database state.
-func runNormalizeEmailsMigration(t *testing.T) {
-	t.Helper()
-	mig, ok := migrations.AsMap()[15]
-	qt.Assert(t, ok, qt.IsTrue)
-	err := mig.Up(context.Background(), testDB.DBClient.Database(testDB.database))
-	qt.Assert(t, err, qt.IsNil)
+func runNormalizeEmailsMigration(c *qt.C) {
+	mig := migrationByVersion(c, 15)
+	c.Assert(mig.Up(context.Background(), testDB.DBClient.Database(testDB.database)), qt.IsNil)
 }
 
 func TestNormalizeMemberEmailsMigration(t *testing.T) {
@@ -67,7 +63,7 @@ func TestNormalizeMemberEmailsMigration(t *testing.T) {
 		_, err = testDB.censusParticipants.InsertOne(ctx, participant)
 		c.Assert(err, qt.IsNil)
 
-		runNormalizeEmailsMigration(t)
+		runNormalizeEmailsMigration(c)
 
 		// Email is now lowercase.
 		var got OrgMember
@@ -132,7 +128,7 @@ func TestNormalizeMemberEmailsMigration(t *testing.T) {
 		})
 		c.Assert(err, qt.IsNil)
 
-		runNormalizeEmailsMigration(t)
+		runNormalizeEmailsMigration(c)
 
 		// The uppercase member is left untouched (email and hash unchanged).
 		var gotUpper OrgMember

--- a/db/migration_question_slots_test.go
+++ b/db/migration_question_slots_test.go
@@ -7,18 +7,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	qt "github.com/frankban/quicktest"
-	"github.com/vocdoni/saas-backend/migrations"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
-
-// questionSlotsMigration returns migration 0018.
-func questionSlotsMigration(c *qt.C) migrations.Migration {
-	mig, ok := migrations.AsMap()[18]
-	c.Assert(ok, qt.IsTrue)
-	return mig
-}
 
 // TestUniqueProcessQuestionSlotsMigration seeds the duplicate slots a pre-fix concurrent draft
 // update stranded (issue #614) and asserts migration 0018 repairs them under its stated policy:
@@ -29,7 +21,7 @@ func TestUniqueProcessQuestionSlotsMigration(t *testing.T) {
 	c := qt.New(t)
 	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
 	ctx := context.Background()
-	mig := questionSlotsMigration(c)
+	mig := migrationByVersion(c, 18)
 	database := testDB.DBClient.Database(testDB.database)
 
 	// the test database is migrated on init, so the unique index already exists; roll it back to
@@ -114,11 +106,11 @@ func TestUniqueProcessQuestionSlotsMigrationDown(t *testing.T) {
 	c := qt.New(t)
 	c.Cleanup(func() {
 		// restore the migrated state for the rest of the suite
-		c.Assert(questionSlotsMigration(c).Up(context.Background(), testDB.DBClient.Database(testDB.database)), qt.IsNil)
+		c.Assert(migrationByVersion(c, 18).Up(context.Background(), testDB.DBClient.Database(testDB.database)), qt.IsNil)
 		c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
 	})
 	ctx := context.Background()
-	mig := questionSlotsMigration(c)
+	mig := migrationByVersion(c, 18)
 	database := testDB.DBClient.Database(testDB.database)
 
 	c.Assert(mig.Down(ctx, database), qt.IsNil)

--- a/db/migrations_test.go
+++ b/db/migrations_test.go
@@ -29,7 +29,6 @@ func TestMigrations(t *testing.T) {
 
 		org := &Organization{
 			Address:   testOrgAddress,
-			Active:    true,
 			CreatedAt: time.Now(),
 			Website:   "testorg.com",
 		}

--- a/db/migrations_test.go
+++ b/db/migrations_test.go
@@ -15,6 +15,14 @@ import (
 	"go.vocdoni.io/dvote/log"
 )
 
+// migrationByVersion returns the registered migration for the given version, so a test can drive
+// its Up/Down directly against the current test database state.
+func migrationByVersion(c *qt.C, version int) migrations.Migration {
+	mig, ok := migrations.AsMap()[version]
+	c.Assert(ok, qt.IsTrue)
+	return mig
+}
+
 func TestMigrations(t *testing.T) {
 	c := qt.New(t)
 

--- a/db/org_members_groups_test.go
+++ b/db/org_members_groups_test.go
@@ -16,7 +16,6 @@ func setupTestOrgMembersGroupPrerequisites(t *testing.T, memberSuffix string) (*
 	// Create test organization
 	org := &Organization{
 		Address:   testOrgAddress,
-		Active:    true,
 		CreatedAt: time.Now(),
 	}
 
@@ -202,7 +201,6 @@ func TestOrganizationMemberGroup(t *testing.T) {
 			// Create a different organization
 			diffOrg := &Organization{
 				Address:   testAnotherOrgAddress,
-				Active:    true,
 				CreatedAt: time.Now(),
 			}
 			err := testDB.SetOrganization(diffOrg)

--- a/db/org_members_test.go
+++ b/db/org_members_test.go
@@ -561,7 +561,7 @@ func TestUpsertOrgMemberPartialUpdateKeepsLoginHash(t *testing.T) {
 	c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
 	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
 
-	org := &Organization{Address: testOrgAddress, Active: true, CreatedAt: time.Now()}
+	org := &Organization{Address: testOrgAddress, CreatedAt: time.Now()}
 	c.Assert(testDB.SetOrganization(org), qt.IsNil)
 
 	member := &OrgMember{
@@ -633,7 +633,7 @@ func TestUpsertOrgMemberReportsCreated(t *testing.T) {
 	c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
 	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
 
-	org := &Organization{Address: testOrgAddress, Active: true, CreatedAt: time.Now()}
+	org := &Organization{Address: testOrgAddress, CreatedAt: time.Now()}
 	c.Assert(testDB.SetOrganization(org), qt.IsNil)
 
 	id, created, err := testDB.UpsertOrgMemberAndCensusParticipants(org, &OrgMember{

--- a/db/organizations.go
+++ b/db/organizations.go
@@ -84,7 +84,11 @@ func (ms *MongoStorage) SetOrganization(org *Organization) error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 	// prepare the document to be updated in the database modifying only the
-	// fields that have changed
+	// fields that have changed.
+	// ponytail: zero values are not persisted — no field is force-updated, so a bool can only go
+	// false->true and a string can never be cleared. Force-updating is what made #625 possible (a
+	// PUT omitting `active` clobbered it), so a field that must reach its zero value needs its own
+	// $set here plus a pointer in the request type, not an entry in alwaysUpdateTags.
 	updateDoc, err := dynamicUpdateDocument(org, nil)
 	if err != nil {
 		return err

--- a/db/organizations.go
+++ b/db/organizations.go
@@ -85,9 +85,7 @@ func (ms *MongoStorage) SetOrganization(org *Organization) error {
 	defer cancel()
 	// prepare the document to be updated in the database modifying only the
 	// fields that have changed
-	// define 'active' parameter to be updated always to update it even its new
-	// value is false
-	updateDoc, err := dynamicUpdateDocument(org, []string{"active"})
+	updateDoc, err := dynamicUpdateDocument(org, nil)
 	if err != nil {
 		return err
 	}

--- a/db/process_bundles_check_test.go
+++ b/db/process_bundles_check_test.go
@@ -25,7 +25,6 @@ func setupCheckBundleFixture(t *testing.T) *checkBundleFixture {
 	org := &Organization{
 		Address:   testOrgAddress,
 		Country:   "ES",
-		Active:    true,
 		CreatedAt: time.Now(),
 	}
 	c.Assert(testDB.SetOrganization(org), qt.IsNil)

--- a/db/process_test.go
+++ b/db/process_test.go
@@ -21,7 +21,6 @@ func setupTestPrerequisites1(c *qt.C, db *MongoStorage) *Census {
 	// Create test organization
 	org := &Organization{
 		Address:   testOrgAddress,
-		Active:    true,
 		CreatedAt: time.Now(),
 	}
 	err := db.SetOrganization(org)

--- a/db/repair_login_hashes_test.go
+++ b/db/repair_login_hashes_test.go
@@ -80,7 +80,7 @@ func TestRepairLoginHashes(t *testing.T) {
 	c := qt.New(t)
 	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
 
-	org := &Organization{Address: testOrgAddress, Active: true, CreatedAt: time.Now(), Country: "ES"}
+	org := &Organization{Address: testOrgAddress, CreatedAt: time.Now(), Country: "ES"}
 
 	newCensus := func(auth OrgMemberAuthFields, twoFa OrgMemberTwoFaFields) (*Census, string) {
 		census := &Census{
@@ -338,7 +338,7 @@ func TestRepairLoginHashes(t *testing.T) {
 
 	t.Run("restricts the run to the selected organization", func(_ *testing.T) {
 		reset()
-		other := &Organization{Address: testAnotherOrgAddress, Active: true, CreatedAt: time.Now()}
+		other := &Organization{Address: testAnotherOrgAddress, CreatedAt: time.Now()}
 		c.Assert(testDB.SetOrganization(other), qt.IsNil)
 
 		mine, mineID := newCensus(authFields, noTwoFa)
@@ -383,7 +383,7 @@ func TestRepairMatchesCanonicalHash(t *testing.T) {
 	c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
 	c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
 
-	org := &Organization{Address: testOrgAddress, Active: true, CreatedAt: time.Now(), Country: "ES"}
+	org := &Organization{Address: testOrgAddress, CreatedAt: time.Now(), Country: "ES"}
 	c.Assert(testDB.SetOrganization(org), qt.IsNil)
 	phone, err := NewHashedPhone(testPlaintextPhone, org)
 	c.Assert(err, qt.IsNil)

--- a/db/types.go
+++ b/db/types.go
@@ -83,7 +83,6 @@ type Organization struct {
 	Subdomain       string                   `json:"subdomain" bson:"subdomain"`
 	Country         string                   `json:"country" bson:"country"`
 	Timezone        string                   `json:"timezone" bson:"timezone"`
-	Active          bool                     `json:"active" bson:"active"`
 	Communications  bool                     `json:"communications" bson:"communications"`
 	TokensPurchased uint64                   `json:"tokensPurchased" bson:"tokensPurchased"`
 	TokensRemaining uint64                   `json:"tokensRemaining" bson:"tokensRemaining"`

--- a/db/voting_processes_test.go
+++ b/db/voting_processes_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func setupVotingProcessOrg(c *qt.C, org common.Address) {
-	err := testDB.SetOrganization(&Organization{Address: org, Active: true, CreatedAt: time.Now()})
+	err := testDB.SetOrganization(&Organization{Address: org, CreatedAt: time.Now()})
 	c.Assert(err, qt.IsNil)
 }
 

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -237,9 +237,6 @@ definitions:
     type: object
   apicommon.CreateManagedOrganizationRequest:
     properties:
-      active:
-        description: Whether the organization is active
-        type: boolean
       address:
         description: The organization's blockchain address
         items:
@@ -351,9 +348,6 @@ definitions:
     type: object
   apicommon.CreateOrganizationRequest:
     properties:
-      active:
-        description: Whether the organization is active
-        type: boolean
       address:
         description: The organization's blockchain address
         items:
@@ -906,9 +900,6 @@ definitions:
     type: object
   apicommon.OrganizationInfo:
     properties:
-      active:
-        description: Whether the organization is active
-        type: boolean
       address:
         description: The organization's blockchain address
         items:

--- a/migrations/0019_drop_organization_active.go
+++ b/migrations/0019_drop_organization_active.go
@@ -1,0 +1,44 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.vocdoni.io/dvote/log"
+)
+
+func init() {
+	AddMigration(19, "drop_organization_active", upDropOrganizationActive, downDropOrganizationActive)
+}
+
+// upDropOrganizationActive removes the organizations' `active` field (issue #625). Nothing ever
+// read it: no handler, middleware or subscription check gated on it, so an organization stored
+// with active=false stayed fully operational. The only writer that ever set it to false was a bug
+// — the partial update handler compared a plain bool, so a PUT body omitting `active` decoded to
+// false and was force-persisted — which left healthy organizations misreporting themselves to
+// clients. The field is gone from the model; this drops the stale values with it.
+func upDropOrganizationActive(ctx context.Context, database *mongo.Database) error {
+	res, err := database.Collection("organizations").UpdateMany(ctx,
+		bson.M{"active": bson.M{"$exists": true}},
+		bson.M{"$unset": bson.M{"active": ""}},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to unset active on organizations: %w", err)
+	}
+	log.Infow("dropped organization active field", "organizations", res.ModifiedCount)
+	return nil
+}
+
+// downDropOrganizationActive restores the field as true, the only value the code ever wrote
+// deliberately: both creation paths hardcoded it, and every false was the bug described above.
+func downDropOrganizationActive(ctx context.Context, database *mongo.Database) error {
+	if _, err := database.Collection("organizations").UpdateMany(ctx,
+		bson.M{"active": bson.M{"$exists": false}},
+		bson.M{"$set": bson.M{"active": true}},
+	); err != nil {
+		return fmt.Errorf("failed to restore active on organizations: %w", err)
+	}
+	return nil
+}

--- a/migrations/0019_drop_organization_active.go
+++ b/migrations/0019_drop_organization_active.go
@@ -15,11 +15,20 @@ func init() {
 
 // upDropOrganizationActive removes the organizations' `active` field (issue #625). Nothing ever
 // read it: no handler, middleware or subscription check gated on it, so an organization stored
-// with active=false stayed fully operational. The only writer that ever set it to false was a bug
-// — the partial update handler compared a plain bool, so a PUT body omitting `active` decoded to
-// false and was force-persisted — which left healthy organizations misreporting themselves to
-// clients. The field is gone from the model; this drops the stale values with it.
+// with active=false stayed fully operational. Deactivating one deliberately was possible — the
+// partial update handler had a branch for it — but a stored false does not prove that intent: the
+// same branch compared a plain bool, so a PUT body merely omitting `active` decoded to false and
+// was force-persisted, leaving healthy organizations misreporting themselves. Since the two cases
+// are indistinguishable and neither was enforced, the field is gone from the model and this drops
+// every stale value with it, logging the addresses it strips a false from.
 func upDropOrganizationActive(ctx context.Context, database *mongo.Database) error {
+	deactivated, err := database.Collection("organizations").Distinct(ctx, "_id", bson.M{"active": false})
+	if err != nil {
+		return fmt.Errorf("failed to list deactivated organizations: %w", err)
+	}
+	if len(deactivated) > 0 {
+		log.Infow("dropping stored organization active=false", "organizations", deactivated)
+	}
 	res, err := database.Collection("organizations").UpdateMany(ctx,
 		bson.M{"active": bson.M{"$exists": true}},
 		bson.M{"$unset": bson.M{"active": ""}},
@@ -31,11 +40,12 @@ func upDropOrganizationActive(ctx context.Context, database *mongo.Database) err
 	return nil
 }
 
-// downDropOrganizationActive restores the field as true, the only value the code ever wrote
-// deliberately: both creation paths hardcoded it, and every false was the bug described above.
+// downDropOrganizationActive restores the field as true on every organization: it is the value
+// both creation paths hardcoded, and a false surviving a partial up (or written by an old binary
+// mid-deploy) is the misreporting this migration exists to remove, so it is overwritten too.
 func downDropOrganizationActive(ctx context.Context, database *mongo.Database) error {
 	if _, err := database.Collection("organizations").UpdateMany(ctx,
-		bson.M{"active": bson.M{"$exists": false}},
+		bson.M{},
 		bson.M{"$set": bson.M{"active": true}},
 	); err != nil {
 		return fmt.Errorf("failed to restore active on organizations: %w", err)

--- a/migrations/0020_drop_organization_active.go
+++ b/migrations/0020_drop_organization_active.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() {
-	AddMigration(19, "drop_organization_active", upDropOrganizationActive, downDropOrganizationActive)
+	AddMigration(20, "drop_organization_active", upDropOrganizationActive, downDropOrganizationActive)
 }
 
 // upDropOrganizationActive removes the organizations' `active` field (issue #625). Nothing ever


### PR DESCRIPTION
Closes #625.

## What was wrong

`Organization.active` was exposed on the organization read endpoints, but **nothing read it**. The only non-test consumer of `org.Active` was the JSON mapping in `OrganizationFromDB` — no middleware, no handler guard, no subscription check. An organization stored with `active: false` remained fully editable and could create and publish processes, exactly as reported.

Nor did anything set it deliberately:

- both creation paths hardcoded `Active: true` and silently discarded the value sent in the request body;
- there is no archival — `DelOrganization` hard-deletes;
- no migration ever touched it.

**The `false` values came from a bug.** `PUT /organizations/{address}` is a partial update: every other field is guarded by an emptiness check (`if newOrgInfo.Website != ""`). `Active` was a plain `bool`, so a request body omitting `active` decoded to `false`, differed from the stored `true`, and flipped the organization. That write was then force-persisted, because `"active"` was the single field opted out of zero-value protection in `SetOrganization`:

```go
// define 'active' parameter to be updated always to update it even its new value is false
updateDoc, err := dynamicUpdateDocument(org, []string{"active"})
```

So any client updating one unrelated setting without echoing `active` back deactivated the org — which is why sibling orgs of the same user disagree. `TestOrganizationPartialUpdate` sends that exact request shape but never asserted `Active` survived, so nothing caught it.

## What this does

Option 2 of the issue: **remove it.** Defining it would mean inventing a suspension lifecycle, an authority model (today any org admin could suspend themselves), and a guard on every write handler — none of which exists or was asked for. Removing the field eliminates the bug by construction.

- Dropped from `db.Organization`, `apicommon.OrganizationInfo` (and therefore from both create-request wrappers), `OrganizationFromDB`, both creation handlers, and the `PUT` handler.
- `SetOrganization` no longer force-writes any zero value.
- **Migration `0019_drop_organization_active`** `$unset`s the stale field; the rollback restores `active: true`, the only value the code ever wrote deliberately.
- Regression test asserts the organization payload carries no `active` key; migration test covers up and down.
- Swagger regenerated.

`Subscription.Active` (Stripe-driven, gates `subscriptions.IsIntegrator`) is a **different field and is untouched**.

## ⚠️ Breaking change

`active` disappears from organization responses and create requests. It must be dropped from `@vocdoni/api-types`. No known consumer reads it — the integrator demo has zero references, and the vocdoni-app gating that prompted this issue was already reverted.

## Verification

- `go build ./... && go vet ./...` clean
- `golangci-lint run ./db/... ./api/... ./migrations/...` → 0 issues
- `go test ./api/... ./db/ ./csp/... ./subscriptions/` → all pass, including the new `TestDropOrganizationActiveMigration`