### PR TITLE
feat(processes): sign a batch of ballots at POST /processes/{processId}/sign-batch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ make swagger     # regenerate docs/swagger.yaml from swag annotations (run after
 # Run a single test / package
 go test -run TestName ./api/
 go test -v ./db/
+# The api package is the slow one (~7 min for the whole suite) because every test
+# publishes real elections against the Voconed container — always narrow with -run.
 
 # Local dev stack (API + MongoDB + mongo-express on :8081)
 cp example.env .env   # then edit secrets
@@ -34,6 +36,14 @@ docker compose up
   There are no unit-test-only mocks for the DB — integration tests hit a real containerized Mongo.
 - After editing any API handler, route, or `apicommon` request/response type, run `make swagger`
   so `docs/swagger.yaml` stays in sync (it is generated from `//` swag annotations on `api/api.go` and handlers).
+  Gotcha: `scripts/generate-swagger.sh` deletes `docs/swagger.yaml` before regenerating and calls
+  `swag` without `$(go env GOPATH)/bin` on `PATH`, so on a machine without `swag` already installed
+  it deletes the file and then fails. Put that directory on `PATH` (or run `swag fmt -d ./` and
+  `swag init -g api/api.go -o docs --outputTypes yaml --parseDependency --parseInternal --parseDepth=4`
+  by hand) if the target errors out.
+- API integration tests drive the server over HTTP through generic helpers in `api/api_test.go`:
+  `requestAndParse[T]`, `requestAndAssertCode`, `requestAndAssertError`, and `enqueueAndPollJob` /
+  `pollJob` for the async job endpoints. Use those rather than hand-rolling requests.
 
 ## Architecture
 
