### PR TITLE
feat(processes): sign a batch of ballots at POST /processes/{processId}/sign-batch

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -485,6 +485,7 @@ func (a *API) initRouter() http.Handler {
 		handle(r, http.MethodPost, processesAuthEndpoint, cspHandlers.ProcessAuthHandler)
 		handle(r, http.MethodPost, processesAuthResendEndpoint, cspHandlers.ProcessAuthResendHandler)
 		handle(r, http.MethodPost, processesSignEndpoint, cspHandlers.ProcessSignHandler)
+		handle(r, http.MethodPost, processesSignBatchEndpoint, cspHandlers.ProcessSignBatchHandler)
 		handle(r, http.MethodPost, processesWeightEndpoint, cspHandlers.ProcessWeightHandler)
 		handle(r, http.MethodPost, processesSignInfoEndpoint, cspHandlers.ProcessSignInfoHandler)
 	})

--- a/api/processes_csp_test.go
+++ b/api/processes_csp_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/csp/handlers"
 	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/errors"
 	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.vocdoni.io/dvote/crypto/ethereum"
@@ -192,4 +193,97 @@ func TestProcessCSP(t *testing.T) {
 	// a malformed process id is a client error
 	requestAndAssertCode(http.StatusBadRequest, t, http.MethodPost, "",
 		&handlers.CheckMembershipRequest{AuthToken: tok0}, "processes", "not-a-valid-id", "check")
+}
+
+// TestProcessCSPSignBatch exercises POST /processes/{processId}/sign-batch: a batch is
+// authorized as a unit and signs nothing on failure, and once authorized every ballot is
+// signed with a per-ballot outcome.
+func TestProcessCSPSignBatch(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateProvisionedOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	// same fixture as TestProcessCSP: question 2 is restricted to the first member.
+	req := newVotingProcessRequest(orgAddress, ids)
+	req.StartDate = ""
+	req.Census.AuthFields = db.OrgMemberAuthFields{db.OrgMemberAuthFieldsName, db.OrgMemberAuthFieldsSurname}
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, req, processesCreateEndpoint)
+	pid := created.ProcessID
+
+	job := enqueueAndPollJob(t, http.MethodPost, token, nil, "processes", pid, "publish")
+	c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("job error: %s", job.Errors))
+
+	got := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	c.Assert(got.Questions, qt.HasLen, 2)
+	openElection := got.Questions[0].UpstreamID
+	restrictedElection := got.Questions[1].UpstreamID
+
+	authReq := func(i int) *handlers.AuthRequest {
+		return &handlers.AuthRequest{Name: members[i].Name, Surname: members[i].Surname, Email: members[i].Email}
+	}
+	voter := ethereum.SignKeys{}
+	c.Assert(voter.Generate(), qt.IsNil)
+	address := hex.EncodeToString(voter.Address().Bytes())
+	batch := func(authToken internal.HexBytes, elections ...internal.HexBytes) *handlers.SignBatchRequest {
+		items := make([]handlers.SignBatchItem, len(elections))
+		for i, e := range elections {
+			items[i] = handlers.SignBatchItem{ProcessID: e, Payload: address}
+		}
+		return &handlers.SignBatchRequest{AuthToken: authToken, Signatures: items}
+	}
+	consumed := func(authToken internal.HexBytes) []handlers.QuestionConsumedAddress {
+		return requestAndParse[handlers.ProcessSignInfoResponse](t, http.MethodPost, "",
+			&handlers.ConsumedAddressRequest{AuthToken: authToken}, "processes", pid, "sign-info").Consumed
+	}
+
+	// --- second member: eligible for the open question only, so a batch naming both is
+	// rejected as a unit and its eligible sibling is NOT signed ---
+	tok1 := authProcessCSP(t, pid, authReq(1))
+	requestAndAssertCode(http.StatusUnauthorized, t, http.MethodPost, "",
+		batch(tok1, openElection, restrictedElection), "processes", pid, "sign-batch")
+	c.Assert(consumed(tok1), qt.HasLen, 0)
+
+	// a repeated election, an empty batch and more ballots than the process has questions are
+	// all client errors, and none of them signs anything
+	requestAndAssertCode(http.StatusBadRequest, t, http.MethodPost, "",
+		batch(tok1, openElection, openElection), "processes", pid, "sign-batch")
+	requestAndAssertCode(http.StatusBadRequest, t, http.MethodPost, "",
+		batch(tok1), "processes", pid, "sign-batch")
+	requestAndAssertError(errors.ErrVoteBatchTooLarge, t, http.MethodPost, "",
+		&handlers.SignBatchRequest{AuthToken: tok1, Signatures: make([]handlers.SignBatchItem, 3)},
+		"processes", pid, "sign-batch")
+	c.Assert(consumed(tok1), qt.HasLen, 0)
+
+	// --- first member: both questions signed in one call ---
+	tok0 := authProcessCSP(t, pid, authReq(0))
+	signed := requestAndParse[handlers.SignBatchResponse](t, http.MethodPost, "",
+		batch(tok0, openElection, restrictedElection), "processes", pid, "sign-batch")
+	c.Assert(signed.Signatures, qt.HasLen, 2)
+	for i, s := range signed.Signatures {
+		c.Assert(s.Error, qt.Equals, "", qt.Commentf("ballot %d", i))
+		c.Assert(s.Signature, qt.Not(qt.HasLen), 0)
+		c.Assert(bytes.Equal(s.Weight, big.NewInt(1).Bytes()), qt.IsTrue)
+	}
+	c.Assert(bytes.Equal(signed.Signatures[0].ProcessID, openElection), qt.IsTrue)
+	c.Assert(bytes.Equal(signed.Signatures[1].ProcessID, restrictedElection), qt.IsTrue)
+	c.Assert(consumed(tok0), qt.HasLen, 2)
+
+	// --- a spent signing slot is a per-ballot error, not a failed batch: exhaust the open
+	// election's overwrites (it is at 1 after the batch above) and re-run the same batch ---
+	for i := 0; i < db.MaxVoteOverwritesPerProcess; i++ {
+		requestAndParse[handlers.AuthResponse](t, http.MethodPost, "",
+			&handlers.SignRequest{AuthToken: tok0, ProcessID: openElection, Payload: address},
+			"processes", pid, "sign")
+	}
+	again := requestAndParse[handlers.SignBatchResponse](t, http.MethodPost, "",
+		batch(tok0, openElection, restrictedElection), "processes", pid, "sign-batch")
+	c.Assert(again.Signatures, qt.HasLen, 2)
+	c.Assert(again.Signatures[0].Error, qt.Not(qt.Equals), "")
+	c.Assert(again.Signatures[0].Signature, qt.HasLen, 0)
+	c.Assert(again.Signatures[1].Error, qt.Equals, "")
+	c.Assert(again.Signatures[1].Signature, qt.Not(qt.HasLen), 0)
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -248,7 +248,11 @@ const (
 	processesAuthEndpoint       = "/processes/{processId}/auth/{step}"
 	processesAuthResendEndpoint = "/processes/{processId}/auth/resend"
 	processesSignEndpoint       = "/processes/{processId}/sign"
-	processesWeightEndpoint     = "/processes/{processId}/weight"
+	// POST /processes/{processId}/sign-batch to sign every question's ballot in one call, so a
+	// voter casting a multi-question process does not need one round trip per question. The
+	// batch is authorized as a unit and signs nothing on failure.
+	processesSignBatchEndpoint = "/processes/{processId}/sign-batch"
+	processesWeightEndpoint    = "/processes/{processId}/weight"
 
 	// // census auth routes (currently not implemented)
 	// // POST /process/{processId}/auth/0 to initiate auth

--- a/csp/handlers/processes.go
+++ b/csp/handlers/processes.go
@@ -11,12 +11,17 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/csp"
+	"github.com/vocdoni/saas-backend/csp/signers"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
 	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/vochain/state"
 )
