### PR TITLE
feat(db): index the census revocation cascade (cspTokens.userid, votingProcesses.censusId)

### DIFF
--- a/db/migration_census_revocation_indexes_test.go
+++ b/db/migration_census_revocation_indexes_test.go
@@ -1,0 +1,68 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/saas-backend/migrations"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// indexKeys maps a collection's index names to their key specs. The key spec is what the queries
+// actually depend on — a name is derived from it, so asserting only the name would pass on an
+// index whose field order or direction had drifted.
+func indexKeys(c *qt.C, coll *mongo.Collection) map[string]bson.D {
+	cursor, err := coll.Indexes().List(context.Background())
+	c.Assert(err, qt.IsNil)
+	var indexes []struct {
+		Name string `bson:"name"`
+		Key  bson.D `bson:"key"`
+	}
+	c.Assert(cursor.All(context.Background(), &indexes), qt.IsNil)
+	keys := make(map[string]bson.D, len(indexes))
+	for _, idx := range indexes {
+		keys[idx.Name] = idx.Key
+	}
+	return keys
+}
+
+// TestCensusRevocationIndexesMigration asserts migration 0019 gives every cspTokens access path an
+// index and the census-to-processes lookup its own, that re-running it is a no-op, and that its
+// down migration drops all three.
+//
+// The key specs are asserted rather than the names: the compound index's field order and its
+// descending createdat are what let it serve LastCSPAuth's sort and still prefix-serve the
+// revocation cascade, and a name alone would not pin either.
+func TestCensusRevocationIndexesMigration(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	mig, ok := migrations.AsMap()[19]
+	c.Assert(ok, qt.IsTrue)
+	database := testDB.DBClient.Database(testDB.database)
+	c.Cleanup(func() {
+		// restore the migrated state for the rest of the suite
+		c.Assert(mig.Up(ctx, database), qt.IsNil)
+	})
+
+	// the test database is migrated on init
+	cspAuth := bson.D{{Key: "userid", Value: int32(1)}, {Key: "bundleid", Value: int32(1)}, {Key: "createdat", Value: int32(-1)}}
+	c.Assert(indexKeys(c, testDB.cspTokens)["userid_1_bundleid_1_createdat_-1"], qt.DeepEquals, cspAuth)
+	c.Assert(indexKeys(c, testDB.cspTokens)["bundleid_1"], qt.DeepEquals, bson.D{{Key: "bundleid", Value: int32(1)}})
+	c.Assert(indexKeys(c, testDB.votingProcesses)["censusId_1"], qt.DeepEquals, bson.D{{Key: "censusId", Value: int32(1)}})
+
+	// re-running over the already-migrated state changes nothing: an identical spec and name is a
+	// server-side no-op, so a redeploy that replays the migration is safe
+	c.Assert(mig.Up(ctx, database), qt.IsNil)
+	c.Assert(indexKeys(c, testDB.cspTokens)["userid_1_bundleid_1_createdat_-1"], qt.DeepEquals, cspAuth)
+
+	c.Assert(mig.Down(ctx, database), qt.IsNil)
+	after := indexKeys(c, testDB.cspTokens)
+	_, ok = after["userid_1_bundleid_1_createdat_-1"]
+	c.Assert(ok, qt.IsFalse)
+	_, ok = after["bundleid_1"]
+	c.Assert(ok, qt.IsFalse)
+	_, ok = indexKeys(c, testDB.votingProcesses)["censusId_1"]
+	c.Assert(ok, qt.IsFalse)
+}