@@ -41,6 +51,47 @@ Configuration flows through **Viper with the `VOCDONI_` env prefix** (e.g. `--mo
 `VOCDONI_MONGOURL`). `cmd/service/main.go` wires every component into an `api.Config` and calls
 `api.New(conf).Start()`. Services are optional and conditionally enabled based on whether their
 config is present (SMTP, Twilio SMS); Stripe is required.
+
+### Two generations of the process API live side by side
+
+This is the single most confusing thing in the codebase, and it is invisible from any one file.
+
+- **New (`/processes`, plural)** — a `db.VotingProcess` is a *container* of `db.VotingProcessQuestion`s,
+  and **each question is its own on-chain election**, identified after publish by its `UpstreamID`.
+  So a voter casts one vote transaction per question, holds one CSP signature per question, and one
+  nullifier per question. Anything taking an on-chain election id resolves it with
+  `db.QuestionByUpstreamID`. Voter-facing CSP handlers for this generation live in
+  `csp/handlers/processes.go`.
+- **Legacy (`/process`, singular, and `/process/bundle/...`)** — a `db.Process` *is* one on-chain
+  election, and a "bundle" groups several. Handlers live in `csp/handlers/handlers.go`. Deprecated
+  but still wired; several routes are marked `@Deprecated` in their swag annotations.
+
+Code that must serve both looks up the new collection and falls back to the legacy one — see
+`parseRelayVote` in `api/process_vote.go`, which tries `db.ProcessByAddress` then
+`db.QuestionByUpstreamID`. New work belongs on the `/processes` side; do not extend the legacy path.
+
+A consequence worth internalizing: because one voter action fans out to N elections, several
+endpoints exist purely in batch form so a voter cannot end up half-done — `POST /votes` (relay),
+`POST /votes/verify`, `POST /processes/{processId}/sign-batch`. They share a shape: cap the body,
+validate/authorize the **whole** batch before doing anything, then act.
+
+### On-chain writes are asynchronous jobs, not request-scoped
+
+Any endpoint that submits a transaction returns **202 + `{"jobId": ...}`** and the caller polls
+`GET /jobs/{jobId}`. The machinery is `api/jobqueue.go`:
+
+- `a.enqueueTx(txTask{...})` / `a.enqueueTxBatch(tasks)` push onto a buffered `txQueue`
+  (512 slots, 16 workers). `enqueueTxBatch` takes all the slots or none; a full queue is a 503.
+- A `txTask.run` closure does the submit *and* waits for the tx to be mined, so it blocks a worker
+  the whole time — never spend one on work that isn't an on-chain submit.
+- `txTask.record` overrides how the outcome is written. Tasks sharing one job (the envelopes of a
+  batch relay) need it, or the first to finish would mark the whole job terminal.
+- `a.orgTxLocks.lock(org)` serializes build→sign→submit per organization so two concurrent requests
+  cannot read the same account nonce. The lock is handed to the worker and released after submit.
+
+`statussync/` closes the loop in the other direction: an enqueue-driven worker that reconciles a
+published question's stored status against the Vochain, triggered by API status changes and by
+reads, rather than by a timer.
 
 Component packages (each is a focused service composed in `main.go`):
 
@@ -71,6 +122,7 @@ Component packages (each is a focused service composed in `main.go`):
 - **`objectstorage/`** — S3-like object storage (images) backed by Mongo, with upload/download handlers.
 - **`errors/`** — typed API `Error` (code + HTTP status + optional data), JSON-serializable; handlers
   return these. Predefined errors in `errors_definition.go`.
+- **`statussync/`** — the on-demand question-status reconciler described above.
 - **`internal/`** — shared primitives: `HexBytes`, birthdate parsing, phone/argon2 helpers.
 - **`cmd/`** — `service/` (the API server), `cli/` (DB query tool for process/voter stats),
   `client/` (HTTP client for CSV member import + census workflows).

--- a/api/api.go
+++ b/api/api.go
@@ -485,6 +485,7 @@ func (a *API) initRouter() http.Handler {
 		handle(r, http.MethodPost, processesAuthEndpoint, cspHandlers.ProcessAuthHandler)
 		handle(r, http.MethodPost, processesAuthResendEndpoint, cspHandlers.ProcessAuthResendHandler)
 		handle(r, http.MethodPost, processesSignEndpoint, cspHandlers.ProcessSignHandler)
+		handle(r, http.MethodPost, processesSignBatchEndpoint, cspHandlers.ProcessSignBatchHandler)
 		handle(r, http.MethodPost, processesWeightEndpoint, cspHandlers.ProcessWeightHandler)
 		handle(r, http.MethodPost, processesSignInfoEndpoint, cspHandlers.ProcessSignInfoHandler)
 	})

--- a/api/apicommon/helpers.go
+++ b/api/apicommon/helpers.go
@@ -5,9 +5,11 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	stderrors "errors"
 	"net/http"
 
 	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/errors"
 	"go.vocdoni.io/dvote/log"
 )
 
@@ -81,4 +83,23 @@ func NewJobID() (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(b), nil
+}
+
+// DecodeCappedJSON reads at most limit bytes of the request body and decodes them into dst,
+// returning the API error to write back on a body that is too large or not the expected JSON.
+// Shared by the public relay and CSP endpoints, whose bodies must be bounded before they are
+// buffered. Lives here (not in package api) so csp/handlers — which api imports — can use it
+// without an import cycle.
+func DecodeCappedJSON(w http.ResponseWriter, r *http.Request, dst any, limit int64) *errors.Error {
+	r.Body = http.MaxBytesReader(w, r.Body, limit)
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		var tooLarge *http.MaxBytesError
+		if stderrors.As(err, &tooLarge) {
+			tooLargeErr := errors.ErrRequestBodyTooLarge.Withf("the limit is %d bytes", limit)
+			return &tooLargeErr
+		}
+		malformed := errors.ErrMalformedBody
+		return &malformed
+	}
+	return nil
 }

--- a/api/apicommon/helpers.go
+++ b/api/apicommon/helpers.go
@@ -95,11 +95,9 @@ func DecodeCappedJSON(w http.ResponseWriter, r *http.Request, dst any, limit int
 	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
 		var tooLarge *http.MaxBytesError
 		if stderrors.As(err, &tooLarge) {
-			tooLargeErr := errors.ErrRequestBodyTooLarge.Withf("the limit is %d bytes", limit)
-			return &tooLargeErr
+			return errors.Ptr(errors.ErrRequestBodyTooLarge.Withf("the limit is %d bytes", limit))
 		}
-		malformed := errors.ErrMalformedBody
-		return &malformed
+		return errors.Ptr(errors.ErrMalformedBody)
 	}
 	return nil
 }

--- a/api/jobqueue.go
+++ b/api/jobqueue.go
@@ -43,7 +43,7 @@ func (o *orgTxMutex) lock(addr common.Address) *sync.Mutex {
 const (
 	// txQueueSize bounds the number of queued-but-not-yet-running tx tasks. It is sized to hold
 	// several full vote batches at once: POST /votes reserves one slot per envelope all-or-nothing,
-	// so a queue merely as large as maxVotesPerBatch would accept a full batch only on a completely
+	// so a queue merely as large as one full batch (db.MaxQuestionsPerProcess) would accept it only on a completely
 	// idle service, and a client turned away falls back to relaying one vote at a time — the
 	// half-voted window that endpoint exists to close. The buffer is not the bottleneck (the
 	// workers below are), so a bigger one adds no chain load or concurrency; it only stops

--- a/api/process_vote.go
+++ b/api/process_vote.go
@@ -46,7 +46,7 @@ import (
 //	@Router			/vote [post]
 func (a *API) relayVoteHandler(w http.ResponseWriter, r *http.Request) {
 	var req apicommon.RelayVoteRequest
-	if err := decodeCappedJSON(w, r, &req, maxVoteBodyBytes); err != nil {
+	if err := apicommon.DecodeCappedJSON(w, r, &req, maxVoteBodyBytes); err != nil {
 		err.Write(w)
 		return
 	}
@@ -88,7 +88,7 @@ func (a *API) relayVoteHandler(w http.ResponseWriter, r *http.Request) {
 const (
 	// maxVotesPerBatch bounds a POST /votes call. A voter casts one vote per question, and a
 	// process cannot hold more questions than this, so the cap is expressed as what it actually
-	// depends on rather than a duplicated literal: raising it means raising maxQuestionsPerProcess
+	// depends on rather than a duplicated literal: raising it means raising db.MaxQuestionsPerProcess
 	// first, and the vochain batch transaction endpoint above that. It is deliberately NOT tied to
 	// txQueueSize — the queue is sized to hold several full batches (see api/jobqueue.go), because
 	// a batch rejected for lack of queue room sends the client back to relaying one vote at a time,
@@ -101,7 +101,7 @@ const (
 	// is strictly better behaved than relaying a prefix and stopping. Rate limiting is intentionally
 	// out of scope for this endpoint; it belongs with the API-wide throttling applied to every route
 	// in initRouter (api/api.go).
-	maxVotesPerBatch = maxQuestionsPerProcess
+	maxVotesPerBatch = db.MaxQuestionsPerProcess
 	// maxVoteBodyBytes bounds the request body of a single relayed envelope. A CSP-signed vote
 	// envelope marshals to ~300 bytes, ~600 characters once hex-encoded into the JSON field, so
 	// this leaves an order of magnitude of headroom for larger proofs while keeping these public,
@@ -111,21 +111,6 @@ const (
 	// JSON framing around them.
 	maxVotesBodyBytes = maxVotesPerBatch*maxVoteBodyBytes + 4<<10
 )
-
-// decodeCappedJSON reads at most limit bytes of the request body and decodes them into dst,
-// returning the API error to write back on a body that is too large or not the expected JSON.
-// The relay endpoints are public, so the body has to be bounded before it is buffered.
-func decodeCappedJSON(w http.ResponseWriter, r *http.Request, dst any, limit int64) *errors.Error {
-	r.Body = http.MaxBytesReader(w, r.Body, limit)
-	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
-		var tooLarge *http.MaxBytesError
-		if stderrors.As(err, &tooLarge) {
-			return asPtr(errors.ErrRequestBodyTooLarge.Withf("the limit is %d bytes", limit))
-		}
-		return asPtr(errors.ErrMalformedBody)
-	}
-	return nil
-}
 
 // relayVotesHandler godoc
 //
@@ -158,7 +143,7 @@ func decodeCappedJSON(w http.ResponseWriter, r *http.Request, dst any, limit int
 //	@Router			/votes [post]
 func (a *API) relayVotesHandler(w http.ResponseWriter, r *http.Request) {
 	var req apicommon.RelayVotesRequest
-	if err := decodeCappedJSON(w, r, &req, maxVotesBodyBytes); err != nil {
+	if err := apicommon.DecodeCappedJSON(w, r, &req, maxVotesBodyBytes); err != nil {
 		err.Write(w)
 		return
 	}
@@ -186,13 +171,15 @@ func (a *API) relayVotesHandler(w http.ResponseWriter, r *http.Request) {
 		// The questions of a voting process share one, so a mixed batch is a client bug.
 		if i > 0 && vote.org != votes[0].org {
 			errors.ErrVoteBatchMixedOrganizations.Withf(
-				"vote index %d targets %s, vote index 0 targets %s", i, vote.org, votes[0].org).Write(w)
+				"vote index %d targets %s, vote index 0 targets %s", i, vote.org, votes[0].org,
+			).Write(w)
 			return
 		}
 		if len(vote.nullifier) > 0 {
 			if first, dup := seenNullifier[vote.nullifier.String()]; dup {
 				errors.ErrInvalidTxFormat.Withf(
-					"vote index %d repeats the nullifier of vote index %d", i, first).Write(w)
+					"vote index %d repeats the nullifier of vote index %d", i, first,
+				).Write(w)
 				return
 			}
 			seenNullifier[vote.nullifier.String()] = i
@@ -282,7 +269,7 @@ var verifyLookupSem = make(chan struct{}, 32)
 //	@Router			/votes/verify [post]
 func (a *API) verifyVotesHandler(w http.ResponseWriter, r *http.Request) {
 	var req apicommon.VerifyVotesRequest
-	if err := decodeCappedJSON(w, r, &req, maxVerifyVotesBodyBytes); err != nil {
+	if err := apicommon.DecodeCappedJSON(w, r, &req, maxVerifyVotesBodyBytes); err != nil {
 		err.Write(w)
 		return
 	}

--- a/api/process_vote.go
+++ b/api/process_vote.go
@@ -365,26 +365,26 @@ type parsedVote struct {
 // the API error to write back, never both.
 func (a *API) parseRelayVote(payload internal.HexBytes) (*parsedVote, *errors.Error) {
 	if len(payload) == 0 {
-		return nil, asPtr(errors.ErrMalformedBody.Withf("missing txPayload"))
+		return nil, errors.Ptr(errors.ErrMalformedBody.Withf("missing txPayload"))
 	}
 
 	signedTx := &models.SignedTx{}
 	if err := proto.Unmarshal(payload, signedTx); err != nil {
-		return nil, asPtr(errors.ErrInvalidTxFormat.Withf("could not decode signed tx: %v", err))
+		return nil, errors.Ptr(errors.ErrInvalidTxFormat.Withf("could not decode signed tx: %v", err))
 	}
 	innerTx := &models.Tx{}
 	if err := proto.Unmarshal(signedTx.Tx, innerTx); err != nil {
-		return nil, asPtr(errors.ErrInvalidTxFormat.Withf("could not decode tx: %v", err))
+		return nil, errors.Ptr(errors.ErrInvalidTxFormat.Withf("could not decode tx: %v", err))
 	}
 
 	vote := innerTx.GetVote()
 	if vote == nil {
-		return nil, asPtr(errors.ErrInvalidTxFormat.With("not a vote tx"))
+		return nil, errors.Ptr(errors.ErrInvalidTxFormat.With("not a vote tx"))
 	}
 	// the target process is the one named in the signed vote envelope.
 	pid := internal.HexBytes(vote.ProcessId)
 	if len(pid) == 0 {
-		return nil, asPtr(errors.ErrInvalidTxFormat.With("vote has no process id"))
+		return nil, errors.Ptr(errors.ErrInvalidTxFormat.With("vote has no process id"))
 	}
 
 	// ensure we manage this election, resolving its owning organization. Legacy elections
@@ -402,12 +402,12 @@ func (a *API) parseRelayVote(payload internal.HexBytes) (*parsedVote, *errors.Er
 		case nil:
 			orgAddress = question.OrgAddress
 		case db.ErrNotFound:
-			return nil, asPtr(errors.ErrProcessNotFound)
+			return nil, errors.Ptr(errors.ErrProcessNotFound)
 		default:
-			return nil, asPtr(errors.ErrGenericInternalServerError.WithErr(qErr))
+			return nil, errors.Ptr(errors.ErrGenericInternalServerError.WithErr(qErr))
 		}
 	default:
-		return nil, asPtr(errors.ErrGenericInternalServerError.WithErr(err))
+		return nil, errors.Ptr(errors.ErrGenericInternalServerError.WithErr(err))
 	}
 
 	return &parsedVote{
@@ -481,9 +481,6 @@ func (a *API) recordBatchVote(jobID string, index int) func(*db.JobResult, error
 		}
 	}
 }
-
-// asPtr lifts an API error to a pointer, so parseRelayVote can signal "no error" with nil.
-func asPtr(e errors.Error) *errors.Error { return &e }
 
 // setProcessStatusHandler godoc
 //

--- a/api/process_vote.go
+++ b/api/process_vote.go
@@ -85,23 +85,23 @@ func (a *API) relayVoteHandler(w http.ResponseWriter, r *http.Request) {
 	apicommon.HTTPWriteJSONStatus(w, http.StatusAccepted, &apicommon.EnqueuedResponse{JobID: jobID})
 }
 
+// A POST /votes call is bounded by db.MaxQuestionsPerProcess, used directly rather than through a
+// local alias so the api package names the cap one way. A voter casts one vote per question, and a
+// process cannot hold more questions than that, so the cap is expressed as what it actually
+// depends on rather than a duplicated literal: raising it means raising db.MaxQuestionsPerProcess
+// first, and the vochain batch transaction endpoint above that. It is deliberately NOT tied to
+// txQueueSize — the queue is sized to hold several full batches (see api/jobqueue.go), because
+// a batch rejected for lack of queue room sends the client back to relaying one vote at a time,
+// which is the half-voted window this endpoint exists to close.
+//
+// On the denial-of-service trade-off: one request can occupy up to this many worker slots, each
+// blocked until its transaction is mined, and the endpoint is public and unauthenticated. That
+// amortizes the existing relay surface, it does not enlarge it — the same client can reach the
+// same state with as many sequential POST /vote calls, and the all-or-nothing 503 here
+// is strictly better behaved than relaying a prefix and stopping. Rate limiting is intentionally
+// out of scope for this endpoint; it belongs with the API-wide throttling applied to every route
+// in initRouter (api/api.go).
 const (
-	// maxVotesPerBatch bounds a POST /votes call. A voter casts one vote per question, and a
-	// process cannot hold more questions than this, so the cap is expressed as what it actually
-	// depends on rather than a duplicated literal: raising it means raising db.MaxQuestionsPerProcess
-	// first, and the vochain batch transaction endpoint above that. It is deliberately NOT tied to
-	// txQueueSize — the queue is sized to hold several full batches (see api/jobqueue.go), because
-	// a batch rejected for lack of queue room sends the client back to relaying one vote at a time,
-	// which is the half-voted window this endpoint exists to close.
-	//
-	// On the denial-of-service trade-off: one request can occupy up to this many worker slots, each
-	// blocked until its transaction is mined, and the endpoint is public and unauthenticated. That
-	// amortizes the existing relay surface, it does not enlarge it — the same client can reach the
-	// same state with maxVotesPerBatch sequential POST /vote calls, and the all-or-nothing 503 here
-	// is strictly better behaved than relaying a prefix and stopping. Rate limiting is intentionally
-	// out of scope for this endpoint; it belongs with the API-wide throttling applied to every route
-	// in initRouter (api/api.go).
-	maxVotesPerBatch = db.MaxQuestionsPerProcess
 	// maxVoteBodyBytes bounds the request body of a single relayed envelope. A CSP-signed vote
 	// envelope marshals to ~300 bytes, ~600 characters once hex-encoded into the JSON field, so
 	// this leaves an order of magnitude of headroom for larger proofs while keeping these public,
@@ -109,7 +109,7 @@ const (
 	maxVoteBodyBytes = 8 << 10
 	// maxVotesBodyBytes bounds a whole batch: one envelope allowance each, plus slack for the
 	// JSON framing around them.
-	maxVotesBodyBytes = maxVotesPerBatch*maxVoteBodyBytes + 4<<10
+	maxVotesBodyBytes = db.MaxQuestionsPerProcess*maxVoteBodyBytes + 4<<10
 )
 
 // relayVotesHandler godoc
@@ -151,8 +151,8 @@ func (a *API) relayVotesHandler(w http.ResponseWriter, r *http.Request) {
 	case len(req.Votes) == 0:
 		errors.ErrVoteBatchEmpty.Write(w)
 		return
-	case len(req.Votes) > maxVotesPerBatch:
-		errors.ErrVoteBatchTooLarge.Withf("%d votes, the maximum is %d", len(req.Votes), maxVotesPerBatch).Write(w)
+	case len(req.Votes) > db.MaxQuestionsPerProcess:
+		errors.ErrVoteBatchTooLarge.Withf("%d votes, the maximum is %d", len(req.Votes), db.MaxQuestionsPerProcess).Write(w)
 		return
 	}
 
@@ -234,7 +234,7 @@ const (
 	// characters, so 80 leaves room for the JSON quoting and separator around each, plus
 	// slack for the framing. Like the relay endpoints this one is public, so the body has
 	// to be bounded before it is buffered.
-	maxVerifyVotesBodyBytes = maxVotesPerBatch*80 + 4<<10
+	maxVerifyVotesBodyBytes = db.MaxQuestionsPerProcess*80 + 4<<10
 )
 
 // verifyLookupSem bounds concurrent node reads across every POST /votes/verify request.
@@ -277,9 +277,9 @@ func (a *API) verifyVotesHandler(w http.ResponseWriter, r *http.Request) {
 	case len(req.Nullifiers) == 0:
 		errors.ErrVoteBatchEmpty.Write(w)
 		return
-	case len(req.Nullifiers) > maxVotesPerBatch:
+	case len(req.Nullifiers) > db.MaxQuestionsPerProcess:
 		errors.ErrVoteBatchTooLarge.Withf("%d nullifiers, the maximum is %d",
-			len(req.Nullifiers), maxVotesPerBatch).Write(w)
+			len(req.Nullifiers), db.MaxQuestionsPerProcess).Write(w)
 		return
 	}
 	for i, nullifier := range req.Nullifiers {

--- a/api/process_vote_test.go
+++ b/api/process_vote_test.go
@@ -371,7 +371,7 @@ func TestRelayVote(t *testing.T) {
 	// an empty batch and one over the cap are rejected before any chain read
 	requestAndAssertError(errors.ErrVoteBatchEmpty, t, http.MethodPost, "",
 		&apicommon.VerifyVotesRequest{}, "votes", "verify")
-	tooMany := make([]internal.HexBytes, maxVotesPerBatch+1)
+	tooMany := make([]internal.HexBytes, db.MaxQuestionsPerProcess+1)
 	for i := range tooMany {
 		tooMany[i] = internal.RandomBytes(nullifierSize)
 	}
@@ -490,7 +490,7 @@ func TestRelayVotesRejectsBatch(t *testing.T) {
 		{"empty batch", nil, errors.ErrVoteBatchEmpty},
 		{
 			"over the cap",
-			make([]apicommon.RelayVoteRequest, maxVotesPerBatch+1),
+			make([]apicommon.RelayVoteRequest, db.MaxQuestionsPerProcess+1),
 			errors.ErrVoteBatchTooLarge,
 		},
 		{

--- a/api/processes.go
+++ b/api/processes.go
@@ -21,10 +21,6 @@ import (
 	"go.vocdoni.io/dvote/log"
 )
 
-// maxQuestionsPerProcess bounds the number of questions of a voting process (the node
-// batch endpoint caps a batch at 100 transactions).
-const maxQuestionsPerProcess = 100
-
 // parseProcessDates parses the optional RFC3339 start/end dates of a create/update request.
 func parseProcessDates(req *apicommon.CreateVotingProcessRequest) (start, end time.Time, err error) {
 	if req.StartDate != "" {
@@ -98,8 +94,8 @@ func (a *API) createVotingProcessHandler(w http.ResponseWriter, r *http.Request)
 		errors.ErrUnauthorized.Withf("user is not admin or manager of the organization").Write(w)
 		return
 	}
-	if len(req.Questions) == 0 || len(req.Questions) > maxQuestionsPerProcess {
-		errors.ErrMalformedBody.Withf("questions must be between 1 and %d", maxQuestionsPerProcess).Write(w)
+	if len(req.Questions) == 0 || len(req.Questions) > db.MaxQuestionsPerProcess {
+		errors.ErrMalformedBody.Withf("questions must be between 1 and %d", db.MaxQuestionsPerProcess).Write(w)
 		return
 	}
 	if err := a.subscriptions.OrgCanCreateVotingProcessDraft(orgAddr); err != nil {
@@ -262,7 +258,8 @@ func parseUpdatedAt(s string) (time.Time, error) {
 		if t, err = time.Parse(time.RFC3339, s); err != nil {
 			return time.Time{}, fmt.Errorf(
 				"invalid updatedAt %q: expected %s (or RFC3339) as returned by the read endpoint",
-				s, apicommon.UpdatedAtLayout)
+				s, apicommon.UpdatedAtLayout,
+			)
 		}
 	}
 	return t.UTC(), nil
@@ -331,8 +328,8 @@ func (a *API) updateVotingProcessHandler(w http.ResponseWriter, r *http.Request)
 		errors.ErrUnauthorized.Withf("user is not admin or manager of the organization").Write(w)
 		return
 	}
-	if len(req.Questions) == 0 || len(req.Questions) > maxQuestionsPerProcess {
-		errors.ErrMalformedBody.Withf("questions must be between 1 and %d", maxQuestionsPerProcess).Write(w)
+	if len(req.Questions) == 0 || len(req.Questions) > db.MaxQuestionsPerProcess {
+		errors.ErrMalformedBody.Withf("questions must be between 1 and %d", db.MaxQuestionsPerProcess).Write(w)
 		return
 	}
 	start, end, err := parseProcessDates(req)
@@ -692,7 +689,7 @@ func (a *API) votingProcessQuestionHandler(w http.ResponseWriter, r *http.Reques
 // parallelForEach runs fn(0..n-1) concurrently with a bounded worker pool and waits for all to
 // finish. It backs the per-question read resolvers and the results handler, which each fan out one
 // Vochain round-trip per question: the bound keeps GET /processes/{id} and /results fast for a process
-// with many questions (up to maxQuestionsPerProcess) without an unbounded goroutine burst.
+// with many questions (up to db.MaxQuestionsPerProcess) without an unbounded goroutine burst.
 func parallelForEach(n int, fn func(i int)) {
 	const workers = 8
 	sem := make(chan struct{}, workers)
@@ -1040,7 +1037,8 @@ func questionSetProblem(vp *db.VotingProcess, questions []db.VotingProcessQuesti
 	}
 	return fmt.Sprintf(
 		"stored questions do not match the process (%d found, %d expected, %d unknown): save the draft again",
-		len(questions), len(vp.QuestionIDs), stray)
+		len(questions), len(vp.QuestionIDs), stray,
+	)
 }
 
 // writeSubscriptionError writes a typed API error verbatim, falling back to 500.

--- a/api/processes_csp_test.go
+++ b/api/processes_csp_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	qt "github.com/frankban/quicktest"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/csp/handlers"
@@ -36,7 +37,8 @@ func verifyProcessCSP(t *testing.T, pid, email string, authToken internal.HexByt
 func authProcessCSP(t *testing.T, pid string, authReq *handlers.AuthRequest) internal.HexBytes {
 	t.Helper()
 	step0 := requestAndParse[handlers.AuthResponse](
-		t, http.MethodPost, "", authReq, "processes", pid, "auth", "0")
+		t, http.MethodPost, "", authReq, "processes", pid, "auth", "0",
+	)
 	qt.Assert(t, step0.AuthToken, qt.Not(qt.HasLen), 0)
 	return verifyProcessCSP(t, pid, authReq.Email, step0.AuthToken)
 }
@@ -60,7 +62,8 @@ func TestProcessCSP(t *testing.T) {
 	req.Census.AuthFields = db.OrgMemberAuthFields{db.OrgMemberAuthFieldsName, db.OrgMemberAuthFieldsSurname}
 	req.Census.Weighted = true
 	created := requestAndParse[apicommon.CreateVotingProcessResponse](
-		t, http.MethodPost, token, req, processesCreateEndpoint)
+		t, http.MethodPost, token, req, processesCreateEndpoint,
+	)
 	pid := created.ProcessID
 
 	job := enqueueAndPollJob(t, http.MethodPost, token, nil, "processes", pid, "publish")
@@ -88,7 +91,8 @@ func TestProcessCSP(t *testing.T) {
 	// --- first member: authenticate, but keep the mid-challenge token to exercise the
 	// unverified-sign gate and the OTP resend before completing verification ---
 	step0 := requestAndParse[handlers.AuthResponse](
-		t, http.MethodPost, "", authReq(0), "processes", pid, "auth", "0")
+		t, http.MethodPost, "", authReq(0), "processes", pid, "auth", "0",
+	)
 	c.Assert(step0.AuthToken, qt.Not(qt.HasLen), 0)
 
 	// an unverified token cannot sign
@@ -216,7 +220,8 @@ func TestProcessCSPSignBatch(t *testing.T) {
 	req.StartDate = ""
 	req.Census.AuthFields = db.OrgMemberAuthFields{db.OrgMemberAuthFieldsName, db.OrgMemberAuthFieldsSurname}
 	created := requestAndParse[apicommon.CreateVotingProcessResponse](
-		t, http.MethodPost, token, req, processesCreateEndpoint)
+		t, http.MethodPost, token, req, processesCreateEndpoint,
+	)
 	pid := created.ProcessID
 
 	job := enqueueAndPollJob(t, http.MethodPost, token, nil, "processes", pid, "publish")
@@ -246,8 +251,17 @@ func TestProcessCSPSignBatch(t *testing.T) {
 	}
 
 	// --- second member: eligible for the open question only, so a batch naming both is
-	// rejected as a unit and its eligible sibling is NOT signed ---
-	tok1 := authProcessCSP(t, pid, authReq(1))
+	// rejected as a unit and its eligible sibling is NOT signed. Keep the mid-challenge token so
+	// the unverified case below can reuse it without a second auth/0 (which the OTP cooldown
+	// would refuse) ---
+	step0tok1 := requestAndParse[handlers.AuthResponse](
+		t, http.MethodPost, "", authReq(1), "processes", pid, "auth", "0",
+	)
+	// an unverified (mid-challenge) token cannot sign. sign-info needs a verified token too, so
+	// the "nothing was signed" half is asserted below, once the same token is verified.
+	requestAndAssertCode(http.StatusUnauthorized, t, http.MethodPost, "",
+		batch(step0tok1.AuthToken, openElection), "processes", pid, "sign-batch")
+	tok1 := verifyProcessCSP(t, pid, members[1].Email, step0tok1.AuthToken)
 	requestAndAssertCode(http.StatusUnauthorized, t, http.MethodPost, "",
 		batch(tok1, openElection, restrictedElection), "processes", pid, "sign-batch")
 	c.Assert(consumed(tok1), qt.HasLen, 0)
@@ -259,7 +273,10 @@ func TestProcessCSPSignBatch(t *testing.T) {
 	requestAndAssertCode(http.StatusBadRequest, t, http.MethodPost, "",
 		batch(tok1), "processes", pid, "sign-batch")
 	requestAndAssertError(errors.ErrVoteBatchTooLarge, t, http.MethodPost, "",
-		&handlers.SignBatchRequest{AuthToken: tok1, Ballots: make([]handlers.SignBatchBallot, 3)},
+		&handlers.SignBatchRequest{
+			AuthToken: tok1,
+			Ballots:   make([]handlers.SignBatchBallot, db.MaxQuestionsPerProcess+1),
+		},
 		"processes", pid, "sign-batch")
 	// a ballot without an address is rejected, and takes the batch with it
 	requestAndAssertCode(http.StatusBadRequest, t, http.MethodPost, "",
@@ -274,6 +291,22 @@ func TestProcessCSPSignBatch(t *testing.T) {
 			AuthToken: tok1,
 			Ballots:   []handlers.SignBatchBallot{{Address: address}},
 		}, "processes", pid, "sign-batch")
+	// a wrong-length address is rejected before it can be pinned as the election's consumer
+	shortAddr := internal.HexBytes(bytes.Repeat([]byte{1}, common.AddressLength-1))
+	requestAndAssertCode(http.StatusBadRequest, t, http.MethodPost, "",
+		&handlers.SignBatchRequest{
+			AuthToken: tok1,
+			Ballots:   []handlers.SignBatchBallot{{UpstreamID: openElection, Address: shortAddr}},
+		},
+		"processes", pid, "sign-batch")
+	// an oversized body is refused before it is buffered (413, not 400)
+	huge := internal.HexBytes(bytes.Repeat([]byte{0}, 30000)) // hex ~60KB > the ~54KB cap
+	requestAndAssertError(errors.ErrRequestBodyTooLarge, t, http.MethodPost, "",
+		&handlers.SignBatchRequest{
+			AuthToken: tok1,
+			Ballots:   []handlers.SignBatchBallot{{UpstreamID: openElection, Address: huge}},
+		},
+		"processes", pid, "sign-batch")
 	c.Assert(consumed(tok1), qt.HasLen, 0)
 
 	// --- first member: both questions signed in one call ---
@@ -281,13 +314,15 @@ func TestProcessCSPSignBatch(t *testing.T) {
 	signed := requestAndParse[handlers.SignBatchResponse](t, http.MethodPost, "",
 		batch(tok0, openElection, restrictedElection), "processes", pid, "sign-batch")
 	c.Assert(signed.Signatures, qt.HasLen, 2)
+	weightOne := internal.HexBytes(big.NewInt(1).Bytes())
 	for i, s := range signed.Signatures {
 		c.Assert(s.Error, qt.Equals, "", qt.Commentf("ballot %d", i))
+		c.Assert(s.Code, qt.Equals, "", qt.Commentf("ballot %d", i))
 		c.Assert(s.Signature, qt.Not(qt.HasLen), 0)
-		c.Assert(bytes.Equal(s.Weight, big.NewInt(1).Bytes()), qt.IsTrue)
+		c.Assert(s.Weight, qt.DeepEquals, weightOne)
 	}
-	c.Assert(bytes.Equal(signed.Signatures[0].UpstreamID, openElection), qt.IsTrue)
-	c.Assert(bytes.Equal(signed.Signatures[1].UpstreamID, restrictedElection), qt.IsTrue)
+	c.Assert(signed.Signatures[0].UpstreamID, qt.DeepEquals, openElection)
+	c.Assert(signed.Signatures[1].UpstreamID, qt.DeepEquals, restrictedElection)
 	c.Assert(consumed(tok0), qt.HasLen, 2)
 
 	// --- a spent signing slot is a per-ballot error, not a failed batch: exhaust the open
@@ -300,8 +335,19 @@ func TestProcessCSPSignBatch(t *testing.T) {
 	again := requestAndParse[handlers.SignBatchResponse](t, http.MethodPost, "",
 		batch(tok0, openElection, restrictedElection), "processes", pid, "sign-batch")
 	c.Assert(again.Signatures, qt.HasLen, 2)
+	c.Assert(again.Signatures[0].Code, qt.Equals, "already_consumed")
 	c.Assert(again.Signatures[0].Error, qt.Not(qt.Equals), "")
 	c.Assert(again.Signatures[0].Signature, qt.HasLen, 0)
+	c.Assert(again.Signatures[1].Code, qt.Equals, "")
 	c.Assert(again.Signatures[1].Error, qt.Equals, "")
 	c.Assert(again.Signatures[1].Signature, qt.Not(qt.HasLen), 0)
+
+	// an all-failed batch is still 200: openElection is spent, so a single-ballot batch over it
+	// returns one entry carrying a code and no signature, not an error status
+	allFailed := requestAndParse[handlers.SignBatchResponse](t, http.MethodPost, "",
+		batch(tok0, openElection), "processes", pid, "sign-batch")
+	c.Assert(allFailed.Signatures, qt.HasLen, 1)
+	c.Assert(allFailed.Signatures[0].Code, qt.Equals, "already_consumed")
+	c.Assert(allFailed.Signatures[0].Signature, qt.HasLen, 0)
+	c.Assert(allFailed.Signatures[0].Error, qt.Not(qt.Equals), "")
 }

--- a/api/processes_csp_test.go
+++ b/api/processes_csp_test.go
@@ -133,6 +133,11 @@ func TestProcessCSP(t *testing.T) {
 		}, "processes", pid, "sign")
 	c.Assert(sign0.Signature, qt.Not(qt.HasLen), 0)
 
+	// a sign request naming no election is a client error, not an internal one
+	requestAndAssertCode(http.StatusBadRequest, t, http.MethodPost, "",
+		&handlers.SignRequest{AuthToken: tok0, Payload: hex.EncodeToString(voter.Address().Bytes())},
+		"processes", pid, "sign")
+
 	// sign-info: member 0's consumed address + nullifier for the open election are now available
 	signInfo := requestAndParse[handlers.ProcessSignInfoResponse](t, http.MethodPost, "",
 		&handlers.ConsumedAddressRequest{AuthToken: tok0}, "processes", pid, "sign-info")
@@ -261,6 +266,13 @@ func TestProcessCSPSignBatch(t *testing.T) {
 		&handlers.SignBatchRequest{
 			AuthToken: tok1,
 			Ballots:   []handlers.SignBatchBallot{{UpstreamID: openElection}},
+		}, "processes", pid, "sign-batch")
+	// ...and so is one without an election: an empty upstreamId is a client error, not the 500
+	// that db.QuestionByUpstreamID's ErrInvalidData would otherwise become
+	requestAndAssertCode(http.StatusBadRequest, t, http.MethodPost, "",
+		&handlers.SignBatchRequest{
+			AuthToken: tok1,
+			Ballots:   []handlers.SignBatchBallot{{Address: address}},
 		}, "processes", pid, "sign-batch")
 	c.Assert(consumed(tok1), qt.HasLen, 0)
 

--- a/api/processes_csp_test.go
+++ b/api/processes_csp_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/csp/handlers"
 	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/errors"
 	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.vocdoni.io/dvote/crypto/ethereum"
@@ -192,4 +193,97 @@ func TestProcessCSP(t *testing.T) {
 	// a malformed process id is a client error
 	requestAndAssertCode(http.StatusBadRequest, t, http.MethodPost, "",
 		&handlers.CheckMembershipRequest{AuthToken: tok0}, "processes", "not-a-valid-id", "check")
+}
+
+// TestProcessCSPSignBatch exercises POST /processes/{processId}/sign-batch: a batch is
+// authorized as a unit and signs nothing on failure, and once authorized every ballot is
+// signed with a per-ballot outcome.
+func TestProcessCSPSignBatch(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateProvisionedOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	// same fixture as TestProcessCSP: question 2 is restricted to the first member.
+	req := newVotingProcessRequest(orgAddress, ids)
+	req.StartDate = ""
+	req.Census.AuthFields = db.OrgMemberAuthFields{db.OrgMemberAuthFieldsName, db.OrgMemberAuthFieldsSurname}
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, req, processesCreateEndpoint)
+	pid := created.ProcessID
+
+	job := enqueueAndPollJob(t, http.MethodPost, token, nil, "processes", pid, "publish")
+	c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("job error: %s", job.Errors))
+
+	got := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	c.Assert(got.Questions, qt.HasLen, 2)
+	openElection := got.Questions[0].UpstreamID
+	restrictedElection := got.Questions[1].UpstreamID
+
+	authReq := func(i int) *handlers.AuthRequest {
+		return &handlers.AuthRequest{Name: members[i].Name, Surname: members[i].Surname, Email: members[i].Email}
+	}
+	voter := ethereum.SignKeys{}
+	c.Assert(voter.Generate(), qt.IsNil)
+	address := hex.EncodeToString(voter.Address().Bytes())
+	batch := func(authToken internal.HexBytes, elections ...internal.HexBytes) *handlers.SignBatchRequest {
+		items := make([]handlers.SignBatchItem, len(elections))
+		for i, e := range elections {
+			items[i] = handlers.SignBatchItem{ProcessID: e, Payload: address}
+		}
+		return &handlers.SignBatchRequest{AuthToken: authToken, Signatures: items}
+	}
+	consumed := func(authToken internal.HexBytes) []handlers.QuestionConsumedAddress {
+		return requestAndParse[handlers.ProcessSignInfoResponse](t, http.MethodPost, "",
+			&handlers.ConsumedAddressRequest{AuthToken: authToken}, "processes", pid, "sign-info").Consumed
+	}
+
+	// --- second member: eligible for the open question only, so a batch naming both is
+	// rejected as a unit and its eligible sibling is NOT signed ---
+	tok1 := authProcessCSP(t, pid, authReq(1))
+	requestAndAssertCode(http.StatusUnauthorized, t, http.MethodPost, "",
+		batch(tok1, openElection, restrictedElection), "processes", pid, "sign-batch")
+	c.Assert(consumed(tok1), qt.HasLen, 0)
+
+	// a repeated election, an empty batch and more ballots than the process has questions are
+	// all client errors, and none of them signs anything
+	requestAndAssertCode(http.StatusBadRequest, t, http.MethodPost, "",
+		batch(tok1, openElection, openElection), "processes", pid, "sign-batch")
+	requestAndAssertCode(http.StatusBadRequest, t, http.MethodPost, "",
+		batch(tok1), "processes", pid, "sign-batch")
+	requestAndAssertError(errors.ErrVoteBatchTooLarge, t, http.MethodPost, "",
+		&handlers.SignBatchRequest{AuthToken: tok1, Signatures: make([]handlers.SignBatchItem, 3)},
+		"processes", pid, "sign-batch")
+	c.Assert(consumed(tok1), qt.HasLen, 0)
+
+	// --- first member: both questions signed in one call ---
+	tok0 := authProcessCSP(t, pid, authReq(0))
+	signed := requestAndParse[handlers.SignBatchResponse](t, http.MethodPost, "",
+		batch(tok0, openElection, restrictedElection), "processes", pid, "sign-batch")
+	c.Assert(signed.Signatures, qt.HasLen, 2)
+	for i, s := range signed.Signatures {
+		c.Assert(s.Error, qt.Equals, "", qt.Commentf("ballot %d", i))
+		c.Assert(s.Signature, qt.Not(qt.HasLen), 0)
+		c.Assert(bytes.Equal(s.Weight, big.NewInt(1).Bytes()), qt.IsTrue)
+	}
+	c.Assert(bytes.Equal(signed.Signatures[0].ProcessID, openElection), qt.IsTrue)
+	c.Assert(bytes.Equal(signed.Signatures[1].ProcessID, restrictedElection), qt.IsTrue)
+	c.Assert(consumed(tok0), qt.HasLen, 2)
+
+	// --- a spent signing slot is a per-ballot error, not a failed batch: exhaust the open
+	// election's overwrites (it is at 1 after the batch above) and re-run the same batch ---
+	for i := 0; i < db.MaxVoteOverwritesPerProcess; i++ {
+		requestAndParse[handlers.AuthResponse](t, http.MethodPost, "",
+			&handlers.SignRequest{AuthToken: tok0, ProcessID: openElection, Payload: address},
+			"processes", pid, "sign")
+	}
+	again := requestAndParse[handlers.SignBatchResponse](t, http.MethodPost, "",
+		batch(tok0, openElection, restrictedElection), "processes", pid, "sign-batch")
+	c.Assert(again.Signatures, qt.HasLen, 2)
+	c.Assert(again.Signatures[0].Error, qt.Not(qt.Equals), "")
+	c.Assert(again.Signatures[0].Signature, qt.HasLen, 0)
+	c.Assert(again.Signatures[1].Error, qt.Equals, "")
+	c.Assert(again.Signatures[1].Signature, qt.Not(qt.HasLen), 0)
 }

--- a/api/processes_csp_test.go
+++ b/api/processes_csp_test.go
@@ -325,6 +325,21 @@ func TestProcessCSPSignBatch(t *testing.T) {
 	c.Assert(signed.Signatures[1].UpstreamID, qt.DeepEquals, restrictedElection)
 	c.Assert(consumed(tok0), qt.HasLen, 2)
 
+	// re-signing a consumed election with a DIFFERENT address is its own recoverable outcome
+	// (address_mismatch, fix: re-send with the pinned address), not already_consumed
+	otherVoter := ethereum.SignKeys{}
+	c.Assert(otherVoter.Generate(), qt.IsNil)
+	mismatch := requestAndParse[handlers.SignBatchResponse](t, http.MethodPost, "",
+		&handlers.SignBatchRequest{
+			AuthToken: tok0,
+			Ballots: []handlers.SignBatchBallot{
+				{UpstreamID: openElection, Address: internal.HexBytes(otherVoter.Address().Bytes())},
+			},
+		}, "processes", pid, "sign-batch")
+	c.Assert(mismatch.Signatures, qt.HasLen, 1)
+	c.Assert(mismatch.Signatures[0].Code, qt.Equals, "address_mismatch")
+	c.Assert(mismatch.Signatures[0].Signature, qt.HasLen, 0)
+
 	// --- a spent signing slot is a per-ballot error, not a failed batch: exhaust the open
 	// election's overwrites (it is at 1 after the batch above) and re-run the same batch ---
 	for i := 0; i < db.MaxVoteOverwritesPerProcess; i++ {

--- a/api/processes_csp_test.go
+++ b/api/processes_csp_test.go
@@ -227,13 +227,13 @@ func TestProcessCSPSignBatch(t *testing.T) {
 	}
 	voter := ethereum.SignKeys{}
 	c.Assert(voter.Generate(), qt.IsNil)
-	address := hex.EncodeToString(voter.Address().Bytes())
+	address := internal.HexBytes(voter.Address().Bytes())
 	batch := func(authToken internal.HexBytes, elections ...internal.HexBytes) *handlers.SignBatchRequest {
-		items := make([]handlers.SignBatchItem, len(elections))
+		ballots := make([]handlers.SignBatchBallot, len(elections))
 		for i, e := range elections {
-			items[i] = handlers.SignBatchItem{ProcessID: e, Payload: address}
+			ballots[i] = handlers.SignBatchBallot{UpstreamID: e, Address: address}
 		}
-		return &handlers.SignBatchRequest{AuthToken: authToken, Signatures: items}
+		return &handlers.SignBatchRequest{AuthToken: authToken, Ballots: ballots}
 	}
 	consumed := func(authToken internal.HexBytes) []handlers.QuestionConsumedAddress {
 		return requestAndParse[handlers.ProcessSignInfoResponse](t, http.MethodPost, "",
@@ -254,8 +254,14 @@ func TestProcessCSPSignBatch(t *testing.T) {
 	requestAndAssertCode(http.StatusBadRequest, t, http.MethodPost, "",
 		batch(tok1), "processes", pid, "sign-batch")
 	requestAndAssertError(errors.ErrVoteBatchTooLarge, t, http.MethodPost, "",
-		&handlers.SignBatchRequest{AuthToken: tok1, Signatures: make([]handlers.SignBatchItem, 3)},
+		&handlers.SignBatchRequest{AuthToken: tok1, Ballots: make([]handlers.SignBatchBallot, 3)},
 		"processes", pid, "sign-batch")
+	// a ballot without an address is rejected, and takes the batch with it
+	requestAndAssertCode(http.StatusBadRequest, t, http.MethodPost, "",
+		&handlers.SignBatchRequest{
+			AuthToken: tok1,
+			Ballots:   []handlers.SignBatchBallot{{UpstreamID: openElection}},
+		}, "processes", pid, "sign-batch")
 	c.Assert(consumed(tok1), qt.HasLen, 0)
 
 	// --- first member: both questions signed in one call ---
@@ -268,15 +274,15 @@ func TestProcessCSPSignBatch(t *testing.T) {
 		c.Assert(s.Signature, qt.Not(qt.HasLen), 0)
 		c.Assert(bytes.Equal(s.Weight, big.NewInt(1).Bytes()), qt.IsTrue)
 	}
-	c.Assert(bytes.Equal(signed.Signatures[0].ProcessID, openElection), qt.IsTrue)
-	c.Assert(bytes.Equal(signed.Signatures[1].ProcessID, restrictedElection), qt.IsTrue)
+	c.Assert(bytes.Equal(signed.Signatures[0].UpstreamID, openElection), qt.IsTrue)
+	c.Assert(bytes.Equal(signed.Signatures[1].UpstreamID, restrictedElection), qt.IsTrue)
 	c.Assert(consumed(tok0), qt.HasLen, 2)
 
 	// --- a spent signing slot is a per-ballot error, not a failed batch: exhaust the open
 	// election's overwrites (it is at 1 after the batch above) and re-run the same batch ---
 	for i := 0; i < db.MaxVoteOverwritesPerProcess; i++ {
 		requestAndParse[handlers.AuthResponse](t, http.MethodPost, "",
-			&handlers.SignRequest{AuthToken: tok0, ProcessID: openElection, Payload: address},
+			&handlers.SignRequest{AuthToken: tok0, ProcessID: openElection, Payload: address.String()},
 			"processes", pid, "sign")
 	}
 	again := requestAndParse[handlers.SignBatchResponse](t, http.MethodPost, "",

--- a/api/routes.go
+++ b/api/routes.go
@@ -248,7 +248,11 @@ const (
 	processesAuthEndpoint       = "/processes/{processId}/auth/{step}"
 	processesAuthResendEndpoint = "/processes/{processId}/auth/resend"
 	processesSignEndpoint       = "/processes/{processId}/sign"
-	processesWeightEndpoint     = "/processes/{processId}/weight"
+	// POST /processes/{processId}/sign-batch to sign every question's ballot in one call, so a
+	// voter casting a multi-question process does not need one round trip per question. The
+	// batch is authorized as a unit and signs nothing on failure.
+	processesSignBatchEndpoint = "/processes/{processId}/sign-batch"
+	processesWeightEndpoint    = "/processes/{processId}/weight"
 
 	// // census auth routes (currently not implemented)
 	// // POST /process/{processId}/auth/0 to initiate auth

--- a/api/routes.go
+++ b/api/routes.go
@@ -249,8 +249,9 @@ const (
 	processesAuthResendEndpoint = "/processes/{processId}/auth/resend"
 	processesSignEndpoint       = "/processes/{processId}/sign"
 	// POST /processes/{processId}/sign-batch to sign every question's ballot in one call, so a
-	// voter casting a multi-question process does not need one round trip per question. The
-	// batch is authorized as a unit and signs nothing on failure.
+	// voter casting a multi-question process does not need one round trip per question.
+	// Authorization is all or nothing — a rejected batch signs nothing — but the signing that
+	// follows reports per ballot: one entry can fail while its siblings succeed.
 	processesSignBatchEndpoint = "/processes/{processId}/sign-batch"
 	processesWeightEndpoint    = "/processes/{processId}/weight"
 

--- a/csp/errors.go
+++ b/csp/errors.go
@@ -49,6 +49,9 @@ var (
 	// ErrProcessAlreadyConsumed is returned when the user is already
 	// identified in the process.
 	ErrProcessAlreadyConsumed = fmt.Errorf("the user is already identified in the process")
+	// ErrAddressMismatch is returned when a signature is requested for a different address
+	// than the one the election was first consumed with (the slot is pinned to it).
+	ErrAddressMismatch = fmt.Errorf("the election was already signed for a different address")
 	// ErrProcessAlreadyVoted is returned when the user has already voted in
 	// the process.
 	ErrProcessAlreadyVoted = fmt.Errorf("the user has already voted in the process")

--- a/csp/handlers/handlers.go
+++ b/csp/handlers/handlers.go
@@ -331,30 +331,51 @@ func weightBytes(w uint64) internal.HexBytes {
 	return new(big.Int).SetUint64(w).Bytes()
 }
 
-// parseAddress parses the address from the payload. The address is signed into the CA bundle and
-// pinned as the election's consumer, after which a different address is rejected forever, so it
-// must be a full 20-byte Ethereum address — HexBytes would otherwise accept any length and pad
-// odd input, locking the voter out of the election with one bad value.
+// validateVoterAddress checks a voter address is a full 20-byte Ethereum address. The address is
+// signed into the CA bundle and pinned as the election's consumer, after which a different
+// address is rejected forever — and HexBytes accepts any length and pads odd input — so one
+// malformed value would lock the voter out of the election permanently. Single choke point for
+// both the single-sign parseAddress and the batch validation pass: this is exactly the invariant
+// that must not drift between them.
+func validateVoterAddress(address internal.HexBytes) *errors.Error {
+	if len(address) != common.AddressLength {
+		return errors.Ptr(errors.ErrMalformedBody.Withf(
+			"address is %d bytes, expected %d", len(address), common.AddressLength))
+	}
+	return nil
+}
+
+// parseAddress parses and validates the voter address from the payload.
 func parseAddress(w http.ResponseWriter, payload string) (*internal.HexBytes, bool) {
 	address := new(internal.HexBytes)
 	if err := address.ParseString(payload); err != nil {
 		errors.ErrMalformedBody.WithErr(err).Write(w)
 		return nil, false
 	}
-	if len(*address) != common.AddressLength {
-		errors.ErrMalformedBody.Withf("address is %d bytes, expected %d", len(*address), common.AddressLength).Write(w)
+	if sErr := validateVoterAddress(*address); sErr != nil {
+		sErr.Write(w)
 		return nil, false
 	}
 	return address, true
 }
 
-// signAndRespond signs the request and sends the response
+// signAndRespond signs the request and sends the response. A failure is mapped through
+// signOutcome so the public body carries the sanitized message, not the raw signer error
+// (csp.Sign joins internal detail into it), which stays in the log: authorization outcomes
+// are 401, internal failures 500.
 func (c *CSPHandlers) signAndRespond(w http.ResponseWriter, authToken, address, processID, weight internal.HexBytes) {
 	log.Debugw("new CSP sign request", "address", address, "procId", processID, "weight", weight)
 
 	signature, err := c.csp.Sign(authToken, address, processID, weight, signers.SignerTypeECDSASalted)
 	if err != nil {
-		errors.ErrUnauthorized.WithErr(err).Write(w)
+		code, message := signOutcome(err)
+		if code == signCodeFailed {
+			log.Warnw("could not sign", "procId", processID, "error", err)
+			errors.ErrGenericInternalServerError.With(message).Write(w)
+			return
+		}
+		log.Debugw("sign rejected", "procId", processID, "reason", err)
+		errors.ErrUnauthorized.With(message).Write(w)
 		return
 	}
 

--- a/csp/handlers/handlers.go
+++ b/csp/handlers/handlers.go
@@ -324,6 +324,13 @@ func findProcessInBundle(bundle *db.ProcessesBundle, processID internal.HexBytes
 	return nil, false
 }
 
+// weightBytes encodes a voter weight as the minimal big-endian bytes carried in a CA bundle
+// and returned to voters. SetUint64 rather than big.NewInt(int64(w)): db.OrgMember.Weight is a
+// uint64, and the signed conversion would wrap to a negative value above 2^63.
+func weightBytes(w uint64) internal.HexBytes {
+	return new(big.Int).SetUint64(w).Bytes()
+}
+
 // parseAddress parses the address from the payload
 func parseAddress(w http.ResponseWriter, payload string) (*internal.HexBytes, bool) {
 	address := new(internal.HexBytes)
@@ -438,7 +445,7 @@ func (c *CSPHandlers) BundleSignHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	// Sign the request and send the response
-	c.signAndRespond(w, req.AuthToken, *address, processID, big.NewInt(int64(weight)).Bytes())
+	c.signAndRespond(w, req.AuthToken, *address, processID, weightBytes(weight))
 }
 
 // UserWeightHandler godoc
@@ -513,7 +520,7 @@ func (c *CSPHandlers) UserWeightHandler(w http.ResponseWriter, r *http.Request) 
 
 	// return the user weight for the bundle
 	apicommon.HTTPWriteJSON(w, &UserWeightResponse{
-		Weight: internal.HexBytes(big.NewInt(int64(weight)).Bytes()),
+		Weight: weightBytes(weight),
 	})
 }
 
@@ -629,7 +636,7 @@ func (c *CSPHandlers) BundleCheckHandler(w http.ResponseWriter, r *http.Request)
 
 	apicommon.HTTPWriteJSON(w, &CheckMembershipResponse{
 		Belongs:  true,
-		Weight:   internal.HexBytes(big.NewInt(int64(weight)).Bytes()),
+		Weight:   weightBytes(weight),
 		HasVoted: hasVoted,
 	})
 }

--- a/csp/handlers/handlers.go
+++ b/csp/handlers/handlers.go
@@ -331,11 +331,18 @@ func weightBytes(w uint64) internal.HexBytes {
 	return new(big.Int).SetUint64(w).Bytes()
 }
 
-// parseAddress parses the address from the payload
+// parseAddress parses the address from the payload. The address is signed into the CA bundle and
+// pinned as the election's consumer, after which a different address is rejected forever, so it
+// must be a full 20-byte Ethereum address — HexBytes would otherwise accept any length and pad
+// odd input, locking the voter out of the election with one bad value.
 func parseAddress(w http.ResponseWriter, payload string) (*internal.HexBytes, bool) {
 	address := new(internal.HexBytes)
 	if err := address.ParseString(payload); err != nil {
 		errors.ErrMalformedBody.WithErr(err).Write(w)
+		return nil, false
+	}
+	if len(*address) != common.AddressLength {
+		errors.ErrMalformedBody.Withf("address is %d bytes, expected %d", len(*address), common.AddressLength).Write(w)
 		return nil, false
 	}
 	return address, true

--- a/csp/handlers/handlers_test.go
+++ b/csp/handlers/handlers_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	stderrors "errors"
 	"fmt"
 	"testing"
 	"time"
@@ -27,8 +28,12 @@ func TestSignOutcome(t *testing.T) {
 		{csp.ErrUserAlreadySigning, signCodeAlreadySigning},
 		{csp.ErrInvalidAuthToken, signCodeAuthInvalid},
 		{csp.ErrAuthTokenNotVerified, signCodeAuthInvalid},
+		{csp.ErrAddressMismatch, signCodeAddressMismatch},
 		{fmt.Errorf("wrapping: %w", csp.ErrProcessAlreadyConsumed), signCodeAlreadyConsumed},
 		{csp.ErrSign, signCodeFailed},
+		// the shape csp.Sign returns for a storage failure: joined, NOT an auth verdict, so a
+		// transient Mongo error stays a retryable per-ballot outcome instead of aborting the batch
+		{stderrors.Join(csp.ErrSign, fmt.Errorf("some storage blip")), signCodeFailed},
 		{fmt.Errorf("some storage blip"), signCodeFailed},
 	} {
 		code, message := signOutcome(tc.err)

--- a/csp/handlers/handlers_test.go
+++ b/csp/handlers/handlers_test.go
@@ -1,15 +1,53 @@
 package handlers
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	qt "github.com/frankban/quicktest"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/vocdoni/saas-backend/csp"
 	"github.com/vocdoni/saas-backend/csp/notifications"
 	"github.com/vocdoni/saas-backend/db"
+	"github.com/vocdoni/saas-backend/errors"
+	"github.com/vocdoni/saas-backend/internal"
 )
+
+func TestSignOutcome(t *testing.T) {
+	c := qt.New(t)
+	// each known sentinel maps to its stable code — including wrapped, the form csp.Sign
+	// actually returns for signer failures — and everything else to the retryable catch-all.
+	for _, tc := range []struct {
+		err  error
+		code string
+	}{
+		{csp.ErrProcessAlreadyConsumed, signCodeAlreadyConsumed},
+		{csp.ErrUserAlreadySigning, signCodeAlreadySigning},
+		{csp.ErrInvalidAuthToken, signCodeAuthInvalid},
+		{csp.ErrAuthTokenNotVerified, signCodeAuthInvalid},
+		{fmt.Errorf("wrapping: %w", csp.ErrProcessAlreadyConsumed), signCodeAlreadyConsumed},
+		{csp.ErrSign, signCodeFailed},
+		{fmt.Errorf("some storage blip"), signCodeFailed},
+	} {
+		code, message := signOutcome(tc.err)
+		c.Assert(code, qt.Equals, tc.code, qt.Commentf("error: %v", tc.err))
+		c.Assert(message, qt.Not(qt.Equals), "")
+		// the sanitized message must not echo the raw error text
+		c.Assert(message, qt.Not(qt.Contains), "blip")
+	}
+}
+
+func TestValidateVoterAddress(t *testing.T) {
+	c := qt.New(t)
+	// qt.IsNil rejects a typed-nil *errors.Error (it implements error), so compare the pointer.
+	c.Assert(validateVoterAddress(internal.HexBytes(make([]byte, common.AddressLength))),
+		qt.Equals, (*errors.Error)(nil))
+	c.Assert(validateVoterAddress(nil), qt.Not(qt.IsNil))
+	c.Assert(validateVoterAddress(internal.HexBytes(make([]byte, common.AddressLength-1))), qt.Not(qt.IsNil))
+	c.Assert(validateVoterAddress(internal.HexBytes(make([]byte, common.AddressLength+1))), qt.Not(qt.IsNil))
+}
 
 func TestHandlePhoneContact(t *testing.T) {
 	c := qt.New(t)

--- a/csp/handlers/processes.go
+++ b/csp/handlers/processes.go
@@ -11,12 +11,17 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/csp"
+	"github.com/vocdoni/saas-backend/csp/signers"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
 	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.vocdoni.io/dvote/log"
 	"go.vocdoni.io/dvote/vochain/state"
 )
+
+// apiErr lifts an API error to a pointer, so a helper can signal "no error" with nil.
+func apiErr(e errors.Error) *errors.Error { return &e }
 
 // parseProcessID parses the {processId} URL param (a voting-process Mongo ObjectID) and
 // returns both the ObjectID and its bytes, which are used as the CSP token anchor.
@@ -196,11 +201,7 @@ func (c *CSPHandlers) ProcessAuthResendHandler(w http.ResponseWriter, r *http.Re
 //	@Failure		500			{object}	errors.Error	"Internal server error"
 //	@Router			/processes/{processId}/sign [post]
 func (c *CSPHandlers) ProcessSignHandler(w http.ResponseWriter, r *http.Request) {
-	oid, anchor, ok := parseProcessID(w, r)
-	if !ok {
-		return
-	}
-	vp, ok := c.getVotingProcess(w, oid)
+	oid, _, ok := parseProcessID(w, r)
 	if !ok {
 		return
 	}
@@ -208,56 +209,233 @@ func (c *CSPHandlers) ProcessSignHandler(w http.ResponseWriter, r *http.Request)
 	if !ok {
 		return
 	}
-	auth, ok := c.getAuthInfo(w, req.AuthToken)
+	sc, ok := c.resolveSignContext(w, oid, req.AuthToken)
 	if !ok {
 		return
 	}
-	if !auth.Verified {
-		errors.ErrUnauthorized.WithErr(csp.ErrAuthTokenNotVerified).Write(w)
+	upstreamID, sErr := c.authorizeQuestion(sc, req.ProcessID)
+	if sErr != nil {
+		sErr.Write(w)
 		return
-	}
-	if !bytes.Equal(anchor, auth.BundleID) {
-		errors.ErrUnauthorized.Withf("token does not belong to the process").Write(w)
-		return
-	}
-	// resolve the target question by its on-chain election id and verify it belongs to
-	// this process
-	question, err := c.mainDB.QuestionByUpstreamID(req.ProcessID)
-	if err != nil && err != db.ErrNotFound {
-		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
-		return
-	}
-	if err != nil || question.ProcessID != oid {
-		errors.ErrUnauthorized.Withf("election not found in process").Write(w)
-		return
-	}
-	// authorize the member against the question's eligibility subset
-	if !memberEligibleForQuestion(question, auth.UserID.String()) {
-		errors.ErrUnauthorized.Withf("member not eligible for this question").Write(w)
-		return
-	}
-	member, ok := c.orgMemberFromAuth(w, vp.OrgAddress, auth)
-	if !ok {
-		return
-	}
-	census, err := c.mainDB.Census(vp.CensusID.Hex())
-	if err != nil {
-		errors.ErrCensusNotFound.WithErr(err).Write(w)
-		return
-	}
-	weight := uint64(1)
-	if census.Weighted {
-		if member.Weight == 0 {
-			errors.ErrZeroWeightVoter.Write(w)
-			return
-		}
-		weight = member.Weight
 	}
 	address, ok := parseAddress(w, req.Payload)
 	if !ok {
 		return
 	}
-	c.signAndRespond(w, req.AuthToken, *address, question.UpstreamID, big.NewInt(int64(weight)).Bytes())
+	c.signAndRespond(w, req.AuthToken, *address, upstreamID, sc.weight)
+}
+
+// signContext is the part of a ballot signing request that is resolved once per call, from
+// the process named in the path and the auth token in the body: the voting process, the
+// member behind the token and their census weight. A batch signs every ballot under one of
+// these, which is the whole point of the batch endpoint.
+type signContext struct {
+	process  *db.VotingProcess
+	memberID string
+	weight   internal.HexBytes
+}
+
+// resolveSignContext runs the per-request half of a ballot signing request: load the voting
+// process, check the auth token is verified and anchored to it, resolve the org member behind
+// it and compute their census weight. It writes the proper error and returns false on failure.
+func (c *CSPHandlers) resolveSignContext(
+	w http.ResponseWriter, oid primitive.ObjectID, authToken internal.HexBytes,
+) (*signContext, bool) {
+	vp, ok := c.getVotingProcess(w, oid)
+	if !ok {
+		return nil, false
+	}
+	auth, ok := c.getAuthInfo(w, authToken)
+	if !ok {
+		return nil, false
+	}
+	if !auth.Verified {
+		errors.ErrUnauthorized.WithErr(csp.ErrAuthTokenNotVerified).Write(w)
+		return nil, false
+	}
+	if !bytes.Equal(oid[:], auth.BundleID) {
+		errors.ErrUnauthorized.Withf("token does not belong to the process").Write(w)
+		return nil, false
+	}
+	member, ok := c.orgMemberFromAuth(w, vp.OrgAddress, auth)
+	if !ok {
+		return nil, false
+	}
+	census, err := c.mainDB.Census(vp.CensusID.Hex())
+	if err != nil {
+		errors.ErrCensusNotFound.WithErr(err).Write(w)
+		return nil, false
+	}
+	weight := uint64(1)
+	if census.Weighted {
+		if member.Weight == 0 {
+			errors.ErrZeroWeightVoter.Write(w)
+			return nil, false
+		}
+		weight = member.Weight
+	}
+	return &signContext{
+		process:  vp,
+		memberID: auth.UserID.String(),
+		weight:   big.NewInt(int64(weight)).Bytes(),
+	}, true
+}
+
+// authorizeQuestion runs the per-ballot half of a signing request: resolve the target question
+// by its on-chain election id, verify it belongs to this process and authorize the member
+// against the question's eligibility subset. It returns the question's on-chain election id, or
+// the API error to write back, never both.
+func (c *CSPHandlers) authorizeQuestion(
+	sc *signContext, electionID internal.HexBytes,
+) (internal.HexBytes, *errors.Error) {
+	question, err := c.mainDB.QuestionByUpstreamID(electionID)
+	if err != nil && err != db.ErrNotFound {
+		return nil, apiErr(errors.ErrGenericInternalServerError.WithErr(err))
+	}
+	if err != nil || question.ProcessID != sc.process.ID {
+		return nil, apiErr(errors.ErrUnauthorized.Withf("election not found in process"))
+	}
+	if !memberEligibleForQuestion(question, sc.memberID) {
+		return nil, apiErr(errors.ErrUnauthorized.Withf("member not eligible for this question"))
+	}
+	return question.UpstreamID, nil
+}
+
+// maxSignBatchBodyBytes bounds a POST /processes/{processId}/sign-batch body. One ballot is an
+// election id plus a voter address, ~200 characters of JSON once hex-encoded and quoted, so 512
+// bytes each leaves ample headroom; a process holds at most 100 questions, and a voter at most
+// one ballot per question. Like the relay endpoints this one is public, so the body has to be
+// bounded before it is buffered.
+const maxSignBatchBodyBytes = 100*512 + 4<<10
+
+// ballot is one validated item of a sign batch: the on-chain election to sign for and the
+// voter address to sign, both resolved during the validation pass.
+type ballot struct {
+	upstreamID internal.HexBytes
+	address    internal.HexBytes
+}
+
+// ProcessSignBatchHandler godoc
+//
+//	@Summary		Sign every question's ballot of a voting process in one call
+//	@Description	Batch form of POST /processes/{processId}/sign. A multi-question voting process is
+//	@Description	one on-chain election per question, so a voter holds one ballot per question and
+//	@Description	signing them one by one costs a round trip each. This signs them all under a single
+//	@Description	verified auth token. Public endpoint: the token authenticates the voter.
+//	@Description	The batch is authorized as a unit and signs nothing on failure — every ballot must
+//	@Description	name an election of this process (else 401) the member is eligible for (else 401),
+//	@Description	carry a parseable voter address (else 400), and no election may be repeated (else
+//	@Description	400). Once authorized, every ballot is signed and the response carries one entry per
+//	@Description	request item, in order: a signature and weight, or the reason that election could not
+//	@Description	be signed (its signing slot is spent, or a concurrent request holds it). Signing
+//	@Description	consumes a per-election slot that cannot be given back, so a failed entry is retried
+//	@Description	by calling again, not rolled back.
+//	@Tags			processes
+//	@Accept			json
+//	@Produce		json
+//	@Param			processId	path		string						true	"Process ID"
+//	@Param			request		body		handlers.SignBatchRequest	true	"Auth token and one ballot per question"
+//	@Success		200			{object}	handlers.SignBatchResponse
+//	@Failure		400			{object}	errors.Error	"Invalid input data"
+//	@Failure		401			{object}	errors.Error	"Unauthorized, unverified token, election not in process, or member not eligible"
+//	@Failure		404			{object}	errors.Error	"Process, census, or user not found"
+//	@Failure		413			{object}	errors.Error	"Request body too large"
+//	@Failure		500			{object}	errors.Error	"Internal server error"
+//	@Router			/processes/{processId}/sign-batch [post]
+//
+//nolint:lll
+func (c *CSPHandlers) ProcessSignBatchHandler(w http.ResponseWriter, r *http.Request) {
+	oid, _, ok := parseProcessID(w, r)
+	if !ok {
+		return
+	}
+	req, ok := parseSignBatchRequest(w, r)
+	if !ok {
+		return
+	}
+	sc, ok := c.resolveSignContext(w, oid, req.AuthToken)
+	if !ok {
+		return
+	}
+	switch {
+	case len(req.Signatures) == 0:
+		errors.ErrVoteBatchEmpty.Write(w)
+		return
+	case len(req.Signatures) > len(sc.process.QuestionIDs):
+		// a voter holds at most one ballot per question, so the process itself is the cap.
+		errors.ErrVoteBatchTooLarge.Withf("%d ballots, the process has %d questions",
+			len(req.Signatures), len(sc.process.QuestionIDs)).Write(w)
+		return
+	}
+
+	// authorize the whole batch before signing anything: signing consumes a per-election slot
+	// that cannot be given back, so a rejected batch must leave the voter with nothing signed
+	// rather than with a signed prefix.
+	ballots := make([]ballot, len(req.Signatures))
+	seen := make(map[string]int, len(req.Signatures))
+	for i, item := range req.Signatures {
+		// a repeated election would contend with itself on the per-(user, election) signer
+		// lock, and a voter has at most one ballot per question anyway.
+		if first, dup := seen[string(item.ProcessID)]; dup {
+			errors.ErrMalformedBody.Withf(
+				"the ballot at index %d repeats the election of index %d", i, first).Write(w)
+			return
+		}
+		seen[string(item.ProcessID)] = i
+		upstreamID, sErr := c.authorizeQuestion(sc, item.ProcessID)
+		if sErr != nil {
+			sErr.Withf("at index %d", i).Write(w)
+			return
+		}
+		address := new(internal.HexBytes)
+		if err := address.ParseString(item.Payload); err != nil {
+			errors.ErrMalformedBody.WithErr(err).Withf("at index %d", i).Write(w)
+			return
+		}
+		ballots[i] = ballot{upstreamID: upstreamID, address: *address}
+	}
+
+	// ponytail: signed sequentially. db.ConsumeCSPProcess takes the storage write lock, so a
+	// parallel fan-out inside one request would serialize on it anyway; revisit only if that
+	// lock stops being the bottleneck.
+	resp := &SignBatchResponse{Signatures: make([]SignBatchResult, len(ballots))}
+	for i, b := range ballots {
+		res := &resp.Signatures[i]
+		res.ProcessID = b.upstreamID
+		signature, err := c.csp.Sign(req.AuthToken, b.address, b.upstreamID, sc.weight,
+			signers.SignerTypeECDSASalted)
+		if err != nil {
+			// per-ballot by nature: this election's signing slot is spent, or a concurrent
+			// request holds its lock. The batch's siblings are unaffected.
+			log.Warnw("could not sign a batch ballot", "procId", b.upstreamID, "error", err)
+			res.Error = err.Error()
+			continue
+		}
+		res.Signature = signature
+		res.Weight = sc.weight
+	}
+	apicommon.HTTPWriteJSON(w, resp)
+}
+
+// parseSignBatchRequest decodes a capped sign-batch body and checks it carries an auth token,
+// writing the proper error and returning false on failure.
+func parseSignBatchRequest(w http.ResponseWriter, r *http.Request) (*SignBatchRequest, bool) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxSignBatchBodyBytes)
+	var req SignBatchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			errors.ErrRequestBodyTooLarge.Withf("the limit is %d bytes", maxSignBatchBodyBytes).Write(w)
+			return nil, false
+		}
+		errors.ErrMalformedBody.Write(w)
+		return nil, false
+	}
+	if req.AuthToken == nil {
+		errors.ErrUnauthorized.Withf("missing auth token").Write(w)
+		return nil, false
+	}
+	return &req, true
 }
 
 // ProcessWeightHandler godoc

--- a/csp/handlers/processes.go
+++ b/csp/handlers/processes.go
@@ -19,11 +19,6 @@ import (
 	"go.vocdoni.io/dvote/vochain/state"
 )
 
-// apiErr lifts an API error to a pointer, so a helper can signal "no error" with nil. Named
-// asErr (not apiErr) because handlers.go has several `apiErr, ok := err.(errors.Error)` locals
-// that would shadow a same-named helper.
-func asErr(e errors.Error) *errors.Error { return &e }
-
 // parseProcessID parses the {processId} URL param (a voting-process Mongo ObjectID) and
 // returns both the ObjectID and its bytes, which are used as the CSP token anchor.
 func parseProcessID(w http.ResponseWriter, r *http.Request) (primitive.ObjectID, internal.HexBytes, bool) {
@@ -285,7 +280,8 @@ func (c *CSPHandlers) resolveSignContext(
 // authorizeQuestion runs the per-ballot half of a signing request: resolve the target question
 // by its on-chain election id, verify it belongs to this process and authorize the member
 // against the question's eligibility subset. It returns the question's on-chain election id, or
-// the API error to write back, never both.
+// the API error to write back, never both. The batch handler resolves against a preloaded map
+// instead (authorizeLoadedQuestion) to avoid one query per ballot.
 func (c *CSPHandlers) authorizeQuestion(
 	sc *signContext, electionID internal.HexBytes,
 ) (internal.HexBytes, *errors.Error) {
@@ -293,17 +289,30 @@ func (c *CSPHandlers) authorizeQuestion(
 	// ErrInvalidData, which the branch below would surface to the client as a 500. The message is
 	// field-neutral because the single-sign endpoint sends this same id as "electionId".
 	if len(electionID) == 0 {
-		return nil, asErr(errors.ErrMalformedBody.With("missing election id"))
+		return nil, errors.Ptr(errors.ErrMalformedBody.With("missing election id"))
 	}
 	question, err := c.mainDB.QuestionByUpstreamID(electionID)
 	if err != nil && !errors.Is(err, db.ErrNotFound) {
-		return nil, asErr(errors.ErrGenericInternalServerError.WithErr(err))
+		return nil, errors.Ptr(errors.ErrGenericInternalServerError.WithErr(err))
 	}
-	if err != nil || question.ProcessID != sc.process.ID {
-		return nil, asErr(errors.ErrUnauthorized.Withf("election not found in process"))
+	if err != nil {
+		question = nil // not found: authorizeLoadedQuestion folds it into the same 401
+	}
+	return authorizeLoadedQuestion(sc, question)
+}
+
+// authorizeLoadedQuestion authorizes one already-loaded question (nil means the election id
+// resolved to nothing): it must belong to this process and the member must be in its
+// eligibility subset. Not-found and wrong-process collapse into the same 401 on purpose — a
+// caller learns nothing about elections outside the process it is signing for.
+func authorizeLoadedQuestion(
+	sc *signContext, question *db.VotingProcessQuestion,
+) (internal.HexBytes, *errors.Error) {
+	if question == nil || question.ProcessID != sc.process.ID {
+		return nil, errors.Ptr(errors.ErrUnauthorized.Withf("election not found in process"))
 	}
 	if !memberEligibleForQuestion(question, sc.memberID) {
-		return nil, asErr(errors.ErrUnauthorized.Withf("member not eligible for this question"))
+		return nil, errors.Ptr(errors.ErrUnauthorized.Withf("member not eligible for this question"))
 	}
 	return question.UpstreamID, nil
 }
@@ -339,10 +348,14 @@ type authorizedBallot struct {
 //	@Description	Once authorized, every ballot is signed and the response is always 200 with one
 //	@Description	entry per request item, in order — even if every ballot fails (the request was
 //	@Description	honored; the outcome is per item). Each entry carries a signature and weight, or a
-//	@Description	stable machine-readable code plus a message. Retry ONLY the entries that carry a
-//	@Description	code: re-sending the whole batch re-signs the ballots that already succeeded, and
-//	@Description	each re-sign counts toward the election's finite overwrite budget
-//	@Description	(MaxVoteOverwritesPerProcess, 10) — past it the election is permanently locked.
+//	@Description	stable machine-readable code plus a message: already_consumed (that election's
+//	@Description	signing slot is spent; not retryable), already_signing (a concurrent request holds
+//	@Description	it; retry), auth_invalid (the token was invalidated mid-batch and every remaining
+//	@Description	entry is stamped with it; authenticate again) or sign_failed (internal failure;
+//	@Description	retry). Retry ONLY the entries that carry a retryable code: re-sending the whole
+//	@Description	batch re-signs the ballots that already succeeded, and each re-sign counts toward
+//	@Description	the election's finite overwrite budget (MaxVoteOverwritesPerProcess, 10) — past it
+//	@Description	the election is permanently locked.
 //	@Tags			processes
 //	@Accept			json
 //	@Produce		json
@@ -385,7 +398,19 @@ func (c *CSPHandlers) ProcessSignBatchHandler(w http.ResponseWriter, r *http.Req
 
 	// authorize the whole batch before signing anything: signing consumes a per-election slot
 	// that cannot be given back, so a rejected batch must leave the voter with nothing signed
-	// rather than with a signed prefix.
+	// rather than with a signed prefix. Every ballot must name a question of this process, so
+	// all of them are loaded in one query and each ballot resolved against the map — a
+	// per-ballot QuestionByUpstreamID would cost up to db.MaxQuestionsPerProcess sequential
+	// round trips on a public endpoint.
+	questions, err := c.mainDB.QuestionsByProcess(oid)
+	if err != nil {
+		errors.ErrGenericInternalServerError.WithErr(err).Write(w)
+		return
+	}
+	byUpstream := make(map[string]*db.VotingProcessQuestion, len(questions))
+	for i := range questions {
+		byUpstream[string(questions[i].UpstreamID)] = &questions[i]
+	}
 	ballots := make([]authorizedBallot, len(req.Ballots))
 	seen := make(map[string]int, len(req.Ballots))
 	for i, item := range req.Ballots {
@@ -398,19 +423,19 @@ func (c *CSPHandlers) ProcessSignBatchHandler(w http.ResponseWriter, r *http.Req
 			return
 		}
 		seen[string(item.UpstreamID)] = i
-		upstreamID, sErr := c.authorizeQuestion(sc, item.UpstreamID)
+		// an empty id cannot name an election; checked before the map so it gets its 400
+		// rather than the map-miss 401.
+		if len(item.UpstreamID) == 0 {
+			errors.ErrMalformedBody.With("missing election id").Withf("at index %d", i).Write(w)
+			return
+		}
+		upstreamID, sErr := authorizeLoadedQuestion(sc, byUpstream[string(item.UpstreamID)])
 		if sErr != nil {
 			sErr.Withf("at index %d", i).Write(w)
 			return
 		}
-		// the address is signed into the CA bundle and pinned as the election's consumer, after
-		// which a different address is rejected forever — so validate its length here. HexBytes
-		// accepts any length and pads odd input, which is exactly the silent corruption to stop.
-		if len(item.Address) != common.AddressLength {
-			errors.ErrMalformedBody.Withf(
-				"the ballot at index %d has an address of %d bytes, expected %d",
-				i, len(item.Address), common.AddressLength,
-			).Write(w)
+		if sErr := validateVoterAddress(item.Address); sErr != nil {
+			sErr.Withf("at index %d", i).Write(w)
 			return
 		}
 		ballots[i] = authorizedBallot{upstreamID: upstreamID, address: item.Address}
@@ -426,11 +451,21 @@ func (c *CSPHandlers) ProcessSignBatchHandler(w http.ResponseWriter, r *http.Req
 		signature, err := c.csp.Sign(req.AuthToken, b.address, b.upstreamID, sc.weight,
 			signers.SignerTypeECDSASalted)
 		if err != nil {
-			// per-ballot by nature: this election's signing slot is spent, or a concurrent
+			// usually per-ballot: this election's signing slot is spent, or a concurrent
 			// request holds its lock. Map it to a stable code + sanitized message for the
 			// response; the raw error stays in the log.
 			res.Code, res.Error = signOutcome(err)
 			logSignFailure(oid, sc.memberID, b.upstreamID, err)
+			// an invalid token dooms every remaining ballot too (the token was valid when
+			// resolveSignContext ran, so it was deleted or unverified mid-batch): stamp the
+			// rest with the same outcome instead of issuing one doomed Sign each.
+			if res.Code == signCodeAuthInvalid {
+				for j := i + 1; j < len(ballots); j++ {
+					resp.Signatures[j].UpstreamID = ballots[j].upstreamID
+					resp.Signatures[j].Code, resp.Signatures[j].Error = res.Code, res.Error
+				}
+				break
+			}
 			continue
 		}
 		res.Signature = signature
@@ -439,17 +474,32 @@ func (c *CSPHandlers) ProcessSignBatchHandler(w http.ResponseWriter, r *http.Req
 	apicommon.HTTPWriteJSON(w, resp)
 }
 
-// signOutcome maps a per-ballot signing error to a stable, machine-readable code and a message
-// safe for the public response body. The raw error (which for signer failures is
-// errors.Join(ErrSign, <internal detail>)) is kept out of the response and logged instead.
+// Stable, machine-readable outcomes of a failed csp.Sign, as returned by signOutcome.
+const (
+	// signCodeAlreadyConsumed: the election's signing slot is spent; retrying cannot succeed.
+	signCodeAlreadyConsumed = "already_consumed"
+	// signCodeAlreadySigning: a concurrent request holds this election's signing lock; retry.
+	signCodeAlreadySigning = "already_signing"
+	// signCodeAuthInvalid: the auth token is gone or no longer verified; the voter must
+	// authenticate again — retrying with the same token cannot succeed, for ANY ballot.
+	signCodeAuthInvalid = "auth_invalid"
+	// signCodeFailed: an internal signer or storage failure; retrying may succeed.
+	signCodeFailed = "sign_failed"
+)
+
+// signOutcome maps a signing error to a stable, machine-readable code and a message safe for
+// the public response body. The raw error (which for signer failures is errors.Join(ErrSign,
+// <internal detail>)) is kept out of the response and logged instead.
 func signOutcome(err error) (code, message string) {
 	switch {
 	case errors.Is(err, csp.ErrProcessAlreadyConsumed):
-		return "already_consumed", "this election's signing slot is already consumed"
+		return signCodeAlreadyConsumed, "this election's signing slot is already consumed"
 	case errors.Is(err, csp.ErrUserAlreadySigning):
-		return "already_signing", "a concurrent request is signing this election"
+		return signCodeAlreadySigning, "a concurrent request is signing this election"
+	case errors.Is(err, csp.ErrInvalidAuthToken), errors.Is(err, csp.ErrAuthTokenNotVerified):
+		return signCodeAuthInvalid, "the auth token is no longer valid; authenticate again"
 	default:
-		return "sign_failed", "could not sign the ballot"
+		return signCodeFailed, "could not sign the ballot"
 	}
 }
 

--- a/csp/handlers/processes.go
+++ b/csp/handlers/processes.go
@@ -19,8 +19,10 @@ import (
 	"go.vocdoni.io/dvote/vochain/state"
 )
 
-// apiErr lifts an API error to a pointer, so a helper can signal "no error" with nil.
-func apiErr(e errors.Error) *errors.Error { return &e }
+// apiErr lifts an API error to a pointer, so a helper can signal "no error" with nil. Named
+// asErr (not apiErr) because handlers.go has several `apiErr, ok := err.(errors.Error)` locals
+// that would shadow a same-named helper.
+func asErr(e errors.Error) *errors.Error { return &e }
 
 // parseProcessID parses the {processId} URL param (a voting-process Mongo ObjectID) and
 // returns both the ObjectID and its bytes, which are used as the CSP token anchor.
@@ -288,29 +290,30 @@ func (c *CSPHandlers) authorizeQuestion(
 	sc *signContext, electionID internal.HexBytes,
 ) (internal.HexBytes, *errors.Error) {
 	// an empty id cannot name an election, and db.QuestionByUpstreamID reports it as
-	// ErrInvalidData, which the branch below would surface to the client as a 500.
+	// ErrInvalidData, which the branch below would surface to the client as a 500. The message is
+	// field-neutral because the single-sign endpoint sends this same id as "electionId".
 	if len(electionID) == 0 {
-		return nil, apiErr(errors.ErrMalformedBody.With("missing upstreamId"))
+		return nil, asErr(errors.ErrMalformedBody.With("missing election id"))
 	}
 	question, err := c.mainDB.QuestionByUpstreamID(electionID)
-	if err != nil && err != db.ErrNotFound {
-		return nil, apiErr(errors.ErrGenericInternalServerError.WithErr(err))
+	if err != nil && !errors.Is(err, db.ErrNotFound) {
+		return nil, asErr(errors.ErrGenericInternalServerError.WithErr(err))
 	}
 	if err != nil || question.ProcessID != sc.process.ID {
-		return nil, apiErr(errors.ErrUnauthorized.Withf("election not found in process"))
+		return nil, asErr(errors.ErrUnauthorized.Withf("election not found in process"))
 	}
 	if !memberEligibleForQuestion(question, sc.memberID) {
-		return nil, apiErr(errors.ErrUnauthorized.Withf("member not eligible for this question"))
+		return nil, asErr(errors.ErrUnauthorized.Withf("member not eligible for this question"))
 	}
 	return question.UpstreamID, nil
 }
 
 // maxSignBatchBodyBytes bounds a POST /processes/{processId}/sign-batch body. One ballot is an
 // election id plus a voter address, ~200 characters of JSON once hex-encoded and quoted, so 512
-// bytes each leaves ample headroom; a process holds at most 100 questions, and a voter at most
-// one ballot per question. Like the relay endpoints this one is public, so the body has to be
-// bounded before it is buffered.
-const maxSignBatchBodyBytes = 100*512 + 4<<10
+// bytes each leaves ample headroom. The cap tracks db.MaxQuestionsPerProcess (a voter holds at
+// most one ballot per question); like the relay endpoints this one is public, so the body has to
+// be bounded before it is buffered.
+const maxSignBatchBodyBytes = db.MaxQuestionsPerProcess*512 + 4<<10
 
 // authorizedBallot is one item of a sign batch that survived the authorization pass: the
 // question's on-chain election id, resolved from the request, and the voter address.
@@ -330,12 +333,16 @@ type authorizedBallot struct {
 //	@Description	the check and sign-info endpoints) and the voter address to sign for it.
 //	@Description	The batch is authorized as a unit and signs nothing on failure — every ballot must
 //	@Description	name an election of this process (else 401) the member is eligible for (else 401),
-//	@Description	carry a voter address (else 400), and no election may be repeated (else 400). Once
-//	@Description	authorized, every ballot is signed and the response carries one entry per request
-//	@Description	item, in order: a signature and weight, or the reason that election could not be
-//	@Description	signed (its signing slot is spent, or a concurrent request holds it). Signing
-//	@Description	consumes a per-election slot that cannot be given back, so a failed entry is retried
-//	@Description	by calling again, not rolled back.
+//	@Description	carry a 20-byte voter address (else 400), and no election may be repeated (else
+//	@Description	400). Authorization strictly precedes the first signature, so a rejected batch
+//	@Description	consumes nothing.
+//	@Description	Once authorized, every ballot is signed and the response is always 200 with one
+//	@Description	entry per request item, in order — even if every ballot fails (the request was
+//	@Description	honored; the outcome is per item). Each entry carries a signature and weight, or a
+//	@Description	stable machine-readable code plus a message. Retry ONLY the entries that carry a
+//	@Description	code: re-sending the whole batch re-signs the ballots that already succeeded, and
+//	@Description	each re-sign counts toward the election's finite overwrite budget
+//	@Description	(MaxVoteOverwritesPerProcess, 10) — past it the election is permanently locked.
 //	@Tags			processes
 //	@Accept			json
 //	@Produce		json
@@ -344,12 +351,10 @@ type authorizedBallot struct {
 //	@Success		200			{object}	handlers.SignBatchResponse
 //	@Failure		400			{object}	errors.Error	"Invalid input data"
 //	@Failure		401			{object}	errors.Error	"Unauthorized, unverified token, election not in process, or member not eligible"
-//	@Failure		404			{object}	errors.Error	"Process, census, or user not found"
+//	@Failure		404			{object}	errors.Error	"Census or user not found"
 //	@Failure		413			{object}	errors.Error	"Request body too large"
 //	@Failure		500			{object}	errors.Error	"Internal server error"
 //	@Router			/processes/{processId}/sign-batch [post]
-//
-//nolint:lll
 func (c *CSPHandlers) ProcessSignBatchHandler(w http.ResponseWriter, r *http.Request) {
 	oid, _, ok := parseProcessID(w, r)
 	if !ok {
@@ -359,18 +364,22 @@ func (c *CSPHandlers) ProcessSignBatchHandler(w http.ResponseWriter, r *http.Req
 	if !ok {
 		return
 	}
-	sc, ok := c.resolveSignContext(w, oid, req.AuthToken)
-	if !ok {
-		return
-	}
+	// the size checks need only the parsed body, so they run before the four DB lookups of
+	// resolveSignContext — an empty or oversized batch never touches the database. The cap is the
+	// shared question limit, not the per-process QuestionIDs count: that field is empty for
+	// processes predating it (see questionSetProblem), which would otherwise make this endpoint
+	// reject every batch for them, including a single ballot.
 	switch {
 	case len(req.Ballots) == 0:
 		errors.ErrVoteBatchEmpty.Write(w)
 		return
-	case len(req.Ballots) > len(sc.process.QuestionIDs):
-		// a voter holds at most one ballot per question, so the process itself is the cap.
-		errors.ErrVoteBatchTooLarge.Withf("%d ballots, the process has %d questions",
-			len(req.Ballots), len(sc.process.QuestionIDs)).Write(w)
+	case len(req.Ballots) > db.MaxQuestionsPerProcess:
+		errors.ErrVoteBatchTooLarge.Withf("%d ballots, the maximum is %d",
+			len(req.Ballots), db.MaxQuestionsPerProcess).Write(w)
+		return
+	}
+	sc, ok := c.resolveSignContext(w, oid, req.AuthToken)
+	if !ok {
 		return
 	}
 
@@ -384,7 +393,8 @@ func (c *CSPHandlers) ProcessSignBatchHandler(w http.ResponseWriter, r *http.Req
 		// lock, and a voter has at most one ballot per question anyway.
 		if first, dup := seen[string(item.UpstreamID)]; dup {
 			errors.ErrMalformedBody.Withf(
-				"the ballot at index %d repeats the election of index %d", i, first).Write(w)
+				"the ballot at index %d repeats the election of index %d", i, first,
+			).Write(w)
 			return
 		}
 		seen[string(item.UpstreamID)] = i
@@ -393,10 +403,14 @@ func (c *CSPHandlers) ProcessSignBatchHandler(w http.ResponseWriter, r *http.Req
 			sErr.Withf("at index %d", i).Write(w)
 			return
 		}
-		// the address is what gets signed into the CA bundle and recorded as the consumer of
-		// the election, so an empty one is rejected here rather than deep in the storage layer.
-		if len(item.Address) == 0 {
-			errors.ErrMalformedBody.Withf("the ballot at index %d has no address", i).Write(w)
+		// the address is signed into the CA bundle and pinned as the election's consumer, after
+		// which a different address is rejected forever — so validate its length here. HexBytes
+		// accepts any length and pads odd input, which is exactly the silent corruption to stop.
+		if len(item.Address) != common.AddressLength {
+			errors.ErrMalformedBody.Withf(
+				"the ballot at index %d has an address of %d bytes, expected %d",
+				i, len(item.Address), common.AddressLength,
+			).Write(w)
 			return
 		}
 		ballots[i] = authorizedBallot{upstreamID: upstreamID, address: item.Address}
@@ -413,9 +427,10 @@ func (c *CSPHandlers) ProcessSignBatchHandler(w http.ResponseWriter, r *http.Req
 			signers.SignerTypeECDSASalted)
 		if err != nil {
 			// per-ballot by nature: this election's signing slot is spent, or a concurrent
-			// request holds its lock. The batch's siblings are unaffected.
-			logSignFailure(b.upstreamID, err)
-			res.Error = err.Error()
+			// request holds its lock. Map it to a stable code + sanitized message for the
+			// response; the raw error stays in the log.
+			res.Code, res.Error = signOutcome(err)
+			logSignFailure(oid, sc.memberID, b.upstreamID, err)
 			continue
 		}
 		res.Signature = signature
@@ -424,30 +439,41 @@ func (c *CSPHandlers) ProcessSignBatchHandler(w http.ResponseWriter, r *http.Req
 	apicommon.HTTPWriteJSON(w, resp)
 }
 
+// signOutcome maps a per-ballot signing error to a stable, machine-readable code and a message
+// safe for the public response body. The raw error (which for signer failures is
+// errors.Join(ErrSign, <internal detail>)) is kept out of the response and logged instead.
+func signOutcome(err error) (code, message string) {
+	switch {
+	case errors.Is(err, csp.ErrProcessAlreadyConsumed):
+		return "already_consumed", "this election's signing slot is already consumed"
+	case errors.Is(err, csp.ErrUserAlreadySigning):
+		return "already_signing", "a concurrent request is signing this election"
+	default:
+		return "sign_failed", "could not sign the ballot"
+	}
+}
+
 // logSignFailure records why one ballot of a batch could not be signed. A spent signing slot and
 // a concurrent request for the same election are the normal outcomes of a voter retrying or of
 // two tabs racing, and the caller is told about them in the response anyway, so they are debug —
-// a warn per occurrence would bury the storage and signer failures that do need attention.
-func logSignFailure(upstreamID internal.HexBytes, err error) {
+// a warn per occurrence would bury the storage and signer failures that do need attention. The
+// member and process ids make a warn attributable during an incident.
+func logSignFailure(oid primitive.ObjectID, memberID string, upstreamID internal.HexBytes, err error) {
 	if errors.Is(err, csp.ErrProcessAlreadyConsumed) || errors.Is(err, csp.ErrUserAlreadySigning) {
-		log.Debugw("skipped a batch ballot", "procId", upstreamID, "reason", err)
+		log.Debugw("skipped a batch ballot", "procId", oid.Hex(), "member", memberID,
+			"electionId", upstreamID, "reason", err)
 		return
 	}
-	log.Warnw("could not sign a batch ballot", "procId", upstreamID, "error", err)
+	log.Warnw("could not sign a batch ballot", "procId", oid.Hex(), "member", memberID,
+		"electionId", upstreamID, "error", err)
 }
 
 // parseSignBatchRequest decodes a capped sign-batch body and checks it carries an auth token,
 // writing the proper error and returning false on failure.
 func parseSignBatchRequest(w http.ResponseWriter, r *http.Request) (*SignBatchRequest, bool) {
-	r.Body = http.MaxBytesReader(w, r.Body, maxSignBatchBodyBytes)
 	var req SignBatchRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		var tooLarge *http.MaxBytesError
-		if errors.As(err, &tooLarge) {
-			errors.ErrRequestBodyTooLarge.Withf("the limit is %d bytes", maxSignBatchBodyBytes).Write(w)
-			return nil, false
-		}
-		errors.ErrMalformedBody.Write(w)
+	if apiErr := apicommon.DecodeCappedJSON(w, r, &req, maxSignBatchBodyBytes); apiErr != nil {
+		apiErr.Write(w)
 		return nil, false
 	}
 	if req.AuthToken == nil {

--- a/csp/handlers/processes.go
+++ b/csp/handlers/processes.go
@@ -308,9 +308,9 @@ func (c *CSPHandlers) authorizeQuestion(
 // bounded before it is buffered.
 const maxSignBatchBodyBytes = 100*512 + 4<<10
 
-// ballot is one validated item of a sign batch: the on-chain election to sign for and the
-// voter address to sign, both resolved during the validation pass.
-type ballot struct {
+// authorizedBallot is one item of a sign batch that survived the authorization pass: the
+// question's on-chain election id, resolved from the request, and the voter address.
+type authorizedBallot struct {
 	upstreamID internal.HexBytes
 	address    internal.HexBytes
 }
@@ -322,12 +322,14 @@ type ballot struct {
 //	@Description	one on-chain election per question, so a voter holds one ballot per question and
 //	@Description	signing them one by one costs a round trip each. This signs them all under a single
 //	@Description	verified auth token. Public endpoint: the token authenticates the voter.
+//	@Description	Each ballot names a question by its on-chain election id (upstreamId, as returned by
+//	@Description	the check and sign-info endpoints) and the voter address to sign for it.
 //	@Description	The batch is authorized as a unit and signs nothing on failure — every ballot must
 //	@Description	name an election of this process (else 401) the member is eligible for (else 401),
-//	@Description	carry a parseable voter address (else 400), and no election may be repeated (else
-//	@Description	400). Once authorized, every ballot is signed and the response carries one entry per
-//	@Description	request item, in order: a signature and weight, or the reason that election could not
-//	@Description	be signed (its signing slot is spent, or a concurrent request holds it). Signing
+//	@Description	carry a voter address (else 400), and no election may be repeated (else 400). Once
+//	@Description	authorized, every ballot is signed and the response carries one entry per request
+//	@Description	item, in order: a signature and weight, or the reason that election could not be
+//	@Description	signed (its signing slot is spent, or a concurrent request holds it). Signing
 //	@Description	consumes a per-election slot that cannot be given back, so a failed entry is retried
 //	@Description	by calling again, not rolled back.
 //	@Tags			processes
@@ -358,41 +360,42 @@ func (c *CSPHandlers) ProcessSignBatchHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 	switch {
-	case len(req.Signatures) == 0:
+	case len(req.Ballots) == 0:
 		errors.ErrVoteBatchEmpty.Write(w)
 		return
-	case len(req.Signatures) > len(sc.process.QuestionIDs):
+	case len(req.Ballots) > len(sc.process.QuestionIDs):
 		// a voter holds at most one ballot per question, so the process itself is the cap.
 		errors.ErrVoteBatchTooLarge.Withf("%d ballots, the process has %d questions",
-			len(req.Signatures), len(sc.process.QuestionIDs)).Write(w)
+			len(req.Ballots), len(sc.process.QuestionIDs)).Write(w)
 		return
 	}
 
 	// authorize the whole batch before signing anything: signing consumes a per-election slot
 	// that cannot be given back, so a rejected batch must leave the voter with nothing signed
 	// rather than with a signed prefix.
-	ballots := make([]ballot, len(req.Signatures))
-	seen := make(map[string]int, len(req.Signatures))
-	for i, item := range req.Signatures {
+	ballots := make([]authorizedBallot, len(req.Ballots))
+	seen := make(map[string]int, len(req.Ballots))
+	for i, item := range req.Ballots {
 		// a repeated election would contend with itself on the per-(user, election) signer
 		// lock, and a voter has at most one ballot per question anyway.
-		if first, dup := seen[string(item.ProcessID)]; dup {
+		if first, dup := seen[string(item.UpstreamID)]; dup {
 			errors.ErrMalformedBody.Withf(
 				"the ballot at index %d repeats the election of index %d", i, first).Write(w)
 			return
 		}
-		seen[string(item.ProcessID)] = i
-		upstreamID, sErr := c.authorizeQuestion(sc, item.ProcessID)
+		seen[string(item.UpstreamID)] = i
+		upstreamID, sErr := c.authorizeQuestion(sc, item.UpstreamID)
 		if sErr != nil {
 			sErr.Withf("at index %d", i).Write(w)
 			return
 		}
-		address := new(internal.HexBytes)
-		if err := address.ParseString(item.Payload); err != nil {
-			errors.ErrMalformedBody.WithErr(err).Withf("at index %d", i).Write(w)
+		// the address is what gets signed into the CA bundle and recorded as the consumer of
+		// the election, so an empty one is rejected here rather than deep in the storage layer.
+		if len(item.Address) == 0 {
+			errors.ErrMalformedBody.Withf("the ballot at index %d has no address", i).Write(w)
 			return
 		}
-		ballots[i] = ballot{upstreamID: upstreamID, address: *address}
+		ballots[i] = authorizedBallot{upstreamID: upstreamID, address: item.Address}
 	}
 
 	// ponytail: signed sequentially. db.ConsumeCSPProcess takes the storage write lock, so a
@@ -401,7 +404,7 @@ func (c *CSPHandlers) ProcessSignBatchHandler(w http.ResponseWriter, r *http.Req
 	resp := &SignBatchResponse{Signatures: make([]SignBatchResult, len(ballots))}
 	for i, b := range ballots {
 		res := &resp.Signatures[i]
-		res.ProcessID = b.upstreamID
+		res.UpstreamID = b.upstreamID
 		signature, err := c.csp.Sign(req.AuthToken, b.address, b.upstreamID, sc.weight,
 			signers.SignerTypeECDSASalted)
 		if err != nil {

--- a/csp/handlers/processes.go
+++ b/csp/handlers/processes.go
@@ -395,11 +395,13 @@ type authorizedBallot struct {
 //	@Description	stable machine-readable code plus a message: already_consumed (that election's
 //	@Description	signing slot is spent; not retryable), already_signing (a concurrent request holds
 //	@Description	it; retry), auth_invalid (the token was invalidated mid-batch and every remaining
-//	@Description	entry is stamped with it; authenticate again) or sign_failed (internal failure;
-//	@Description	retry). Retry ONLY the entries that carry a retryable code: re-sending the whole
-//	@Description	batch re-signs the ballots that already succeeded, and each re-sign counts toward
-//	@Description	the election's finite overwrite budget (MaxVoteOverwritesPerProcess, 10) — past it
-//	@Description	the election is permanently locked.
+//	@Description	entry is stamped with it; authenticate again), address_mismatch (that election was
+//	@Description	already signed for a different address; re-send with the address sign-info
+//	@Description	reports) or sign_failed (internal failure; retry). Retry ONLY the entries that
+//	@Description	carry a retryable code: re-sending the whole batch re-signs the ballots that
+//	@Description	already succeeded, and each re-sign counts toward the election's finite overwrite
+//	@Description	budget (MaxVoteOverwritesPerProcess, 10) — past it the election is permanently
+//	@Description	locked.
 //	@Tags			processes
 //	@Accept			json
 //	@Produce		json
@@ -527,6 +529,9 @@ const (
 	// signCodeAuthInvalid: the auth token is gone or no longer verified; the voter must
 	// authenticate again — retrying with the same token cannot succeed, for ANY ballot.
 	signCodeAuthInvalid = "auth_invalid"
+	// signCodeAddressMismatch: the election was already signed for a different address; the
+	// retry that succeeds re-sends with the pinned address, which sign-info reports.
+	signCodeAddressMismatch = "address_mismatch"
 	// signCodeFailed: an internal signer or storage failure; retrying may succeed.
 	signCodeFailed = "sign_failed"
 )
@@ -542,6 +547,9 @@ func signOutcome(err error) (code, message string) {
 		return signCodeAlreadySigning, "a concurrent request is signing this election"
 	case errors.Is(err, csp.ErrInvalidAuthToken), errors.Is(err, csp.ErrAuthTokenNotVerified):
 		return signCodeAuthInvalid, "the auth token is no longer valid; authenticate again"
+	case errors.Is(err, csp.ErrAddressMismatch):
+		return signCodeAddressMismatch,
+			"this election was already signed for a different address; re-send using the address reported by sign-info"
 	default:
 		return signCodeFailed, "could not sign the ballot"
 	}
@@ -553,7 +561,8 @@ func signOutcome(err error) (code, message string) {
 // a warn per occurrence would bury the storage and signer failures that do need attention. The
 // member and process ids make a warn attributable during an incident.
 func logSignFailure(oid primitive.ObjectID, memberID string, upstreamID internal.HexBytes, err error) {
-	if errors.Is(err, csp.ErrProcessAlreadyConsumed) || errors.Is(err, csp.ErrUserAlreadySigning) {
+	if errors.Is(err, csp.ErrProcessAlreadyConsumed) || errors.Is(err, csp.ErrUserAlreadySigning) ||
+		errors.Is(err, csp.ErrAddressMismatch) {
 		log.Debugw("skipped a batch ballot", "procId", oid.Hex(), "member", memberID,
 			"electionId", upstreamID, "reason", err)
 		return

--- a/csp/handlers/processes.go
+++ b/csp/handlers/processes.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"net/http"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -277,7 +276,7 @@ func (c *CSPHandlers) resolveSignContext(
 	return &signContext{
 		process:  vp,
 		memberID: auth.UserID.String(),
-		weight:   big.NewInt(int64(weight)).Bytes(),
+		weight:   weightBytes(weight),
 	}, true
 }
 
@@ -288,6 +287,11 @@ func (c *CSPHandlers) resolveSignContext(
 func (c *CSPHandlers) authorizeQuestion(
 	sc *signContext, electionID internal.HexBytes,
 ) (internal.HexBytes, *errors.Error) {
+	// an empty id cannot name an election, and db.QuestionByUpstreamID reports it as
+	// ErrInvalidData, which the branch below would surface to the client as a 500.
+	if len(electionID) == 0 {
+		return nil, apiErr(errors.ErrMalformedBody.With("missing upstreamId"))
+	}
 	question, err := c.mainDB.QuestionByUpstreamID(electionID)
 	if err != nil && err != db.ErrNotFound {
 		return nil, apiErr(errors.ErrGenericInternalServerError.WithErr(err))
@@ -410,7 +414,7 @@ func (c *CSPHandlers) ProcessSignBatchHandler(w http.ResponseWriter, r *http.Req
 		if err != nil {
 			// per-ballot by nature: this election's signing slot is spent, or a concurrent
 			// request holds its lock. The batch's siblings are unaffected.
-			log.Warnw("could not sign a batch ballot", "procId", b.upstreamID, "error", err)
+			logSignFailure(b.upstreamID, err)
 			res.Error = err.Error()
 			continue
 		}
@@ -418,6 +422,18 @@ func (c *CSPHandlers) ProcessSignBatchHandler(w http.ResponseWriter, r *http.Req
 		res.Weight = sc.weight
 	}
 	apicommon.HTTPWriteJSON(w, resp)
+}
+
+// logSignFailure records why one ballot of a batch could not be signed. A spent signing slot and
+// a concurrent request for the same election are the normal outcomes of a voter retrying or of
+// two tabs racing, and the caller is told about them in the response anyway, so they are debug —
+// a warn per occurrence would bury the storage and signer failures that do need attention.
+func logSignFailure(upstreamID internal.HexBytes, err error) {
+	if errors.Is(err, csp.ErrProcessAlreadyConsumed) || errors.Is(err, csp.ErrUserAlreadySigning) {
+		log.Debugw("skipped a batch ballot", "procId", upstreamID, "reason", err)
+		return
+	}
+	log.Warnw("could not sign a batch ballot", "procId", upstreamID, "error", err)
 }
 
 // parseSignBatchRequest decodes a capped sign-batch body and checks it carries an auth token,
@@ -496,7 +512,7 @@ func (c *CSPHandlers) ProcessWeightHandler(w http.ResponseWriter, r *http.Reques
 	if census.Weighted {
 		weight = member.Weight
 	}
-	apicommon.HTTPWriteJSON(w, &UserWeightResponse{Weight: internal.HexBytes(big.NewInt(int64(weight)).Bytes())})
+	apicommon.HTTPWriteJSON(w, &UserWeightResponse{Weight: weightBytes(weight)})
 }
 
 // ProcessCheckHandler godoc
@@ -552,7 +568,7 @@ func (c *CSPHandlers) ProcessCheckHandler(w http.ResponseWriter, r *http.Request
 		if cErr == nil && census.Weighted {
 			weight = member.Weight
 		}
-		resp.Weight = internal.HexBytes(big.NewInt(int64(weight)).Bytes())
+		resp.Weight = weightBytes(weight)
 	}
 	questions, err := c.mainDB.QuestionsByProcess(oid)
 	if err != nil {

--- a/csp/handlers/types.go
+++ b/csp/handlers/types.go
@@ -57,6 +57,34 @@ type SignRequest struct {
 	ProcessID internal.HexBytes `json:"electionId,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`
 }
 