+
+// apiErr lifts an API error to a pointer, so a helper can signal "no error" with nil.
+func apiErr(e errors.Error) *errors.Error { return &e }
 
 // parseProcessID parses the {processId} URL param (a voting-process Mongo ObjectID) and
 // returns both the ObjectID and its bytes, which are used as the CSP token anchor.
@@ -196,11 +201,7 @@ func (c *CSPHandlers) ProcessAuthResendHandler(w http.ResponseWriter, r *http.Re
 //	@Failure		500			{object}	errors.Error	"Internal server error"
 //	@Router			/processes/{processId}/sign [post]
 func (c *CSPHandlers) ProcessSignHandler(w http.ResponseWriter, r *http.Request) {
-	oid, anchor, ok := parseProcessID(w, r)
-	if !ok {
-		return
-	}
-	vp, ok := c.getVotingProcess(w, oid)
+	oid, _, ok := parseProcessID(w, r)
 	if !ok {
 		return
 	}
@@ -208,56 +209,233 @@ func (c *CSPHandlers) ProcessSignHandler(w http.ResponseWriter, r *http.Request)
 	if !ok {
 		return
 	}
-	auth, ok := c.getAuthInfo(w, req.AuthToken)
+	sc, ok := c.resolveSignContext(w, oid, req.AuthToken)
 	if !ok {
 		return
 	}
-	if !auth.Verified {
-		errors.ErrUnauthorized.WithErr(csp.ErrAuthTokenNotVerified).Write(w)
+	upstreamID, sErr := c.authorizeQuestion(sc, req.ProcessID)
+	if sErr != nil {
+		sErr.Write(w)
 		return
-	}
-	if !bytes.Equal(anchor, auth.BundleID) {
-		errors.ErrUnauthorized.Withf("token does not belong to the process").Write(w)
-		return
-	}
-	// resolve the target question by its on-chain election id and verify it belongs to
-	// this process
-	question, err := c.mainDB.QuestionByUpstreamID(req.ProcessID)
-	if err != nil && err != db.ErrNotFound {
-		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
-		return
-	}
-	if err != nil || question.ProcessID != oid {
-		errors.ErrUnauthorized.Withf("election not found in process").Write(w)
-		return
-	}
-	// authorize the member against the question's eligibility subset
-	if !memberEligibleForQuestion(question, auth.UserID.String()) {
-		errors.ErrUnauthorized.Withf("member not eligible for this question").Write(w)
-		return
-	}
-	member, ok := c.orgMemberFromAuth(w, vp.OrgAddress, auth)
-	if !ok {
-		return
-	}
-	census, err := c.mainDB.Census(vp.CensusID.Hex())
-	if err != nil {
-		errors.ErrCensusNotFound.WithErr(err).Write(w)
-		return
-	}
-	weight := uint64(1)
-	if census.Weighted {
-		if member.Weight == 0 {
-			errors.ErrZeroWeightVoter.Write(w)
-			return
-		}
-		weight = member.Weight
 	}
 	address, ok := parseAddress(w, req.Payload)
 	if !ok {
 		return
 	}
-	c.signAndRespond(w, req.AuthToken, *address, question.UpstreamID, big.NewInt(int64(weight)).Bytes())
+	c.signAndRespond(w, req.AuthToken, *address, upstreamID, sc.weight)
+}
+
+// signContext is the part of a ballot signing request that is resolved once per call, from
+// the process named in the path and the auth token in the body: the voting process, the
+// member behind the token and their census weight. A batch signs every ballot under one of
+// these, which is the whole point of the batch endpoint.
+type signContext struct {
+	process  *db.VotingProcess
+	memberID string
+	weight   internal.HexBytes
+}
+
+// resolveSignContext runs the per-request half of a ballot signing request: load the voting
+// process, check the auth token is verified and anchored to it, resolve the org member behind
+// it and compute their census weight. It writes the proper error and returns false on failure.
+func (c *CSPHandlers) resolveSignContext(
+	w http.ResponseWriter, oid primitive.ObjectID, authToken internal.HexBytes,
+) (*signContext, bool) {
+	vp, ok := c.getVotingProcess(w, oid)
+	if !ok {
+		return nil, false
+	}
+	auth, ok := c.getAuthInfo(w, authToken)
+	if !ok {
+		return nil, false
+	}
+	if !auth.Verified {
+		errors.ErrUnauthorized.WithErr(csp.ErrAuthTokenNotVerified).Write(w)
+		return nil, false
+	}
+	if !bytes.Equal(oid[:], auth.BundleID) {
+		errors.ErrUnauthorized.Withf("token does not belong to the process").Write(w)
+		return nil, false
+	}
+	member, ok := c.orgMemberFromAuth(w, vp.OrgAddress, auth)
+	if !ok {
+		return nil, false
+	}
+	census, err := c.mainDB.Census(vp.CensusID.Hex())
+	if err != nil {
+		errors.ErrCensusNotFound.WithErr(err).Write(w)
+		return nil, false
+	}
+	weight := uint64(1)
+	if census.Weighted {
+		if member.Weight == 0 {
+			errors.ErrZeroWeightVoter.Write(w)
+			return nil, false
+		}
+		weight = member.Weight
+	}
+	return &signContext{
+		process:  vp,
+		memberID: auth.UserID.String(),
+		weight:   big.NewInt(int64(weight)).Bytes(),
+	}, true
+}
+
+// authorizeQuestion runs the per-ballot half of a signing request: resolve the target question
+// by its on-chain election id, verify it belongs to this process and authorize the member
+// against the question's eligibility subset. It returns the question's on-chain election id, or
+// the API error to write back, never both.
+func (c *CSPHandlers) authorizeQuestion(
+	sc *signContext, electionID internal.HexBytes,
+) (internal.HexBytes, *errors.Error) {
+	question, err := c.mainDB.QuestionByUpstreamID(electionID)
+	if err != nil && err != db.ErrNotFound {
+		return nil, apiErr(errors.ErrGenericInternalServerError.WithErr(err))
+	}
+	if err != nil || question.ProcessID != sc.process.ID {
+		return nil, apiErr(errors.ErrUnauthorized.Withf("election not found in process"))
+	}
+	if !memberEligibleForQuestion(question, sc.memberID) {
+		return nil, apiErr(errors.ErrUnauthorized.Withf("member not eligible for this question"))
+	}
+	return question.UpstreamID, nil
+}
+
+// maxSignBatchBodyBytes bounds a POST /processes/{processId}/sign-batch body. One ballot is an
+// election id plus a voter address, ~200 characters of JSON once hex-encoded and quoted, so 512
+// bytes each leaves ample headroom; a process holds at most 100 questions, and a voter at most
+// one ballot per question. Like the relay endpoints this one is public, so the body has to be
+// bounded before it is buffered.
+const maxSignBatchBodyBytes = 100*512 + 4<<10
+
+// ballot is one validated item of a sign batch: the on-chain election to sign for and the
+// voter address to sign, both resolved during the validation pass.
+type ballot struct {
+	upstreamID internal.HexBytes
+	address    internal.HexBytes
+}
+
+// ProcessSignBatchHandler godoc
+//
+//	@Summary		Sign every question's ballot of a voting process in one call
+//	@Description	Batch form of POST /processes/{processId}/sign. A multi-question voting process is
+//	@Description	one on-chain election per question, so a voter holds one ballot per question and
+//	@Description	signing them one by one costs a round trip each. This signs them all under a single
+//	@Description	verified auth token. Public endpoint: the token authenticates the voter.
+//	@Description	The batch is authorized as a unit and signs nothing on failure — every ballot must
+//	@Description	name an election of this process (else 401) the member is eligible for (else 401),
+//	@Description	carry a parseable voter address (else 400), and no election may be repeated (else
+//	@Description	400). Once authorized, every ballot is signed and the response carries one entry per
+//	@Description	request item, in order: a signature and weight, or the reason that election could not
+//	@Description	be signed (its signing slot is spent, or a concurrent request holds it). Signing
+//	@Description	consumes a per-election slot that cannot be given back, so a failed entry is retried
+//	@Description	by calling again, not rolled back.
+//	@Tags			processes
+//	@Accept			json
+//	@Produce		json
+//	@Param			processId	path		string						true	"Process ID"
+//	@Param			request		body		handlers.SignBatchRequest	true	"Auth token and one ballot per question"
+//	@Success		200			{object}	handlers.SignBatchResponse
+//	@Failure		400			{object}	errors.Error	"Invalid input data"
+//	@Failure		401			{object}	errors.Error	"Unauthorized, unverified token, election not in process, or member not eligible"
+//	@Failure		404			{object}	errors.Error	"Process, census, or user not found"
+//	@Failure		413			{object}	errors.Error	"Request body too large"
+//	@Failure		500			{object}	errors.Error	"Internal server error"
+//	@Router			/processes/{processId}/sign-batch [post]
+//
+//nolint:lll
+func (c *CSPHandlers) ProcessSignBatchHandler(w http.ResponseWriter, r *http.Request) {
+	oid, _, ok := parseProcessID(w, r)
+	if !ok {
+		return
+	}
+	req, ok := parseSignBatchRequest(w, r)
+	if !ok {
+		return
+	}
+	sc, ok := c.resolveSignContext(w, oid, req.AuthToken)
+	if !ok {
+		return
+	}
+	switch {
+	case len(req.Signatures) == 0:
+		errors.ErrVoteBatchEmpty.Write(w)
+		return
+	case len(req.Signatures) > len(sc.process.QuestionIDs):
+		// a voter holds at most one ballot per question, so the process itself is the cap.
+		errors.ErrVoteBatchTooLarge.Withf("%d ballots, the process has %d questions",
+			len(req.Signatures), len(sc.process.QuestionIDs)).Write(w)
+		return
+	}
+
+	// authorize the whole batch before signing anything: signing consumes a per-election slot
+	// that cannot be given back, so a rejected batch must leave the voter with nothing signed
+	// rather than with a signed prefix.
+	ballots := make([]ballot, len(req.Signatures))
+	seen := make(map[string]int, len(req.Signatures))
+	for i, item := range req.Signatures {
+		// a repeated election would contend with itself on the per-(user, election) signer
+		// lock, and a voter has at most one ballot per question anyway.
+		if first, dup := seen[string(item.ProcessID)]; dup {
+			errors.ErrMalformedBody.Withf(
+				"the ballot at index %d repeats the election of index %d", i, first).Write(w)
+			return
+		}
+		seen[string(item.ProcessID)] = i
+		upstreamID, sErr := c.authorizeQuestion(sc, item.ProcessID)
+		if sErr != nil {
+			sErr.Withf("at index %d", i).Write(w)
+			return
+		}
+		address := new(internal.HexBytes)
+		if err := address.ParseString(item.Payload); err != nil {
+			errors.ErrMalformedBody.WithErr(err).Withf("at index %d", i).Write(w)
+			return
+		}
+		ballots[i] = ballot{upstreamID: upstreamID, address: *address}
+	}
+
+	// ponytail: signed sequentially. db.ConsumeCSPProcess takes the storage write lock, so a
+	// parallel fan-out inside one request would serialize on it anyway; revisit only if that
+	// lock stops being the bottleneck.
+	resp := &SignBatchResponse{Signatures: make([]SignBatchResult, len(ballots))}
+	for i, b := range ballots {
+		res := &resp.Signatures[i]
+		res.ProcessID = b.upstreamID
+		signature, err := c.csp.Sign(req.AuthToken, b.address, b.upstreamID, sc.weight,
+			signers.SignerTypeECDSASalted)
+		if err != nil {
+			// per-ballot by nature: this election's signing slot is spent, or a concurrent
+			// request holds its lock. The batch's siblings are unaffected.
+			log.Warnw("could not sign a batch ballot", "procId", b.upstreamID, "error", err)
+			res.Error = err.Error()
+			continue
+		}
+		res.Signature = signature
+		res.Weight = sc.weight
+	}
+	apicommon.HTTPWriteJSON(w, resp)
+}
+
+// parseSignBatchRequest decodes a capped sign-batch body and checks it carries an auth token,
+// writing the proper error and returning false on failure.
+func parseSignBatchRequest(w http.ResponseWriter, r *http.Request) (*SignBatchRequest, bool) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxSignBatchBodyBytes)
+	var req SignBatchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			errors.ErrRequestBodyTooLarge.Withf("the limit is %d bytes", maxSignBatchBodyBytes).Write(w)
+			return nil, false
+		}
+		errors.ErrMalformedBody.Write(w)
+		return nil, false
+	}
+	if req.AuthToken == nil {
+		errors.ErrUnauthorized.Withf("missing auth token").Write(w)
+		return nil, false
+	}
+	return &req, true
 }
 
 // ProcessWeightHandler godoc