--- a/migrations/0019_census_revocation_indexes.go
+++ b/migrations/0019_census_revocation_indexes.go
@@ -1,0 +1,72 @@
+package migrations
+
+import (
+	"context"
+	stderrors "errors"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func init() {
+	AddMigration(19, "census_revocation_indexes", upCensusRevocationIndexes, downCensusRevocationIndexes)
+}
+
+// upCensusRevocationIndexes adds the indexes behind the census revocation cascade (#621), promised
+// as a follow-up in #629. Each of these lookups was a collection scan before: cspTokens carried no
+// index beyond _id, and 0017's votingProcesses index leads with orgAddress.
+func upCensusRevocationIndexes(ctx context.Context, database *mongo.Database) error {
+	// Two indexes cover every way cspTokens is queried.
+	//
+	// The compound one is keyed for LastCSPAuth — filter {userid, bundleid}, sort {createdat: -1},
+	// the hot voter-auth path — and its userid prefix serves the revocation cascade's
+	// DeleteMany({userid: $in}) just as a bare {userid: 1} would.
+	//
+	// bundleid alone is the second: DeleteCSPAuthByBundle and the two Count*ByBundle helpers
+	// predicate on bundleid with no userid, so the compound index cannot serve them (a non-leading
+	// field is not a usable prefix). The delete runs once per bundle in a loop on org teardown and
+	// GDPR erasure, so those are the scans that repeat.
+	if _, err := database.Collection("cspTokens").Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{Keys: bson.D{
+			{Key: "userid", Value: 1},
+			{Key: "bundleid", Value: 1},
+			{Key: "createdat", Value: -1},
+		}},
+		{Keys: bson.D{{Key: "bundleid", Value: 1}}},
+	}); err != nil {
+		return fmt.Errorf("failed to create indexes on cspTokens: %w", err)
+	}
+	// the access path from a census back to the processes built on it (VotingProcessesByCensus,
+	// arriving with #621); 0017's index leads with orgAddress and cannot serve a censusId predicate.
+	if _, err := database.Collection("votingProcesses").Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{Keys: bson.D{{Key: "censusId", Value: 1}}},
+	}); err != nil {
+		return fmt.Errorf("failed to create indexes on votingProcesses: %w", err)
+	}
+	return nil
+}
+
+// downCensusRevocationIndexes drops the indexes again. They carry no data, so unlike the
+// data-bearing collections this migration is genuinely reversible.
+func downCensusRevocationIndexes(ctx context.Context, database *mongo.Database) error {
+	for _, idx := range []struct {
+		collection string
+		name       string
+	}{
+		{"cspTokens", "userid_1_bundleid_1_createdat_-1"},
+		{"cspTokens", "bundleid_1"},
+		{"votingProcesses", "censusId_1"},
+	} {
+		if _, err := database.Collection(idx.collection).Indexes().DropOne(ctx, idx.name); err != nil {
+			// Nothing to drop is not a failure to drop: IndexNotFound (27) means the up never got
+			// far enough to create it, NamespaceNotFound (26) that the collection itself is gone.
+			// The driver only forgives 26 on IndexView.List, so DropOne needs it spelled out here.
+			var cmdErr mongo.CommandError
+			if !stderrors.As(err, &cmdErr) || (cmdErr.Code != 27 && cmdErr.Code != 26) {
+				return fmt.Errorf("failed to drop index %s on %s: %w", idx.name, idx.collection, err)
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #629. Refs #621.

**Stacked on #621** (`feat/memberbase-census-sync`) — merge that first; this PR then carries only the one migration commit.

Migration 0019 restores the indexes from the migration #621 dropped in `aa74686` while slot 0018 was contended (0018 is now #615's unique question-slot index). Following review, the keys are chosen to cover **every** `cspTokens` access path rather than only the cascade's own.

### `cspTokens` — two indexes, previously nothing beyond `_id`

| Index | Serves |
|---|---|
| `{userid: 1, bundleid: 1, createdat: -1}` | `LastCSPAuth` (the hot voter-auth path) in full, sort included — and the revocation cascade's `DeleteMany({userid: $in})` on its `userid` prefix |
| `{bundleid: 1}` | `DeleteCSPAuthByBundle` and the two `Count*ByBundle` helpers |

The compound key means one index serves both the cascade and the voter-auth read. `bundleid` needs its own: those three queries predicate on `bundleid` with no `userid`, and a non-leading field is not a usable prefix. `DeleteCSPAuthByBundle` runs **once per bundle in a loop** on org teardown (`api/organizations_managed.go`) and GDPR erasure (`db/user_erase.go`), so those are the scans that repeat.

### `votingProcesses` — `{censusId: 1}`

0017's index leads with `orgAddress` and cannot serve `VotingProcessesByCensus`' `censusId` predicate. Harmless before #621 lands, load-bearing after.

The third index the original migration carried (`processesQuestions.eligibleMemberIds`) was redundant with 0017's `processId` index and stays dropped, per the issue.

### Rollout cost

The build runs **inline during `RunMigrationsUp`** on the startup path, under a **single 10-minute context shared by all pending migrations** (`db/migrations.go`) — so on a database jumping from <18 it shares that budget with 0018's `dedupeQuestionSlots` data pass. On MongoDB ≥ 4.2 index builds are hybrid, so writes are not blocked and the risk is the shared timeout on a large `cspTokens`, not availability. Worth knowing before deploying against a big collection; no code change implied.

### Reversibility

Index-only, so genuinely reversible unlike the data-bearing collections. The down drops all three and tolerates both `IndexNotFound` (27) and `NamespaceNotFound` (26) — the driver forgives 26 only on `IndexView.List`, so `DropOne` needs it spelled out — inspecting the error with `errors.As` per CLAUDE.md.

`TestCensusRevocationIndexesMigration` asserts the index **key specs** rather than their auto-derived names (the compound field order and the descending `createdat` are what make it serve both paths), re-runs `Up` over the already-migrated state to pin that a replay is a no-op, and asserts all three are gone after `Down`.

## Verification

```
go build ./... && go vet ./...
golangci-lint run                # 0 issues
./scripts/check-qt-patterns.sh   # clean
go test -count=1 ./db/           # 251 passed
```

The test was also run against the previous single-`{userid:1}` shape and fails there. No API change, so no swagger regeneration.