+// SignBatchRequest is the batch form of SignRequest: one auth token and one ballot per
+// question of a voting process, signed in a single call.
+type SignBatchRequest struct {
+	AuthToken  internal.HexBytes `json:"authToken" swaggertype:"string" format:"hex" example:"deadbeef"`
+	Signatures []SignBatchItem   `json:"signatures"`
+}
+
+// SignBatchItem is one ballot of a SignBatchRequest: the question's on-chain election id and
+// the voter address to sign, matching SignRequest's electionId and payload fields.
+type SignBatchItem struct {
+	ProcessID internal.HexBytes `json:"electionId" swaggertype:"string" format:"hex" example:"deadbeef"`
+	Payload   string            `json:"payload"`
+}
+
+// SignBatchResponse holds one result per requested ballot, in request order.
+type SignBatchResponse struct {
+	Signatures []SignBatchResult `json:"signatures"`
+}
+
+// SignBatchResult is one ballot's outcome: the signature and the weight it was signed with, or
+// the reason that election could not be signed. Exactly one of Signature and Error is set.
+type SignBatchResult struct {
+	ProcessID internal.HexBytes `json:"electionId" swaggertype:"string" format:"hex" example:"deadbeef"`
+	Signature internal.HexBytes `json:"signature,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`
+	Weight    internal.HexBytes `json:"weight,omitempty" swaggertype:"string" format:"hex" example:"2a"`
+	Error     string            `json:"error,omitempty"`
+}
+
 // UserWeightRequest defines the payload for the request to get the
 // weight of a user for a given bundle. It includes the authToken to query
 // the information.