--- a/csp/handlers/types.go
+++ b/csp/handlers/types.go
@@ -57,6 +57,34 @@ type SignRequest struct {
 	ProcessID internal.HexBytes `json:"electionId,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`
 }
 
+// SignBatchRequest is the batch form of SignRequest: one auth token and one ballot per
+// question of a voting process, signed in a single call.
+type SignBatchRequest struct {
+	AuthToken  internal.HexBytes `json:"authToken" swaggertype:"string" format:"hex" example:"deadbeef"`
+	Signatures []SignBatchItem   `json:"signatures"`
+}
+
+// SignBatchItem is one ballot of a SignBatchRequest: the question's on-chain election id and
+// the voter address to sign, matching SignRequest's electionId and payload fields.
+type SignBatchItem struct {
+	ProcessID internal.HexBytes `json:"electionId" swaggertype:"string" format:"hex" example:"deadbeef"`
+	Payload   string            `json:"payload"`
+}
+
+// SignBatchResponse holds one result per requested ballot, in request order.
+type SignBatchResponse struct {
+	Signatures []SignBatchResult `json:"signatures"`
+}
+
+// SignBatchResult is one ballot's outcome: the signature and the weight it was signed with, or
+// the reason that election could not be signed. Exactly one of Signature and Error is set.
+type SignBatchResult struct {
+	ProcessID internal.HexBytes `json:"electionId" swaggertype:"string" format:"hex" example:"deadbeef"`
+	Signature internal.HexBytes `json:"signature,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`
+	Weight    internal.HexBytes `json:"weight,omitempty" swaggertype:"string" format:"hex" example:"2a"`
+	Error     string            `json:"error,omitempty"`
+}
+
 // UserWeightRequest defines the payload for the request to get the
 // weight of a user for a given bundle. It includes the authToken to query
 // the information.

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2638,6 +2638,50 @@ definitions:
         format: hex
         type: string
     type: object
