### PR TITLE
fix(census): narrow the removal guard to the elections the member would actually leave

### DIFF
--- a/api/census_guard.go
+++ b/api/census_guard.go
@@ -26,8 +26,10 @@ import (
 // can belong to someone who is no longer counted. The participation scoping preserves exactly
 // that: a member with a signature but no participant row is already outside the count, and only
 // the censuses that would lose a counted member can lose the invariant. Question eligibility
-// lists deliberately play no part — a consumed signature is a live potential vote whatever the
-// list says today, and the CSP sign gate checks participation, not eligibility.
+// lists deliberately play no part — eligibility is enforced once, at sign time
+// (ProcessSignHandler), and never re-checked afterwards, so a consumed signature is a live
+// potential vote whatever the list says today; participation is the only axis this removal
+// changes.
 //
 // One census is checked per iteration — the participant filter is per census, and matching it by
 // exact participantID string mirrors the $in delete in RevokeMembersFromCensuses, so the guard
@@ -71,7 +73,7 @@ func (a *API) blockedVoters(censusIDs, memberIDs []string) ([]string, error) {
 		}
 		hit, err := a.db.MembersWithUsedCSPProcesses(elections, present)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("could not resolve the members signed for on the census elections: %w", err)
 		}
 		for _, id := range hit {
 			blocked[id] = true

--- a/api/census_guard.go
+++ b/api/census_guard.go
@@ -12,31 +12,83 @@ import (
 )
 
 // blockedVoters returns the subset of memberIDs that may not be removed from the given censuses
-// because the CSP has already signed for them in a process that is still running.
+// because the CSP has already signed for them in a process the removal would actually strip them
+// from: an ongoing election of a census they still participate in. A signature on a census a
+// member has already left blocks nothing — the removal does not touch that election, so there is
+// nothing left to protect by refusing it (#630).
 //
-// "Still running" means a published question whose status is READY or PAUSED. ENDED, CANCELED and
+// "Ongoing" means a published question whose status is READY or PAUSED. ENDED, CANCELED and
 // RESULTS release their members, so once voting closes the removal goes through and erasure is
 // never permanently blocked.
 //
 // Refusing rather than silently revoking is what keeps census.Size an honest recount of live
-// participants, and votes <= censusSize true by construction: no signature the chain will accept can
-// belong to someone who is no longer counted.
+// participants, and votes <= censusSize true by construction: no signature the chain will accept
+// can belong to someone who is no longer counted. The participation scoping preserves exactly
+// that: a member with a signature but no participant row is already outside the count, and only
+// the censuses that would lose a counted member can lose the invariant. Question eligibility
+// lists deliberately play no part — a consumed signature is a live potential vote whatever the
+// list says today, and the CSP sign gate checks participation, not eligibility.
+//
+// One census is checked per iteration — the participant filter is per census, and matching it by
+// exact participantID string mirrors the $in delete in RevokeMembersFromCensuses, so the guard
+// refuses exactly what the write would remove. The handful of censuses a single request names
+// keeps this cheap; group the queries if that ever stops holding.
 func (a *API) blockedVoters(censusIDs, memberIDs []string) ([]string, error) {
 	if len(censusIDs) == 0 || len(memberIDs) == 0 {
 		return nil, nil
 	}
-	questions, err := a.db.OngoingQuestionsByCensuses(censusIDs)
-	if err != nil {
-		return nil, fmt.Errorf("could not resolve the ongoing questions of the censuses: %w", err)
+	blocked := make(map[string]bool, len(memberIDs))
+	for _, censusID := range censusIDs {
+		questions, err := a.db.OngoingQuestionsByCensuses([]string{censusID})
+		if err != nil {
+			return nil, fmt.Errorf("could not resolve the ongoing questions of the census: %w", err)
+		}
+		if len(questions) == 0 {
+			continue
+		}
+		participants, err := a.db.CensusParticipantsByMemberIDs(censusID, memberIDs)
+		if err != nil {
+			return nil, fmt.Errorf("could not resolve the participants of the census: %w", err)
+		}
+		if len(participants) == 0 {
+			continue
+		}
+		inCensus := make(map[string]bool, len(participants))
+		for i := range participants {
+			inCensus[participants[i].ParticipantID] = true
+		}
+		// the caller's own ids, filtered rather than the participant rows echoed, so
+		// MembersWithUsedCSPProcesses answers in the caller's spelling as before
+		present := make([]string, 0, len(participants))
+		for _, id := range memberIDs {
+			if inCensus[id] {
+				present = append(present, id)
+			}
+		}
+		elections := make([]internal.HexBytes, 0, len(questions))
+		for i := range questions {
+			elections = append(elections, questions[i].UpstreamID)
+		}
+		hit, err := a.db.MembersWithUsedCSPProcesses(elections, present)
+		if err != nil {
+			return nil, err
+		}
+		for _, id := range hit {
+			blocked[id] = true
+		}
 	}
-	if len(questions) == 0 {
+	if len(blocked) == 0 {
 		return nil, nil
 	}
-	elections := make([]internal.HexBytes, 0, len(questions))
-	for i := range questions {
-		elections = append(elections, questions[i].UpstreamID)
+	// answer in the order the caller asked, each id once however many censuses block it
+	result := make([]string, 0, len(blocked))
+	for _, id := range memberIDs {
+		if blocked[id] {
+			result = append(result, id)
+			delete(blocked, id)
+		}
 	}
-	return a.db.MembersWithUsedCSPProcesses(elections, memberIDs)
+	return result, nil
 }
 
 // refuseBlockedVoters answers 409 when any of the members may not be removed, and reports whether

--- a/api/census_sync_test.go
+++ b/api/census_sync_test.go
@@ -871,6 +871,128 @@ func TestGroupCensusGuards(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 }
 
+// TestMemberDeletionReleasedByStaleSignature pins the #630 narrowing on the member-delete door: a
+// consumed signature only blocks a member while they still participate in the census it belongs
+// to. The stale state — signed for an ongoing election, yet out of its census — is exactly what
+// the guard/CSP race documented on refuseBlockedVoters leaves behind, modelled here with the same
+// direct RevokeMembersFromCensuses call as TestProcessCSPRevocation. Before the narrowing this
+// deletion answered 409 naming members[0], because members[1] kept the census in the request's
+// census union.
+func TestMemberDeletionReleasedByStaleSignature(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateProvisionedOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	pid, got := publishedProcess(t, token, orgAddress, ids)
+	c.Assert(signAs(t, pid, members[0], got.Questions[0].UpstreamID), qt.Equals, http.StatusOK)
+
+	// revoked underneath their signature; the consumption row survives by design
+	vp, err := testDB.VotingProcess(objectID(c, pid))
+	c.Assert(err, qt.IsNil)
+	_, _, err = testDB.RevokeMembersFromCensuses([]string{vp.CensusID.Hex()}, []string{ids[0]})
+	c.Assert(err, qt.IsNil)
+
+	// deleting both members succeeds: members[0]'s signature belongs to a census they already
+	// left, and members[1] has signed nothing
+	del := requestAndParse[apicommon.DeleteMembersResponse](t, http.MethodDelete, token,
+		&apicommon.DeleteMembersRequest{IDs: ids},
+		"organizations", orgAddress.String(), "members")
+	c.Assert(del.Count, qt.Equals, 2)
+	_, err = testDB.CensusParticipant(vp.CensusID.Hex(), ids[1])
+	c.Assert(err, qt.Equals, db.ErrNotFound)
+}
+
+// TestGroupRemovalReleasedForNonParticipant is TestMemberDeletionReleasedByStaleSignature for the
+// group door: a group member already revoked from the group's census can leave the group even
+// though the CSP once signed for them on its still-ongoing election.
+func TestGroupRemovalReleasedForNonParticipant(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateProvisionedOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	group := requestAndParse[apicommon.OrganizationMemberGroupInfo](
+		t, http.MethodPost, token, &apicommon.CreateOrganizationMemberGroupRequest{
+			Title: "voters", Description: "group census", MemberIDs: ids,
+		}, "organizations", orgAddress.String(), "groups",
+	)
+	req := newVotingProcessRequest(orgAddress, ids)
+	req.StartDate = ""
+	req.Census = apicommon.CensusSpec{
+		TwoFaFields: db.OrgMemberTwoFaFields{db.OrgMemberTwoFaFieldEmail},
+		AuthFields:  db.OrgMemberAuthFields{db.OrgMemberAuthFieldsName, db.OrgMemberAuthFieldsSurname},
+		GroupID:     group.ID,
+	}
+	req.Questions = req.Questions[:1]
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, req, processesCreateEndpoint,
+	)
+	pid := created.ProcessID
+	job := enqueueAndPollJob(t, http.MethodPost, token, nil, "processes", pid, "publish")
+	c.Assert(job.Status, qt.Equals, db.JobStatusCompleted, qt.Commentf("publish job error: %s", job.Errors))
+
+	got := requestAndParse[apicommon.VotingProcessResponse](t, http.MethodGet, token, nil, "processes", pid)
+	c.Assert(signAs(t, pid, members[0], got.Questions[0].UpstreamID), qt.Equals, http.StatusOK)
+
+	// out of the census, still in the group, signature consumed for an election still READY
+	vp, err := testDB.VotingProcess(objectID(c, pid))
+	c.Assert(err, qt.IsNil)
+	_, _, err = testDB.RevokeMembersFromCensuses([]string{vp.CensusID.Hex()}, []string{ids[0]})
+	c.Assert(err, qt.IsNil)
+
+	// removing them from the group succeeds now: it strips them from no election they are in
+	_, code := testRequest(t, http.MethodPut, token, &apicommon.UpdateOrganizationMemberGroupsRequest{
+		RemoveMembers: []string{ids[0]},
+	}, "organizations", orgAddress.String(), "groups", group.ID)
+	c.Assert(code, qt.Equals, http.StatusOK)
+	stored, err := testDB.OrganizationMemberGroup(group.ID, orgAddress)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stored.MemberIDs, qt.Not(qt.Contains), ids[0])
+}
+
+// TestBlockedVotersScopedAndDeduped exercises the guard predicate directly: blocked means signed
+// for an ongoing election of a census the member still participates in, answered once per member
+// in the caller's order however many censuses block them or however often the caller repeats them.
+func TestBlockedVotersScopedAndDeduped(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateProvisionedOrganization(t, token)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	// two processes, each with its own census over the same members; members[0] signs on both
+	pid1, got1 := publishedProcess(t, token, orgAddress, ids)
+	pid2, got2 := publishedProcess(t, token, orgAddress, ids)
+	c.Assert(signAs(t, pid1, members[0], got1.Questions[0].UpstreamID), qt.Equals, http.StatusOK)
+	c.Assert(signAs(t, pid2, members[0], got2.Questions[0].UpstreamID), qt.Equals, http.StatusOK)
+	vp1, err := testDB.VotingProcess(objectID(c, pid1))
+	c.Assert(err, qt.IsNil)
+	vp2, err := testDB.VotingProcess(objectID(c, pid2))
+	c.Assert(err, qt.IsNil)
+	census1, census2 := vp1.CensusID.Hex(), vp2.CensusID.Hex()
+
+	// blocked by both censuses and repeated by the caller, yet answered once, in caller order
+	blocked, err := testAPI.blockedVoters([]string{census1, census2}, []string{ids[1], ids[0], ids[0]})
+	c.Assert(err, qt.IsNil)
+	c.Assert(blocked, qt.DeepEquals, []string{ids[0]})
+
+	// out of census1, their signature there stops blocking — while census2 still does
+	_, _, err = testDB.RevokeMembersFromCensuses([]string{census1}, []string{ids[0]})
+	c.Assert(err, qt.IsNil)
+	blocked, err = testAPI.blockedVoters([]string{census1}, []string{ids[0]})
+	c.Assert(err, qt.IsNil)
+	c.Assert(blocked, qt.HasLen, 0)
+	blocked, err = testAPI.blockedVoters([]string{census1, census2}, []string{ids[0]})
+	c.Assert(err, qt.IsNil)
+	c.Assert(blocked, qt.DeepEquals, []string{ids[0]})
+}
+
 // TestDeleteMembersIsOrgScoped pins that the member ids a caller submits are scoped to their own
 // organization before anything acts on them. The delete is org-scoped already, but the guard and
 // the revocation cascade resolve censuses from the ids alone: unscoped, an admin of one

--- a/api/org_members.go
+++ b/api/org_members.go
@@ -414,8 +414,8 @@ func (a *API) upsertOrganizationMemberHandler(w http.ResponseWriter, r *http.Req
 //	@Description	actually deleted and may be lower than the number of ids submitted.
 //	@Description
 //	@Description	Deletion is refused with 409 for any member the CSP has already signed for while a
-//	@Description	question of one of their processes is still READY or PAUSED; the offending ids come back
-//	@Description	in `data.signedMemberIds`. Once voting closes on those questions the deletion succeeds.
+//	@Description	question of a census they still participate in is READY or PAUSED; the offending ids come
+//	@Description	back in `data.signedMemberIds`. Once voting closes on those questions the deletion succeeds.
 //	@Description
 //	@Description	Also callable with a scoped API key (scope: `members:write`).
 //	@Tags			organizations

--- a/api/processes_admin.go
+++ b/api/processes_admin.go
@@ -487,7 +487,8 @@ func diffMemberIDs(previous, next []string) (added, removed []string) {
 //	@Description	eligibility list built on it, so the CSP stops signing for them. Refused with 409 for
 //	@Description	any member the CSP has already signed for while a question of the process is still
 //	@Description	READY or PAUSED; once voting closes on those questions the removal succeeds. The
-//	@Description	offending ids come back in `data.signedMemberIds`.
+//	@Description	offending ids come back in `data.signedMemberIds`. Members no longer in the census are
+//	@Description	removed as a no-op rather than refused.
 //	@Description
 //	@Description	Pruning a question's eligibility list to empty opens it to the whole census, so a
 //	@Description	maxCensusSize increase may be enqueued as an async job (poll GET /jobs/{jobId}).

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4207,8 +4207,8 @@ paths:
         actually deleted and may be lower than the number of ids submitted.
 
         Deletion is refused with 409 for any member the CSP has already signed for while a
-        question of one of their processes is still READY or PAUSED; the offending ids come back
-        in `data.signedMemberIds`. Once voting closes on those questions the deletion succeeds.
+        question of a census they still participate in is READY or PAUSED; the offending ids come
+        back in `data.signedMemberIds`. Once voting closes on those questions the deletion succeeds.
 
         Also callable with a scoped API key (scope: `members:write`).
       parameters:
@@ -6394,7 +6394,8 @@ paths:
         eligibility list built on it, so the CSP stops signing for them. Refused with 409 for
         any member the CSP has already signed for while a question of the process is still
         READY or PAUSED; once voting closes on those questions the removal succeeds. The
-        offending ids come back in `data.signedMemberIds`.
+        offending ids come back in `data.signedMemberIds`. Members no longer in the census are
+        removed as a no-op rather than refused.
 
         Pruning a question's eligibility list to empty opens it to the whole census, so a
         maxCensusSize increase may be enqueued as an async job (poll GET /jobs/{jobId}).


### PR DESCRIPTION
Closes #630. Refs #621.

**Stacked on #635** (`index_census_revocation`, itself stacked on #621's `feat/memberbase-census-sync`) — merge those first; this PR then carries only the one guard commit.

`blockedVoters` refused a removal when the CSP had signed for a member on **any** ongoing question of the affected censuses — the full censusIDs × memberIDs cross product. But the write it guards is pair-scoped: `revokeWrites` deletes `(census, member)` participant rows, so a member with no row in a census loses nothing there. A stale consumed `cspTokensStatus` row (they survive revocation by design — see step 4 of `revokeWrites`) for a census the member had already left could block, e.g., a member-delete whose census union only contained that census through *another* target member.

The guard now blocks a member only when they still **participate** in a census whose ongoing election they were signed for — the elections the removal would actually strip them from, the same per-election precision `refuseVotersLosingEligibility` already has.

- Checked per census, reusing the existing `CensusParticipantsByMemberIDs` / `OngoingQuestionsByCensuses` / `MembersWithUsedCSPProcesses` — no db-layer changes. The participant filter's exact `participantID` matching mirrors the revocation's own `$in` delete, so the guard refuses exactly what the write would remove.
- Question eligibility lists deliberately play **no** part in the predicate: a consumed signature is a live potential vote whatever the list says today, and the CSP sign gate checks participation, not eligibility. The `votes <= censusSize` invariant is preserved — a member with a signature but no participant row is already outside the count.
- **Behavioural change (409 → 200):** removals blocked only through censuses the member had already left now succeed. The `signedMemberIds` list (renamed from `votedMemberIds` by the base branch) is also answered once per member, in the caller's order (the old guard echoed duplicated request ids twice).
- Swag `@Description` wording tightened on the member DELETE and process-census DELETE; `make swagger` regenerated.

New tests: `TestMemberDeletionReleasedByStaleSignature` (the 409→200 flagship on the member-delete door), `TestGroupRemovalReleasedForNonParticipant` (group door), `TestBlockedVotersScopedAndDeduped` (predicate scoping, ordering and dedup, direct call). The existing refusal tests (`TestMemberDeletionRefusedForVoter`, `TestGroupCensusGuards`, `TestRemoveProcessCensusContract`, both org-scoping tests) pass unchanged and pin the still-blocks half.

## Verification

```
go build ./... && go vet ./...
golangci-lint run                # 0 issues
./scripts/check-qt-patterns.sh   # clean
make swagger                     # regenerated, wording-only diff
go test -count=1 ./api/ ./db/    # 506 passed
```