--- a/csp/handlers/types.go
+++ b/csp/handlers/types.go
@@ -58,17 +58,18 @@ type SignRequest struct {
 }
 
 // SignBatchRequest is the batch form of SignRequest: one auth token and one ballot per
-// question of a voting process, signed in a single call.
+// question of a voting process, signed in a single call. It follows the /processes naming
+// (upstreamId, address) rather than SignRequest's legacy electionId/payload.
 type SignBatchRequest struct {
-	AuthToken  internal.HexBytes `json:"authToken" swaggertype:"string" format:"hex" example:"deadbeef"`
-	Signatures []SignBatchItem   `json:"signatures"`
+	AuthToken internal.HexBytes `json:"authToken" swaggertype:"string" format:"hex" example:"deadbeef"`
+	Ballots   []SignBatchBallot `json:"ballots"`
 }
 
-// SignBatchItem is one ballot of a SignBatchRequest: the question's on-chain election id and
-// the voter address to sign, matching SignRequest's electionId and payload fields.
-type SignBatchItem struct {
-	ProcessID internal.HexBytes `json:"electionId" swaggertype:"string" format:"hex" example:"deadbeef"`
-	Payload   string            `json:"payload"`
+// SignBatchBallot is one ballot of a SignBatchRequest: the question's on-chain election id
+// and the voter address to sign for it.
+type SignBatchBallot struct {
+	UpstreamID internal.HexBytes `json:"upstreamId" swaggertype:"string" format:"hex" example:"deadbeef"`
+	Address    internal.HexBytes `json:"address" swaggertype:"string" format:"hex" example:"deadbeef"`
 }
 
 // SignBatchResponse holds one result per requested ballot, in request order.
@@ -79,10 +80,10 @@ type SignBatchResponse struct {
 // SignBatchResult is one ballot's outcome: the signature and the weight it was signed with, or
 // the reason that election could not be signed. Exactly one of Signature and Error is set.
 type SignBatchResult struct {
-	ProcessID internal.HexBytes `json:"electionId" swaggertype:"string" format:"hex" example:"deadbeef"`
-	Signature internal.HexBytes `json:"signature,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`
-	Weight    internal.HexBytes `json:"weight,omitempty" swaggertype:"string" format:"hex" example:"2a"`
-	Error     string            `json:"error,omitempty"`
+	UpstreamID internal.HexBytes `json:"upstreamId" swaggertype:"string" format:"hex" example:"deadbeef"`
+	Signature  internal.HexBytes `json:"signature,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`
+	Weight     internal.HexBytes `json:"weight,omitempty" swaggertype:"string" format:"hex" example:"2a"`
+	Error      string            `json:"error,omitempty"`
 }
 
 // UserWeightRequest defines the payload for the request to get the

--- a/csp/handlers/types.go
+++ b/csp/handlers/types.go
@@ -78,11 +78,15 @@ type SignBatchResponse struct {
 }
 
 // SignBatchResult is one ballot's outcome: the signature and the weight it was signed with, or
-// the reason that election could not be signed. Exactly one of Signature and Error is set.
+// the reason that election could not be signed. On failure, Code is a stable machine-readable
+// reason ("already_consumed", "already_signing", "sign_failed") and Error is a sanitized message
+// — never the raw signer detail, which is logged server-side. Exactly one of Signature and Code
+// is set.
 type SignBatchResult struct {
 	UpstreamID internal.HexBytes `json:"upstreamId" swaggertype:"string" format:"hex" example:"deadbeef"`
 	Signature  internal.HexBytes `json:"signature,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`
 	Weight     internal.HexBytes `json:"weight,omitempty" swaggertype:"string" format:"hex" example:"2a"`
+	Code       string            `json:"code,omitempty"`
 	Error      string            `json:"error,omitempty"`
 }
 

--- a/csp/handlers/types.go
+++ b/csp/handlers/types.go
@@ -79,9 +79,9 @@ type SignBatchResponse struct {
 
 // SignBatchResult is one ballot's outcome: the signature and the weight it was signed with, or
 // the reason that election could not be signed. On failure, Code is a stable machine-readable
-// reason ("already_consumed", "already_signing", "sign_failed") and Error is a sanitized message
-// — never the raw signer detail, which is logged server-side. Exactly one of Signature and Code
-// is set.
+// reason — one of the signCode* constants in processes.go, which are the source of truth — and
+// Error is a sanitized message, never the raw signer detail, which is logged server-side.
+// Exactly one of Signature and Code is set.
 type SignBatchResult struct {
 	UpstreamID internal.HexBytes `json:"upstreamId" swaggertype:"string" format:"hex" example:"deadbeef"`
 	Signature  internal.HexBytes `json:"signature,omitempty" swaggertype:"string" format:"hex" example:"deadbeef"`

--- a/csp/sign.go
+++ b/csp/sign.go
@@ -59,6 +59,13 @@ func (c *CSP) prepareSaltedKeySigner(token, address, processID, weight internal.
 	if err != nil {
 		return nil, nil, nil, ErrInvalidAuthToken
 	}
+	// ensure that the auth token has been verified. Checked BEFORE taking the signer lock: an
+	// error return between lock and the deferred unlock in Sign used to leave the (user,
+	// election) lock held forever, because the nil userID returned alongside the error made the
+	// defer unlock a different key than the one locked.
+	if !authTokenData.Verified {
+		return nil, nil, nil, ErrAuthTokenNotVerified
+	}
 	// check if the user is already signing
 	if c.isLocked(authTokenData.UserID, processID) {
 		return nil, nil, nil, ErrUserAlreadySigning
@@ -75,12 +82,10 @@ func (c *CSP) prepareSaltedKeySigner(token, address, processID, weight internal.
 	} else if consumed {
 		return nil, nil, nil, ErrProcessAlreadyConsumed
 	}
-	// lock the user data to avoid concurrent signing
+	// lock the user data to avoid concurrent signing. Every return below this line carries
+	// authTokenData.UserID — error or not — so Sign's deferred unlock always releases the key
+	// that was locked here.
 	c.lock(authTokenData.UserID, processID)
-	// ensure that the auth token has been verified
-	if !authTokenData.Verified {
-		return nil, nil, nil, ErrAuthTokenNotVerified
-	}
 
 	// prepare the data for the signature
 	caBundle := &models.CAbundle{
@@ -91,12 +96,12 @@ func (c *CSP) prepareSaltedKeySigner(token, address, processID, weight internal.
 	// encode the data to sign
 	signatureMsg, err := proto.Marshal(caBundle)
 	if err != nil {
-		return nil, nil, nil, ErrPrepareSignature
+		return authTokenData.UserID, nil, nil, ErrPrepareSignature
 	}
 	// generate the salt
 	salt := [saltedkey.SaltSize]byte{}
 	if len(processID) < saltedkey.SaltSize {
-		return nil, nil, nil, ErrInvalidSalt
+		return authTokenData.UserID, nil, nil, ErrInvalidSalt
 	}
 	copy(salt[:], processID[:saltedkey.SaltSize])
 	return authTokenData.UserID, &salt, signatureMsg, nil
@@ -125,6 +130,11 @@ func (c *CSP) finishSaltedKeySigner(token, address, processID internal.HexBytes)
 	// update the process data to mark it as consumed, and set the token used
 	if err := c.Storage.ConsumeCSPProcess(token, processID, address); err != nil {
 		log.Warn(err)
+		// a different address than the one this election was first consumed with is an
+		// authorization rejection (the slot is pinned to that address), not a signer failure.
+		if errors.Is(err, db.ErrInvalidData) {
+			return ErrProcessAlreadyConsumed
+		}
 		return ErrSign
 	}
 	return nil

--- a/csp/sign.go
+++ b/csp/sign.go
@@ -54,10 +54,15 @@ func (c *CSP) Sign(
 func (c *CSP) prepareSaltedKeySigner(token, address, processID, weight internal.HexBytes) (
 	internal.HexBytes, *[saltedkey.SaltSize]byte, internal.HexBytes, error,
 ) {
-	// get the data of the auth token and the user from the storage
+	// get the data of the auth token and the user from the storage. A token that is genuinely
+	// gone is an auth verdict; any other storage failure must NOT be — the batch endpoint
+	// aborts every remaining ballot on an auth verdict, and a Mongo blip is retryable.
 	authTokenData, err := c.Storage.CSPAuth(token)
 	if err != nil {
-		return nil, nil, nil, ErrInvalidAuthToken
+		if errors.Is(err, db.ErrTokenNotFound) {
+			return nil, nil, nil, ErrInvalidAuthToken
+		}
+		return nil, nil, nil, errors.Join(ErrSign, err)
 	}
 	// ensure that the auth token has been verified. Checked BEFORE taking the signer lock: an
 	// error return between lock and the deferred unlock in Sign used to leave the (user,
@@ -108,10 +113,14 @@ func (c *CSP) prepareSaltedKeySigner(token, address, processID, weight internal.
 }
 
 func (c *CSP) finishSaltedKeySigner(token, address, processID internal.HexBytes) error {
-	// get the data of the auth token and the user from the storage
+	// get the data of the auth token and the user from the storage; same not-found vs
+	// storage-failure split as prepareSaltedKeySigner, and for the same reason.
 	authTokenData, err := c.Storage.CSPAuth(token)
 	if err != nil {
-		return ErrInvalidAuthToken
+		if errors.Is(err, db.ErrTokenNotFound) {
+			return ErrInvalidAuthToken
+		}
+		return errors.Join(ErrSign, err)
 	}
 	// ensure that the auth token has been verified
 	if !authTokenData.Verified {
@@ -131,9 +140,10 @@ func (c *CSP) finishSaltedKeySigner(token, address, processID internal.HexBytes)
 	if err := c.Storage.ConsumeCSPProcess(token, processID, address); err != nil {
 		log.Warn(err)
 		// a different address than the one this election was first consumed with is an
-		// authorization rejection (the slot is pinned to that address), not a signer failure.
+		// authorization rejection (the slot is pinned to that address), not a signer failure —
+		// and it is recoverable: re-sign with the pinned address, which sign-info reports.
 		if errors.Is(err, db.ErrInvalidData) {
-			return ErrProcessAlreadyConsumed
+			return ErrAddressMismatch
 		}
 		return ErrSign
 	}

--- a/csp/sign_test.go
+++ b/csp/sign_test.go
@@ -214,6 +214,24 @@ func TestFinishSaltedKeySigner(t *testing.T) {
 		c.Assert(err, qt.ErrorIs, ErrUserIsNotAlreadySigning)
 	})
 
+	c.Run("address mismatch", func(c *qt.C) {
+		c.Cleanup(func() {
+			c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)
+			csp.unlock(testUserID, testPID)
+		})
+		// store and verify the token, then consume the election with testAddress
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID, ""), qt.IsNil)
+		c.Assert(csp.Storage.VerifyCSPAuth(testToken), qt.IsNil)
+		c.Assert(csp.Storage.ConsumeCSPProcess(testToken, testPID, testAddress), qt.IsNil)
+		// signing again for a DIFFERENT address is the pinned-address rejection, its own
+		// outcome — the fix that succeeds is re-signing with the pinned address, so it must
+		// not read as already_consumed (terminal) nor as a signer failure.
+		csp.lock(testUserID, testPID)
+		otherAddress := internal.HexBytes(util.RandomBytes(20))
+		err := csp.finishSaltedKeySigner(testToken, otherAddress, testPID)
+		c.Assert(err, qt.ErrorIs, ErrAddressMismatch)
+	})
+
 	c.Run("success", func(c *qt.C) {
 		c.Cleanup(func() {
 			c.Assert(testDB.DeleteAllDocuments(), qt.IsNil)

--- a/csp/sign_test.go
+++ b/csp/sign_test.go
@@ -49,6 +49,22 @@ func TestSign(t *testing.T) {
 		c.Assert(sign, qt.Not(qt.IsNil))
 		c.Assert(csp.isLocked(testUserID, pid), qt.IsFalse)
 	})
+
+	c.Run("failed sign does not leak the signer lock", func(c *qt.C) {
+		pid := internal.HexBytes(util.RandomBytes(32))
+		c.Cleanup(func() { c.Assert(testDB.DeleteAllDocuments(), qt.IsNil) })
+		// an unverified token is rejected...
+		c.Assert(csp.Storage.SetCSPAuth(testToken, testUserID, testBundleID, ""), qt.IsNil)
+		_, err := csp.Sign(testToken, testAddress, pid, testUserWeightBytes, signers.SignerTypeECDSASalted)
+		c.Assert(err, qt.ErrorIs, ErrAuthTokenNotVerified)
+		// ...without leaving the (user, election) lock held: after verifying the same token,
+		// signing must succeed rather than report the user as already signing forever.
+		c.Assert(csp.isLocked(testUserID, pid), qt.IsFalse)
+		c.Assert(csp.Storage.VerifyCSPAuth(testToken), qt.IsNil)
+		sign, err := csp.Sign(testToken, testAddress, pid, testUserWeightBytes, signers.SignerTypeECDSASalted)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sign, qt.Not(qt.IsNil))
+	})
 }
 
 func TestPrepareSaltedKeySigner(t *testing.T) {

--- a/db/const.go
+++ b/db/const.go
@@ -25,6 +25,10 @@ const (
 	TestMaxCensusSize = 10
 	// max vote overwrites per process
 	MaxVoteOverwritesPerProcess = 10
+	// MaxQuestionsPerProcess bounds the number of questions a voting process may hold, and so the
+	// number of ballots a voter can sign for one. Shared by the /processes validation and the CSP
+	// sign-batch cap (which cannot reach the api-package constant through the import cycle).
+	MaxQuestionsPerProcess = 100
 
 	// Voting-process question status values (derived at read; empty means draft).
 	QuestionStatusReady    = "READY"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2638,13 +2638,15 @@ definitions:
         format: hex
         type: string
     type: object
-  handlers.SignBatchItem:
+  handlers.SignBatchBallot:
     properties:
-      electionId:
+      address:
         example: deadbeef
         format: hex
         type: string
-      payload:
+      upstreamId:
+        example: deadbeef
+        format: hex
         type: string
     type: object
   handlers.SignBatchRequest:
@@ -2653,9 +2655,9 @@ definitions:
         example: deadbeef
         format: hex
         type: string
-      signatures:
+      ballots:
         items:
-          $ref: '#/definitions/handlers.SignBatchItem'
+          $ref: '#/definitions/handlers.SignBatchBallot'
         type: array
     type: object
   handlers.SignBatchResponse:
@@ -2667,13 +2669,13 @@ definitions:
     type: object
   handlers.SignBatchResult:
     properties:
-      electionId:
-        example: deadbeef
-        format: hex
-        type: string
       error:
         type: string
       signature:
+        example: deadbeef
+        format: hex
+        type: string
+      upstreamId:
         example: deadbeef
         format: hex
         type: string
@@ -6733,12 +6735,14 @@ paths:
         one on-chain election per question, so a voter holds one ballot per question and
         signing them one by one costs a round trip each. This signs them all under a single
         verified auth token. Public endpoint: the token authenticates the voter.
+        Each ballot names a question by its on-chain election id (upstreamId, as returned by
+        the check and sign-info endpoints) and the voter address to sign for it.
         The batch is authorized as a unit and signs nothing on failure — every ballot must
         name an election of this process (else 401) the member is eligible for (else 401),
-        carry a parseable voter address (else 400), and no election may be repeated (else
-        400). Once authorized, every ballot is signed and the response carries one entry per
-        request item, in order: a signature and weight, or the reason that election could not
-        be signed (its signing slot is spent, or a concurrent request holds it). Signing
+        carry a voter address (else 400), and no election may be repeated (else 400). Once
+        authorized, every ballot is signed and the response carries one entry per request
+        item, in order: a signature and weight, or the reason that election could not be
+        signed (its signing slot is spent, or a concurrent request holds it). Signing
         consumes a per-election slot that cannot be given back, so a failed entry is retried
         by calling again, not rolled back.
       parameters:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -6747,10 +6747,14 @@ paths:
         Once authorized, every ballot is signed and the response is always 200 with one
         entry per request item, in order — even if every ballot fails (the request was
         honored; the outcome is per item). Each entry carries a signature and weight, or a
-        stable machine-readable code plus a message. Retry ONLY the entries that carry a
-        code: re-sending the whole batch re-signs the ballots that already succeeded, and
-        each re-sign counts toward the election's finite overwrite budget
-        (MaxVoteOverwritesPerProcess, 10) — past it the election is permanently locked.
+        stable machine-readable code plus a message: already_consumed (that election's
+        signing slot is spent; not retryable), already_signing (a concurrent request holds
+        it; retry), auth_invalid (the token was invalidated mid-batch and every remaining
+        entry is stamped with it; authenticate again) or sign_failed (internal failure;
+        retry). Retry ONLY the entries that carry a retryable code: re-sending the whole
+        batch re-signs the ballots that already succeeded, and each re-sign counts toward
+        the election's finite overwrite budget (MaxVoteOverwritesPerProcess, 10) — past it
+        the election is permanently locked.
       parameters:
       - description: Process ID
         in: path

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2638,6 +2638,50 @@ definitions:
         format: hex
         type: string
     type: object
+  handlers.SignBatchItem:
+    properties:
+      electionId:
+        example: deadbeef
+        format: hex
+        type: string
+      payload:
+        type: string
+    type: object
+  handlers.SignBatchRequest:
+    properties:
+      authToken:
+        example: deadbeef
+        format: hex
+        type: string
+      signatures:
+        items:
+          $ref: '#/definitions/handlers.SignBatchItem'
+        type: array
+    type: object
+  handlers.SignBatchResponse:
+    properties:
+      signatures:
+        items:
+          $ref: '#/definitions/handlers.SignBatchResult'
+        type: array
+    type: object
+  handlers.SignBatchResult:
+    properties:
+      electionId:
+        example: deadbeef
+        format: hex
+        type: string
+      error:
+        type: string
+      signature:
+        example: deadbeef
+        format: hex
+        type: string
+      weight:
+        example: 2a
+        format: hex
+        type: string
+    type: object
   handlers.SignRequest:
     properties:
       authToken:
@@ -6678,6 +6722,66 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
       summary: Sign a ballot for a voting process question
+      tags:
+      - processes
+  /processes/{processId}/sign-batch:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Batch form of POST /processes/{processId}/sign. A multi-question voting process is
+        one on-chain election per question, so a voter holds one ballot per question and
+        signing them one by one costs a round trip each. This signs them all under a single
+        verified auth token. Public endpoint: the token authenticates the voter.
+        The batch is authorized as a unit and signs nothing on failure — every ballot must
+        name an election of this process (else 401) the member is eligible for (else 401),
+        carry a parseable voter address (else 400), and no election may be repeated (else
+        400). Once authorized, every ballot is signed and the response carries one entry per
+        request item, in order: a signature and weight, or the reason that election could not
+        be signed (its signing slot is spent, or a concurrent request holds it). Signing
+        consumes a per-election slot that cannot be given back, so a failed entry is retried
+        by calling again, not rolled back.
+      parameters:
+      - description: Process ID
+        in: path
+        name: processId
+        required: true
+        type: string
+      - description: Auth token and one ballot per question
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.SignBatchRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.SignBatchResponse'
+        "400":
+          description: Invalid input data
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "401":
+          description: Unauthorized, unverified token, election not in process, or
+            member not eligible
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "404":
+          description: Process, census, or user not found
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "413":
+          description: Request body too large
+          schema:
+            $ref: '#/definitions/errors.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/errors.Error'
+      summary: Sign every question's ballot of a voting process in one call
       tags:
       - processes
   /processes/{processId}/sign-info:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -7014,11 +7014,13 @@ paths:
         stable machine-readable code plus a message: already_consumed (that election's
         signing slot is spent; not retryable), already_signing (a concurrent request holds
         it; retry), auth_invalid (the token was invalidated mid-batch and every remaining
-        entry is stamped with it; authenticate again) or sign_failed (internal failure;
-        retry). Retry ONLY the entries that carry a retryable code: re-sending the whole
-        batch re-signs the ballots that already succeeded, and each re-sign counts toward
-        the election's finite overwrite budget (MaxVoteOverwritesPerProcess, 10) — past it
-        the election is permanently locked.
+        entry is stamped with it; authenticate again), address_mismatch (that election was
+        already signed for a different address; re-send with the address sign-info
+        reports) or sign_failed (internal failure; retry). Retry ONLY the entries that
+        carry a retryable code: re-sending the whole batch re-signs the ballots that
+        already succeeded, and each re-sign counts toward the election's finite overwrite
+        budget (MaxVoteOverwritesPerProcess, 10) — past it the election is permanently
+        locked.
       parameters:
       - description: Process ID
         in: path

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2669,6 +2669,8 @@ definitions:
     type: object
   handlers.SignBatchResult:
     properties:
+      code:
+        type: string
       error:
         type: string
       signature:
@@ -6739,12 +6741,16 @@ paths:
         the check and sign-info endpoints) and the voter address to sign for it.
         The batch is authorized as a unit and signs nothing on failure — every ballot must
         name an election of this process (else 401) the member is eligible for (else 401),
-        carry a voter address (else 400), and no election may be repeated (else 400). Once
-        authorized, every ballot is signed and the response carries one entry per request
-        item, in order: a signature and weight, or the reason that election could not be
-        signed (its signing slot is spent, or a concurrent request holds it). Signing
-        consumes a per-election slot that cannot be given back, so a failed entry is retried
-        by calling again, not rolled back.
+        carry a 20-byte voter address (else 400), and no election may be repeated (else
+        400). Authorization strictly precedes the first signature, so a rejected batch
+        consumes nothing.
+        Once authorized, every ballot is signed and the response is always 200 with one
+        entry per request item, in order — even if every ballot fails (the request was
+        honored; the outcome is per item). Each entry carries a signature and weight, or a
+        stable machine-readable code plus a message. Retry ONLY the entries that carry a
+        code: re-sending the whole batch re-signs the ballots that already succeeded, and
+        each re-sign counts toward the election's finite overwrite budget
+        (MaxVoteOverwritesPerProcess, 10) — past it the election is permanently locked.
       parameters:
       - description: Process ID
         in: path
@@ -6774,7 +6780,7 @@ paths:
           schema:
             $ref: '#/definitions/errors.Error'
         "404":
-          description: Process, census, or user not found
+          description: Census or user not found
           schema:
             $ref: '#/definitions/errors.Error'
         "413":

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -131,6 +131,9 @@ func (e Error) Write(w http.ResponseWriter) {
 	http.Error(w, string(msg), e.HTTPstatus)
 }
 
+// Ptr lifts an Error to a pointer, so functions returning *Error can signal "no error" with nil.
+func Ptr(e Error) *Error { return &e }
+
 // Withf returns a copy of Error with the Sprintf formatted string appended at the end of e.Err
 func (e Error) Withf(format string, args ...any) Error {
 	return Error{


### PR DESCRIPTION
## Why

A multi-question voting process is **one on-chain election per question**, so a voter holds one ballot per question. `POST /votes` already relays them in a single call — the signing side had no counterpart. A voter had to hit `POST /processes/{processId}/sign` once per question, and each call re-did the same work (load the process, load and verify the auth token, load the org member, load the census, compute the weight) before signing one ballot.

## What

`POST /processes/{processId}/sign-batch` — one auth token, N ballots, one response.

```jsonc
// request
{"authToken": "…", "ballots": [
  {"upstreamId": "aa…", "address": "…"},
  {"upstreamId": "bb…", "address": "…"}
]}

// response
{"signatures": [
  {"upstreamId": "aa…", "signature": "…", "weight": "01"},
  {"upstreamId": "bb…", "error": "process already consumed"}
]}
```

Fields follow the `/processes` naming (`upstreamId`, `address`) that `ProcessQuestionStatus`, `QuestionConsumedAddress` and `db.VotingProcessQuestion` already use — not the `electionId`/`payload` of the shared/legacy `SignRequest` — so the ids read the same as in the `check` and `sign-info` responses a voter already called.

`ProcessSignHandler` is split into two reusable halves so the batch handler shares the exact checks rather than duplicating them:

- `resolveSignContext` — the per-request part: voting process, verified token anchored to it, member behind it, census weight.
- `authorizeQuestion` — the per-ballot part: the election belongs to this process, and the member is eligible for that question.

The single endpoint keeps its authorization semantics, with two review-driven changes: failures are sanitized through the same `signOutcome` mapping as the batch (no raw signer detail in the body), and an *internal* signer/storage failure is now a 500 rather than a 401 — authorization rejections stay 401.

## Failure semantics

Signing consumes a per-election slot that cannot be given back (`csp.Sign` → `db.ConsumeCSPProcess`), so the batch is **authorized as a unit and signs nothing on failure**:

| Condition | Result |
|---|---|
| election not in this process / member not eligible | 401, nothing signed |
| missing voter address | 400, nothing signed |
| repeated `upstreamId` | 400, nothing signed |
| empty batch / more ballots than the process has questions | 400, nothing signed |

Once authorized, every ballot is signed and the response carries one entry per request item, in order — a signature and weight, or the reason that election could not be signed. Those residual failures are per-ballot by nature (the slot is spent, or a concurrent request holds its `(user, election)` lock), so a failed entry is retried by calling again rather than rolled back. `MaxVoteOverwritesPerProcess` (10) makes that retry viable.

## Notes

- **No new cap constant** — a voter has at most one ballot per question, so `len(vp.QuestionIDs)` is the real bound (`maxQuestionsPerProcess` = 100 caps it transitively).
- **No new error codes** — reuses `ErrVoteBatchEmpty`, `ErrVoteBatchTooLarge`, `ErrRequestBodyTooLarge` from the vote relay, with the same `at index %d` annotation.
- **Body is capped** before it is buffered, as on the other public endpoints.
- **Signed sequentially** — `db.ConsumeCSPProcess` takes the storage write lock, so a parallel fan-out inside one request would serialize on it anyway.
- The legacy `POST /process/bundle/{bundleId}/sign` keeps its single-ballot form, but inherits two hardenings through the shared helpers: the 20-byte voter address check (`parseAddress` → `validateVoterAddress`) and the sanitized `signOutcome` error mapping.
- `CLAUDE.md` gains the two sections a new reader needs to reconstruct this from scratch: the two generations of the process API (and why several endpoints exist only in batch form), and the async transaction job queue behind every `202 + jobId`.

## Testing

`TestProcessCSPSignBatch` (`api/processes_csp_test.go`) covers: whole-batch rejection leaves nothing consumed, duplicate election → 400, empty → 400, over-cap → `ErrVoteBatchTooLarge`, missing address → 400, happy path signs both questions and `sign-info` reports both consumed, and a spent signing slot surfaces as a per-ballot `error` while its sibling still signs.

- `go test ./csp/... ./api/` → 294 passed
- `make lint` → 0 issues
- `scripts/check-qt-patterns.sh` → clean
- `docs/swagger.yaml` regenerated