+  handlers.SignBatchItem:
+    properties:
+      electionId:
+        example: deadbeef
+        format: hex
+        type: string
+      payload:
+        type: string
+    type: object
+  handlers.SignBatchRequest:
+    properties:
+      authToken:
+        example: deadbeef
+        format: hex
+        type: string
+      signatures:
+        items:
+          $ref: '#/definitions/handlers.SignBatchItem'
+        type: array
+    type: object
+  handlers.SignBatchResponse:
+    properties:
+      signatures:
+        items:
+          $ref: '#/definitions/handlers.SignBatchResult'
+        type: array
+    type: object
+  handlers.SignBatchResult:
+    properties:
+      electionId:
+        example: deadbeef
+        format: hex
+        type: string
+      error:
+        type: string
+      signature:
+        example: deadbeef
+        format: hex
+        type: string
+      weight:
+        example: 2a
+        format: hex
+        type: string
+    type: object
   handlers.SignRequest:
     properties:
       authToken:
@@ -6678,6 +6722,66 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
       summary: Sign a ballot for a voting process question
+      tags:
+      - processes
+  /processes/{processId}/sign-batch:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Batch form of POST /processes/{processId}/sign. A multi-question voting process is
+        one on-chain election per question, so a voter holds one ballot per question and
+        signing them one by one costs a round trip each. This signs them all under a single
+        verified auth token. Public endpoint: the token authenticates the voter.
+        The batch is authorized as a unit and signs nothing on failure — every ballot must
+        name an election of this process (else 401) the member is eligible for (else 401),
+        carry a parseable voter address (else 400), and no election may be repeated (else
+        400). Once authorized, every ballot is signed and the response carries one entry per
+        request item, in order: a signature and weight, or the reason that election could not
+        be signed (its signing slot is spent, or a concurrent request holds it). Signing
+        consumes a per-election slot that cannot be given back, so a failed entry is retried
+        by calling again, not rolled back.
+      parameters:
+      - description: Process ID
+        in: path
+        name: processId
+        required: true
+        type: string
+      - description: Auth token and one ballot per question
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.SignBatchRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.SignBatchResponse'
+        "400":
+          description: Invalid input data
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "401":
+          description: Unauthorized, unverified token, election not in process, or
+            member not eligible
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "404":
+          description: Process, census, or user not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "413":
+          description: Request body too large
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+      summary: Sign every question's ballot of a voting process in one call
       tags:
       - processes
   /processes/{processId}/sign-info:


### PR DESCRIPTION
## Why

A multi-question voting process is **one on-chain election per question**, so a voter holds one ballot per question. `POST /votes` already relays them in a single call — the signing side had no counterpart. A voter had to hit `POST /processes/{processId}/sign` once per question, and each call re-did the same work (load the process, load and verify the auth token, load the org member, load the census, compute the weight) before signing one ballot.

## What

`POST /processes/{processId}/sign-batch` — one auth token, N ballots, one response.

`ProcessSignHandler` is split into two reusable halves so the batch handler shares the exact checks rather than duplicating them:

- `resolveSignContext` — the per-request part: voting process, verified token anchored to it, member behind it, census weight.
- `authorizeQuestion` — the per-ballot part: the election belongs to this process, and the member is eligible for that question.

The single endpoint's behaviour and status codes are unchanged.

## Failure semantics

Signing consumes a per-election slot that cannot be given back (`csp.Sign` → `db.ConsumeCSPProcess`), so the batch is **authorized as a unit and signs nothing on failure**:

| Condition | Result |
|---|---|
| election not in this process / member not eligible | 401, nothing signed |
| unparseable voter address | 400, nothing signed |
| repeated `electionId` | 400, nothing signed |
| empty batch / more ballots than the process has questions | 400, nothing signed |

Once authorized, every ballot is signed and the response carries one entry per request item, in order — a signature and weight, or the reason that election could not be signed. Those residual failures are per-ballot by nature (the slot is spent, or a concurrent request holds its `(user, election)` lock), so a failed entry is retried by calling again rather than rolled back. `MaxVoteOverwritesPerProcess` (10) makes that retry viable.

```json
{"signatures": [
  {"electionId": "aa..", "signature": "..", "weight": "01"},
  {"electionId": "bb..", "error": "process already consumed"}
]}
```

## Notes

- **No new cap constant** — a voter has at most one ballot per question, so `len(vp.QuestionIDs)` is the real bound (`maxQuestionsPerProcess` = 100 caps it transitively).
- **No new error codes** — reuses `ErrVoteBatchEmpty`, `ErrVoteBatchTooLarge`, `ErrRequestBodyTooLarge` from the vote relay, with the same `at index %d` annotation.
- **Body is capped** before it is buffered, as on the other public endpoints.
- **Signed sequentially** — `db.ConsumeCSPProcess` takes the storage write lock, so a parallel fan-out inside one request would serialize on it anyway.
- The legacy `POST /process/bundle/{bundleId}/sign` is untouched.

## Testing

`TestProcessCSPSignBatch` (`api/processes_csp_test.go`) covers: whole-batch rejection leaves nothing consumed, duplicate election → 400, empty → 400, over-cap → `ErrVoteBatchTooLarge`, happy path signs both questions and `sign-info` reports both consumed, and a spent signing slot surfaces as a per-ballot `error` while its sibling still signs.

- `go test ./csp/... ./api/` → 294 passed
- `make lint` → 0 issues
- `scripts/check-qt-patterns.sh` → clean
- `docs/swagger.yaml` regenerated