### PR TITLE
feat(processes)!: name the ranked and cumulative question types

### DIFF
--- a/account/ballot.go
+++ b/account/ballot.go
@@ -207,6 +207,18 @@ func ValidateBallotProtocol(bp *db.BallotProtocol) error {
 			uint64(bp.MaxValue)+1, bp.MaxCount, bp.MaxCount, bp.MaxValue,
 		)
 	}
+	// maxValue 0 is the protocol's "values are aggregable amounts" marker: the per-value cap then
+	// comes from maxTotalCost (raised to costExponent) or, for a weighted election, the census
+	// weight (costFromWeight). With neither set the chain imposes no limit at all — a voter can put
+	// any uint32 on any field — so refuse it. Scoped to MaxCount > 1: at one field, maxValue 0 is
+	// also what a singlechoice over a single 0-valued choice derives, which is a legitimate ballot
+	// rather than the amounts-mode evasion this catches.
+	if bp.MaxValue == 0 && bp.MaxTotalCost == 0 && !bp.CostFromWeight && bp.MaxCount > 1 {
+		return fmt.Errorf(
+			"maxValue 0 with maxTotalCost 0 and costFromWeight false leaves every field unbounded: " +
+				"a cumulative ballot needs a budget (maxTotalCost > 0) or costFromWeight",
+		)
+	}
 	return nil
 }
 

--- a/account/ballot.go
+++ b/account/ballot.go
@@ -144,9 +144,12 @@ func QuestionTypeFromBallotProtocol(
 	if bp == nil || len(choices) == 0 {
 		return "", db.QuestionTypeSetup{}, false
 	}
-	// At most one candidate can ever match, whatever the order: each named type's image is disjoint
-	// from the others — ranked alone sets uniqueValues, cumulative alone sets maxValue 0,
-	// singlechoice alone sets maxCount 1 — pinned by TestBallotShapeUnambiguous.
+	// At most one candidate can ever match, whatever the order: each named type maps to a protocol
+	// image no other named type produces, so recognition is a function rather than a first-match
+	// heuristic. No single field is unique to one type — cumulative shares maxCount 1 with
+	// singlechoice at one choice, and maxValue 0 with singlechoice when its only choice is valued 0
+	// — but the full 7-field image is distinct for every pair (costExponent and maxTotalCost settle
+	// those degenerate cases), pinned by TestBallotShapeUnambiguous.
 	candidates := []struct {
 		qType string
 		setup db.QuestionTypeSetup

--- a/account/ballot.go
+++ b/account/ballot.go
@@ -6,8 +6,9 @@ import (
 	"github.com/vocdoni/saas-backend/db"
 )
 
-// A question describes its ballot twice: as a named type (singlechoice/multichoice) with its
-// TypeSetup, and as a raw BallotProtocol. This file keeps the two halves in step.
+// A question describes its ballot twice: as a named type (singlechoice, multichoice, ranked,
+// cumulative) with its TypeSetup, and as a raw BallotProtocol. This file keeps the two halves
+// in step.
 //
 // BallotProtocolFromType is the single mapping table, and the reverse direction is defined as
 // equality against it — QuestionTypeFromBallotProtocol asks "which named type would produce
@@ -54,14 +55,20 @@ func VoteTypeFromQuestion(q *db.VotingProcessQuestion) (db.VoteType, error) {
 }
 
 // BallotProtocolFromType derives the canonical on-chain ballot parameters of a named question
-// type. singlechoice picks one of N choices (one field, value = the chosen Choice.Value);
-// multichoice is approval-style (one field per choice, each 0/1, with MaxTotalCost bounding the
-// number of selections).
+// type:
+//   - singlechoice picks one of N choices (one field, value = the chosen Choice.Value);
+//   - multichoice is approval-style (one field per choice, each 0/1, with MaxTotalCost bounding
+//     the number of selections);
+//   - ranked assigns every choice a distinct rank (one field per choice holding its rank 0..N-1,
+//     so uniqueValues holds); the convention is highest-value-wins;
+//   - cumulative spreads a budget across the choices (maxValue 0 is the "amounts" marker; the
+//     per-value cap comes from MaxTotalCost and CostExponent, 1 for a linear budget or 2 for
+//     quadratic).
 //
 // setup.MinChoices has no protocol counterpart and is ignored — the chain has no minimum-count
-// field. setup.UniqueChoices is ignored too: a named type never produces a unique-values ballot,
-// because on the multichoice layout it would admit no vote (#619) and on singlechoice it is
-// vacuous. Callers reject it at the API boundary rather than silently dropping it.
+// field. setup.UniqueChoices is ignored too: the only named type that uses uniqueValues is ranked,
+// and it derives the flag from the type, not from this field. Callers reject a multichoice that
+// sets it at the API boundary rather than silently dropping it.
 //
 // MaxVoteOverwrites and CostFromWeight are always zero here: QuestionTypeSetup has no field that
 // could express them, so a protocol carrying either is simply not a named shape.
@@ -89,6 +96,32 @@ func BallotProtocolFromType(
 			CostExponent: 1,
 			MaxTotalCost: setup.MaxChoices,
 		}, nil
+	case db.VotingTypeRanked:
+		// Ranking needs at least two choices to mean anything. maxValue reaches N-1 so the N
+		// distinct ranks (0..N-1) fit, which is also what makes uniqueValues satisfiable.
+		if len(choices) < 2 {
+			return nil, fmt.Errorf("ranked ballot requires at least two choices")
+		}
+		return &db.BallotProtocol{
+			MaxCount:     uint32(len(choices)),
+			MaxValue:     uint32(len(choices) - 1),
+			UniqueValues: true,
+		}, nil
+	case db.VotingTypeCumulative:
+		// maxValue 0 is the protocol's "values are aggregable amounts" marker: each field holds a
+		// credit, bounded in total by MaxTotalCost (the budget) raised to CostExponent. CostExponent
+		// 1 is a linear budget, 2 is quadratic.
+		if setup.Budget == 0 {
+			return nil, fmt.Errorf("cumulative ballot requires a budget greater than zero")
+		}
+		if setup.CostExponent != 1 && setup.CostExponent != 2 {
+			return nil, fmt.Errorf("cumulative ballot costExponent must be 1 (linear) or 2 (quadratic)")
+		}
+		return &db.BallotProtocol{
+			MaxCount:     uint32(len(choices)),
+			CostExponent: setup.CostExponent,
+			MaxTotalCost: setup.Budget,
+		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported question type %q", qType)
 	}
@@ -99,8 +132,9 @@ func BallotProtocolFromType(
 // recognised only when BallotProtocolFromType reproduces the protocol exactly, so a recognised
 // type is guaranteed to re-derive the same on-chain parameters.
 //
-// ok is false for the shapes that have no named type — ranked, quadratic, anything using vote
-// overwrites or weighted cost — which stay expressible as a raw protocol.
+// ok is false for the shapes that have no named type — anything using vote overwrites or weighted
+// cost, or a cumulative/ranked protocol a client hand-crafted away from its canonical shape —
+// which stay expressible as a raw protocol.
 //
 // The choices are part of the question: a protocol whose MaxValue cannot carry the highest
 // Choice.Value is not singlechoice over those choices, however much it looks like one.
@@ -110,8 +144,9 @@ func QuestionTypeFromBallotProtocol(
 	if bp == nil || len(choices) == 0 {
 		return "", db.QuestionTypeSetup{}, false
 	}
-	// At most one candidate can ever match, whatever the order: CostExponent is unconditionally
-	// 0 for singlechoice and 1 for multichoice, so their images are always distinct.
+	// At most one candidate can ever match, whatever the order: each named type's image is disjoint
+	// from the others — ranked alone sets uniqueValues, cumulative alone sets maxValue 0,
+	// singlechoice alone sets maxCount 1 — pinned by TestBallotShapeUnambiguous.
 	candidates := []struct {
 		qType string
 		setup db.QuestionTypeSetup
@@ -120,6 +155,11 @@ func QuestionTypeFromBallotProtocol(
 		{db.VotingTypeMultiChoice, db.QuestionTypeSetup{
 			MinChoices: minChoicesFor(bp.MaxTotalCost),
 			MaxChoices: bp.MaxTotalCost,
+		}},
+		{db.VotingTypeRanked, db.QuestionTypeSetup{}},
+		{db.VotingTypeCumulative, db.QuestionTypeSetup{
+			Budget:       bp.MaxTotalCost,
+			CostExponent: bp.CostExponent,
 		}},
 	}
 	for _, candidate := range candidates {
@@ -213,9 +253,9 @@ type BallotShape struct {
 // half alone, and what keeps the API's answer equal to what the election will be.
 //
 // Supplying both halves is only allowed when they agree, or when the protocol has no named shape
-// (the ranked ballot a client may still label singlechoice). Two named shapes that disagree are an
-// error rather than a silent win for the protocol: a client editing a question through its
-// TypeSetup would otherwise get a 200 and none of its edit.
+// at all (vote overwrites, weighted cost, or a hand-crafted non-canonical shape). Two named shapes
+// that disagree are an error rather than a silent win for the protocol: a client editing a
+// question through its TypeSetup would otherwise get a 200 and none of its edit.
 //
 // MinChoices is the one thing that cannot be derived, having no on-chain counterpart, and is
 // carried over from the input for multichoice only, clamped to the resolved MaxChoices. A

--- a/account/ballot_test.go
+++ b/account/ballot_test.go
@@ -288,8 +288,9 @@ func TestBallotShapeUnambiguous(t *testing.T) {
 				protos = append(protos, named{qType, *bp})
 			}
 			// every named type well-defined over cs. A single multichoice representative suffices:
-			// maxChoices only changes its MaxTotalCost, and multichoice is the only type with
-			// maxValue 1, so no value of it can collide with another type's image.
+			// maxChoices only changes its MaxTotalCost, and multichoice is the only type whose image
+			// always carries uniqueValues:false with costExponent:1, so it can never collide with
+			// ranked (uniqueValues:true) or singlechoice (costExponent:0) for any maxTotalCost.
 			add(db.VotingTypeSingleChoice, db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1})
 			add(db.VotingTypeMultiChoice, db.QuestionTypeSetup{MaxChoices: uint32(n)})
 			if n >= 2 { // ranked needs at least two choices
@@ -475,6 +476,8 @@ func TestValidateBallotProtocol(t *testing.T) {
 			"one short of a permutation": {MaxCount: 4, MaxValue: 2, UniqueValues: true},
 			// one value short of a permutation, at the top of the uint32 range
 			"one short at the uint32 ceiling": {MaxCount: math.MaxUint32, MaxValue: math.MaxUint32 - 2, UniqueValues: true},
+			// amounts mode (maxValue 0) with no budget and no costFromWeight: every field unbounded
+			"unbounded cumulative": {MaxCount: 3, MaxValue: 0, CostExponent: 1, MaxTotalCost: 0},
 		} {
 			c.Assert(ValidateBallotProtocol(bp), qt.Not(qt.IsNil), qt.Commentf("%s", name))
 		}

--- a/account/ballot_test.go
+++ b/account/ballot_test.go
@@ -158,12 +158,42 @@ func TestBallotProtocolFromType(t *testing.T) {
 		})
 	})
 
+	c.Run("ranked derives a unique-values permutation", func(c *qt.C) {
+		bp, err := BallotProtocolFromType(db.VotingTypeRanked, db.QuestionTypeSetup{}, choices(3))
+		c.Assert(err, qt.IsNil)
+		want := db.BallotProtocol{MaxCount: 3, MaxValue: 2, UniqueValues: true}
+		c.Assert(*bp, qt.Equals, want)
+	})
+
+	c.Run("cumulative reads budget and costExponent, maxValue 0", func(c *qt.C) {
+		// linear budget (costExponent 1)
+		bp, err := BallotProtocolFromType(db.VotingTypeCumulative,
+			db.QuestionTypeSetup{Budget: 10, CostExponent: 1}, choices(3))
+		c.Assert(err, qt.IsNil)
+		c.Assert(*bp, qt.Equals, db.BallotProtocol{MaxCount: 3, CostExponent: 1, MaxTotalCost: 10})
+		// quadratic (costExponent 2) — same shape, different exponent
+		bp, err = BallotProtocolFromType(db.VotingTypeCumulative,
+			db.QuestionTypeSetup{Budget: 12, CostExponent: 2}, choices(3))
+		c.Assert(err, qt.IsNil)
+		c.Assert(*bp, qt.Equals, db.BallotProtocol{MaxCount: 3, CostExponent: 2, MaxTotalCost: 12})
+	})
+
 	c.Run("errors", func(c *qt.C) {
 		_, err := BallotProtocolFromType(db.VotingTypeSingleChoice, db.QuestionTypeSetup{}, nil)
 		c.Assert(err, qt.Not(qt.IsNil))
 		_, err = BallotProtocolFromType("", db.QuestionTypeSetup{}, choices(2))
 		c.Assert(err, qt.Not(qt.IsNil))
 		_, err = BallotProtocolFromType("quadratic", db.QuestionTypeSetup{}, choices(2))
+		c.Assert(err, qt.Not(qt.IsNil)) // quadratic is not a type name; it is cumulative exp 2
+		// ranked needs at least two choices to mean anything
+		_, err = BallotProtocolFromType(db.VotingTypeRanked, db.QuestionTypeSetup{}, choices(1))
+		c.Assert(err, qt.Not(qt.IsNil))
+		// cumulative needs a budget and a 1-or-2 exponent
+		_, err = BallotProtocolFromType(db.VotingTypeCumulative,
+			db.QuestionTypeSetup{Budget: 0, CostExponent: 2}, choices(3))
+		c.Assert(err, qt.Not(qt.IsNil))
+		_, err = BallotProtocolFromType(db.VotingTypeCumulative,
+			db.QuestionTypeSetup{Budget: 10, CostExponent: 3}, choices(3))
 		c.Assert(err, qt.Not(qt.IsNil))
 	})
 }
@@ -186,6 +216,20 @@ func TestQuestionTypeFromBallotProtocol(t *testing.T) {
 		c.Assert(ok, qt.IsTrue)
 		c.Assert(qType, qt.Equals, db.VotingTypeMultiChoice)
 		c.Assert(setup, qt.Equals, db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 2})
+
+		// ranked: the permutation ballot saas-integrator-demo sends, now named
+		qType, setup, ok = QuestionTypeFromBallotProtocol(
+			&db.BallotProtocol{MaxCount: 3, MaxValue: 2, UniqueValues: true}, choices(3))
+		c.Assert(ok, qt.IsTrue)
+		c.Assert(qType, qt.Equals, db.VotingTypeRanked)
+		c.Assert(setup, qt.Equals, db.QuestionTypeSetup{})
+
+		// cumulative: maxValue 0 is the "amounts" marker; budget and exponent come back as setup
+		qType, setup, ok = QuestionTypeFromBallotProtocol(
+			&db.BallotProtocol{MaxCount: 3, MaxValue: 0, CostExponent: 2, MaxTotalCost: 12}, choices(3))
+		c.Assert(ok, qt.IsTrue)
+		c.Assert(qType, qt.Equals, db.VotingTypeCumulative)
+		c.Assert(setup, qt.Equals, db.QuestionTypeSetup{Budget: 12, CostExponent: 2})
 	})
 
 	c.Run("an unbounded approval ballot is still multichoice", func(c *qt.C) {
@@ -198,8 +242,6 @@ func TestQuestionTypeFromBallotProtocol(t *testing.T) {
 
 	c.Run("shapes with no named type", func(c *qt.C) {
 		for name, bp := range map[string]*db.BallotProtocol{
-			// a ranking: n fields each holding a distinct rank 0..n-1
-			"ranked":            {MaxCount: 3, MaxValue: 2, UniqueValues: true},
 			"vote overwrites":   {MaxCount: 1, MaxValue: 2, MaxVoteOverwrites: 1},
 			"weighted cost":     {MaxCount: 1, MaxValue: 2, CostFromWeight: true},
 			"quadratic":         {MaxCount: 3, MaxValue: 4, CostExponent: 2, MaxTotalCost: 12},
@@ -227,23 +269,38 @@ func TestQuestionTypeFromBallotProtocol(t *testing.T) {
 	})
 }
 
-// TestBallotShapeUnambiguous guards the property the reverse direction rests on: the two named
-// types never produce the same protocol, so recognition is a function rather than a first-match
-// heuristic. If a future field change breaks this, recognition starts depending on candidate
-// order and this fails before anything subtler does.
+// TestBallotShapeUnambiguous guards the property the reverse direction rests on: the named types
+// never share a protocol image, so recognition is a function rather than a first-match heuristic.
+// If a future field change breaks this, recognition starts depending on candidate order and this
+// fails before anything subtler does.
 func TestBallotShapeUnambiguous(t *testing.T) {
 	c := qt.New(t)
 	for n := 1; n <= 8; n++ {
 		for _, cs := range [][]db.Choice{choices(n), valuedChoices(0, 2, 5)[:min(n, 3)]} {
-			for maxChoices := range uint32(n + 1) {
-				single, err := BallotProtocolFromType(db.VotingTypeSingleChoice,
-					db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1}, cs)
+			type named struct {
+				qType string
+				bp    db.BallotProtocol
+			}
+			var protos []named
+			add := func(qType string, setup db.QuestionTypeSetup) {
+				bp, err := BallotProtocolFromType(qType, setup, cs)
 				c.Assert(err, qt.IsNil)
-				multi, err := BallotProtocolFromType(db.VotingTypeMultiChoice,
-					db.QuestionTypeSetup{MaxChoices: maxChoices}, cs)
-				c.Assert(err, qt.IsNil)
-				c.Assert(*single, qt.Not(qt.Equals), *multi,
-					qt.Commentf("n=%d maxChoices=%d", n, maxChoices))
+				protos = append(protos, named{qType, *bp})
+			}
+			// every named type well-defined over cs. A single multichoice representative suffices:
+			// maxChoices only changes its MaxTotalCost, and multichoice is the only type with
+			// maxValue 1, so no value of it can collide with another type's image.
+			add(db.VotingTypeSingleChoice, db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1})
+			add(db.VotingTypeMultiChoice, db.QuestionTypeSetup{MaxChoices: uint32(n)})
+			if n >= 2 { // ranked needs at least two choices
+				add(db.VotingTypeRanked, db.QuestionTypeSetup{})
+			}
+			add(db.VotingTypeCumulative, db.QuestionTypeSetup{Budget: 10, CostExponent: 2})
+			for i, a := range protos {
+				for _, b := range protos[i+1:] {
+					c.Assert(a.bp, qt.Not(qt.Equals), b.bp,
+						qt.Commentf("n=%d %s == %s", n, a.qType, b.qType))
+				}
 			}
 		}
 	}
@@ -263,6 +320,8 @@ func TestResolveBallotShapeRoundTrip(t *testing.T) {
 		{Type: db.VotingTypeMultiChoice, TypeSetup: db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1}, Choices: choices(1)},
 		{Type: db.VotingTypeMultiChoice, TypeSetup: db.QuestionTypeSetup{MinChoices: 0, MaxChoices: 2}, Choices: choices(4)},
 		{Type: db.VotingTypeMultiChoice, TypeSetup: db.QuestionTypeSetup{MinChoices: 4, MaxChoices: 4}, Choices: choices(4)},
+		{Type: db.VotingTypeRanked, Choices: choices(3)},
+		{Type: db.VotingTypeCumulative, TypeSetup: db.QuestionTypeSetup{Budget: 10, CostExponent: 2}, Choices: choices(3)},
 	} {
 		shape, err := ResolveBallotShape(in)
 		c.Assert(err, qt.IsNil)
@@ -294,19 +353,45 @@ func TestResolveBallotShapeProtocolWins(t *testing.T) {
 	c := qt.New(t)
 
 	c.Run("an unnamed protocol empties the type", func(c *qt.C) {
-		// the shape saas-integrator-demo sends for a ranked question: a permutation ballot,
-		// labelled singlechoice because the API demanded some type
-		ranked := &db.BallotProtocol{MaxCount: 3, MaxValue: 2, UniqueValues: true}
+		// a shape with no named type at all — vote overwrites — labelled singlechoice: the
+		// protocol is kept, the type it cannot be named is dropped
+		unnamed := &db.BallotProtocol{MaxCount: 1, MaxValue: 2, MaxVoteOverwrites: 1}
 		shape, err := ResolveBallotShape(BallotShapeInput{
 			Type:      db.VotingTypeSingleChoice,
 			TypeSetup: db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1},
-			Protocol:  ranked,
+			Protocol:  unnamed,
 			Choices:   choices(3),
 		})
 		c.Assert(err, qt.IsNil)
 		c.Assert(shape.Type, qt.Equals, "")
 		c.Assert(shape.TypeSetup, qt.Equals, db.QuestionTypeSetup{})
+		c.Assert(*shape.Protocol, qt.Equals, *unnamed)
+	})
+
+	c.Run("a ranked protocol is now named, not emptied", func(c *qt.C) {
+		// the permutation ballot saas-integrator-demo sends is recognised as ranked; with no
+		// stated type it resolves to ranked rather than to the empty type it used to
+		ranked := &db.BallotProtocol{MaxCount: 3, MaxValue: 2, UniqueValues: true}
+		shape, err := ResolveBallotShape(BallotShapeInput{
+			Protocol: ranked,
+			Choices:  choices(3),
+		})
+		c.Assert(err, qt.IsNil)
+		c.Assert(shape.Type, qt.Equals, db.VotingTypeRanked)
+		c.Assert(shape.TypeSetup, qt.Equals, db.QuestionTypeSetup{})
 		c.Assert(*shape.Protocol, qt.Equals, *ranked)
+	})
+
+	c.Run("a ranked protocol mislabelled singlechoice is refused", func(c *qt.C) {
+		// the demo's old request shape (type singlechoice + ranked protocol) is now a
+		// disagreement, since ranked is a named type: send it as type ranked instead
+		_, err := ResolveBallotShape(BallotShapeInput{
+			Type:      db.VotingTypeSingleChoice,
+			TypeSetup: db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1},
+			Protocol:  &db.BallotProtocol{MaxCount: 3, MaxValue: 2, UniqueValues: true},
+			Choices:   choices(3),
+		})
+		c.Assert(err, qt.Not(qt.IsNil))
 	})
 
 	c.Run("two named halves that disagree are refused", func(c *qt.C) {
@@ -401,6 +486,7 @@ func TestValidateBallotProtocol(t *testing.T) {
 			"unique over one field": {MaxCount: 1, MaxValue: 0, UniqueValues: true},
 			"singlechoice":          {MaxCount: 1, MaxValue: 2},
 			"multichoice":           {MaxCount: 4, MaxValue: 1, CostExponent: 1, MaxTotalCost: 2},
+			"cumulative/quadratic":  {MaxCount: 3, MaxValue: 0, CostExponent: 2, MaxTotalCost: 12},
 			"quadratic":             {MaxCount: 3, MaxValue: 4, CostExponent: 2, MaxTotalCost: 12},
 			// exactly enough values for the fields, where maxValue+1 overflows uint32: computed in
 			// uint32 it wraps to 0 and this permutation reads as unsatisfiable
@@ -424,12 +510,13 @@ func TestEffectiveQuestionType(t *testing.T) {
 	})
 
 	c.Run("a legacy question whose type contradicts its protocol", func(c *qt.C) {
-		// stored before the halves were reconciled: labelled singlechoice, mints a ranking
+		// stored before the halves were reconciled: labelled singlechoice, mints a ranking. The
+		// effective type comes from the ballot, not the label, so it is ranked.
 		c.Assert(EffectiveQuestionType(&db.VotingProcessQuestion{
 			Type:           db.VotingTypeSingleChoice,
 			Choices:        choices(3),
 			BallotProtocol: &db.BallotProtocol{MaxCount: 3, MaxValue: 2, UniqueValues: true},
-		}), qt.Equals, "")
+		}), qt.Equals, db.VotingTypeRanked)
 	})
 
 	c.Run("a raw protocol that is a named shape", func(c *qt.C) {

--- a/api/processes.go
+++ b/api/processes.go
@@ -193,10 +193,26 @@ func (a *API) buildQuestions(
 							"independent yes/no field; use type %q for a ranked ballot", i, db.VotingTypeRanked,
 					)
 				}
-			case db.VotingTypeSingleChoice, db.VotingTypeRanked, db.VotingTypeCumulative:
-				// nothing the switch can usefully check: singlechoice and ranked ignore typeSetup,
-				// and cumulative's budget/costExponent are validated when the protocol is derived
-				// below (ResolveBallotShape -> BallotProtocolFromType).
+			case db.VotingTypeRanked:
+				// ranked uses no typeSetup: its protocol is fixed by the choices. Reject a non-empty
+				// setup rather than silently dropping it, so a client does not believe it set a
+				// constraint the ballot does not have.
+				if q.TypeSetup != (db.QuestionTypeSetup{}) {
+					return nil, errors.ErrInvalidData.Withf(
+						"question %d: type %q takes no typeSetup; its ballot is fixed by the choices", i, q.Type,
+					)
+				}
+			case db.VotingTypeCumulative:
+				// cumulative uses only budget/costExponent (validated when the protocol is derived);
+				// the multichoice fields do not apply, so reject them rather than silently dropping them.
+				if q.TypeSetup.MinChoices != 0 || q.TypeSetup.MaxChoices != 0 || q.TypeSetup.UniqueChoices {
+					return nil, errors.ErrInvalidData.Withf(
+						"question %d: minChoices, maxChoices and uniqueChoices apply only to multichoice; "+
+							"cumulative is configured through typeSetup.budget and typeSetup.costExponent", i,
+					)
+				}
+			case db.VotingTypeSingleChoice:
+				// singlechoice ignores typeSetup
 			default:
 				return nil, errors.ErrInvalidData.Withf("question %d: unsupported type %q", i, q.Type)
 			}

--- a/api/processes.go
+++ b/api/processes.go
@@ -46,13 +46,17 @@ func parseProcessDates(req *apicommon.CreateVotingProcessRequest) (start, end ti
 //	@Description	Create a multi-question voting process draft. Requires Manager/Admin role of the org
 //	@Description	(or a scoped API key with `voting:write`). Creates the inline census unpublished.
 //	@Description
-//	@Description	Each question must define a named `type` (with `typeSetup` for multichoice), a raw
-//	@Description	`ballotProtocol`, or both. The two are kept in sync: whichever is supplied, the other
-//	@Description	is derived, so the stored question always describes the election it will mint. A
-//	@Description	supplied `ballotProtocol` is authoritative — it is what reaches the chain — so `type`
-//	@Description	and `typeSetup` are re-derived from it, and come back empty when it encodes a shape
-//	@Description	with no named type (ranked, quadratic). Sending both halves is fine when they agree;
-//	@Description	when they describe two different named ballots it is a 400 rather than a silent win
+//	@Description	Each question must define a named `type` — `singlechoice`, `multichoice`, `ranked`
+//	@Description	or `cumulative` — a raw `ballotProtocol`, or both. `multichoice` and `cumulative`
+//	@Description	need a `typeSetup` (maxChoices for the former, budget and costExponent for the
+//	@Description	latter); `singlechoice` and `ranked` derive their whole protocol from the choices.
+//	@Description	The two are kept in sync: whichever is supplied, the other is derived, so the
+//	@Description	stored question always describes the election it will mint. A supplied
+//	@Description	`ballotProtocol` is authoritative — it is what reaches the chain — so `type`
+//	@Description	and `typeSetup` are re-derived from it, and come back empty only when it encodes a
+//	@Description	shape with no named type at all (vote overwrites, weighted cost, or a hand-crafted
+//	@Description	non-canonical shape). Sending both halves is fine when they agree; when they
+//	@Description	describe two different named ballots it is a 400 rather than a silent win
 //	@Description	for the protocol. **Omit `ballotProtocol` to author or edit a question through its
 //	@Description	`typeSetup`** — responses always carry a protocol, so echoing one back unchanged
 //	@Description	re-applies it.
@@ -163,15 +167,14 @@ func (a *API) buildQuestions(
 	for i, q := range questions {
 		// ballot shape: a question must define a named type, a raw BallotProtocol, or both. The
 		// two halves are reconciled below so they describe the same ballot; a supplied protocol
-		// is what the election will be, so it wins and the type is re-derived from it. For a
-		// named type, typeSetup is required for every type except singlechoice (which ignores it
-		// on chain); a multichoice maps MaxChoices onto MaxTotalCost so it must be bounded.
+		// is what the election will be, so it wins and the type is re-derived from it. typeSetup is
+		// required for multichoice and cumulative (singlechoice and ranked derive their whole
+		// protocol from the choices); a multichoice maps MaxChoices onto MaxTotalCost so it must be
+		// bounded.
 		if q.BallotProtocol == nil {
 			switch q.Type {
 			case "":
 				return nil, errors.ErrInvalidData.Withf("question %d: a type or a ballotProtocol is required", i)
-			case db.VotingTypeSingleChoice:
-				// singlechoice ignores typeSetup
 			case db.VotingTypeMultiChoice:
 				if q.TypeSetup.MaxChoices < 1 || q.TypeSetup.MaxChoices > uint32(len(q.Choices)) {
 					return nil, errors.ErrInvalidData.Withf(
@@ -187,9 +190,13 @@ func (a *API) buildQuestions(
 					// vote at all: the election would accept every envelope and tally zero.
 					return nil, errors.ErrInvalidData.Withf(
 						"question %d: uniqueChoices is not supported for multichoice, where each choice is an "+
-							"independent yes/no field; use a ballotProtocol for a ranked ballot", i,
+							"independent yes/no field; use type %q for a ranked ballot", i, db.VotingTypeRanked,
 					)
 				}
+			case db.VotingTypeSingleChoice, db.VotingTypeRanked, db.VotingTypeCumulative:
+				// nothing the switch can usefully check: singlechoice and ranked ignore typeSetup,
+				// and cumulative's budget/costExponent are validated when the protocol is derived
+				// below (ResolveBallotShape -> BallotProtocolFromType).
 			default:
 				return nil, errors.ErrInvalidData.Withf("question %d: unsupported type %q", i, q.Type)
 			}
@@ -1002,7 +1009,7 @@ func validateVotingProcessForPublish(
 		if len(q.Choices) == 0 {
 			problems = append(problems, fmt.Sprintf("question %d has no choices", i))
 		}
-		if q.BallotProtocol == nil && q.Type != db.VotingTypeSingleChoice && q.Type != db.VotingTypeMultiChoice {
+		if q.BallotProtocol == nil && !db.IsNamedVotingType(q.Type) {
 			problems = append(problems, fmt.Sprintf("question %d has an unsupported type %q", i, q.Type))
 		}
 		// A question stored before authoring rejected these can still hold a ballot no voter can

--- a/api/processes_publish.go
+++ b/api/processes_publish.go
@@ -109,19 +109,16 @@ func (a *API) publishPreflightProblems(
 	// than the type it is labelled with: a stored type is only a label, and a question written
 	// before the two halves were reconciled may carry one its protocol contradicts.
 	//
-	// Shapes with no named type (ranked, quadratic) resolve to an empty type and are gated
-	// nowhere: not here, and not on the build path either — hasElectionMetadataPermissions still
-	// carries the TODO for it, and plan.VotingTypes has no flag anything can resolve to (see the
-	// TODO on OrgAllowsVotingType's allowed map). That is pre-existing, and unchanged by this
-	// gate, but it is not "gated elsewhere".
+	// EffectiveQuestionType recognises the four named types (singlechoice, multichoice, ranked,
+	// cumulative) from their canonical protocol and gates each on its plan flag, so a raw protocol
+	// that encodes one of them is gated too — the label cannot be dropped to evade the plan.
 	//
-	// This tightens what main did — which skipped the gate for every raw protocol — but does not
-	// close it. EffectiveQuestionType recognises a shape only when it is exactly canonical, which
-	// is what storage needs and what authorization does not: {maxCount:2, maxValue:1,
-	// maxTotalCost:2} is the same ballot as the multichoice one field-for-field bar costExponent,
-	// and stays ungated. Actually holding the gate needs a deliberately loose classifier
-	// (maxValue == 1 && maxCount > 1 ⇒ effectively multiple-choice, whatever else is set), not
-	// this one.
+	// What still slips through is a protocol that is *almost* canonical: {maxCount:2, maxValue:1,
+	// maxTotalCost:2} is the multichoice ballot field-for-field bar costExponent, so it is not
+	// recognised and stays ungated. EffectiveQuestionType recognises a shape only when it is
+	// exactly canonical, which is what storage needs and what authorization does not. Actually
+	// holding the gate needs a deliberately loose classifier (maxValue == 1 && maxCount > 1 ⇒
+	// effectively multiple-choice, whatever else is set), not this one.
 	for i := range questions {
 		if err := a.subscriptions.OrgAllowsVotingType(vp.OrgAddress, account.EffectiveQuestionType(&questions[i])); err != nil {
 			problems = append(problems, err.Error())

--- a/api/processes_publish.go
+++ b/api/processes_publish.go
@@ -120,6 +120,12 @@ func (a *API) publishPreflightProblems(
 	// holding the gate needs a deliberately loose classifier (maxValue == 1 && maxCount > 1 ⇒
 	// effectively multiple-choice, whatever else is set), not this one.
 	for i := range questions {
+		// a question that already mined (UpstreamID set) is immutable on chain: its type cannot be
+		// changed, and gating it would only block a resume that mints the remaining questions. So the
+		// voting-type gate covers only questions still pending their first publish.
+		if len(questions[i].UpstreamID) > 0 {
+			continue
+		}
 		if err := a.subscriptions.OrgAllowsVotingType(vp.OrgAddress, account.EffectiveQuestionType(&questions[i])); err != nil {
 			problems = append(problems, err.Error())
 		}

--- a/api/processes_test.go
+++ b/api/processes_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vocdoni/saas-backend/api/apicommon"
 	"github.com/vocdoni/saas-backend/db"
 	"github.com/vocdoni/saas-backend/errors"
+	"github.com/vocdoni/saas-backend/internal"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	dvoteapi "go.vocdoni.io/dvote/api"
 	"go.vocdoni.io/dvote/types"
@@ -335,6 +336,18 @@ func TestVotingProcessAuthoringErrors(t *testing.T) {
 	cumulativeBadExp.Questions[0].Type = db.VotingTypeCumulative
 	cumulativeBadExp.Questions[0].TypeSetup = db.QuestionTypeSetup{Budget: 10, CostExponent: 3}
 	requestAndAssertError(errors.ErrInvalidData, t, http.MethodPost, adminToken, cumulativeBadExp, processesCreateEndpoint)
+
+	// ranked takes no typeSetup; a non-empty one is rejected, not silently dropped -> 400
+	rankedSetup := newVotingProcessRequest(orgAddress, ids)
+	rankedSetup.Questions[0].Type = db.VotingTypeRanked
+	rankedSetup.Questions[0].TypeSetup = db.QuestionTypeSetup{MaxChoices: 2}
+	requestAndAssertError(errors.ErrInvalidData, t, http.MethodPost, adminToken, rankedSetup, processesCreateEndpoint)
+
+	// cumulative uses only budget/costExponent; the multichoice fields are rejected -> 400
+	cumulativeSpurious := newVotingProcessRequest(orgAddress, ids)
+	cumulativeSpurious.Questions[0].Type = db.VotingTypeCumulative
+	cumulativeSpurious.Questions[0].TypeSetup = db.QuestionTypeSetup{Budget: 10, CostExponent: 2, MaxChoices: 3}
+	requestAndAssertError(errors.ErrInvalidData, t, http.MethodPost, adminToken, cumulativeSpurious, processesCreateEndpoint)
 
 	// multichoice + uniqueChoices -> 400. Each choice is its own 0/1 field, so a unique-values
 	// ballot over them admits no vote: the election used to be accepted and then tally every
@@ -1185,4 +1198,58 @@ func TestVotingProcessPlanGateOnEffectiveType(t *testing.T) {
 	val = requestAndParse[apicommon.VotingProcessValidateResponse](
 		t, http.MethodGet, token, nil, "processes", created.ProcessID, "validation")
 	c.Assert(val.Valid, qt.IsFalse, qt.Commentf("a plan without ranked must not mint a ranked ballot: %v", val.Errors))
+}
+
+// TestVotingProcessPublishGateSkipsMinted covers the resume case: a question that already mined
+// (UpstreamID set) is immutable on chain, so the voting-type gate must skip it. Otherwise a plan
+// change after a partial publish wedges the process — the remaining questions can never be minted
+// while the mined one's election is live.
+func TestVotingProcessPublishGateSkipsMinted(t *testing.T) {
+	c := qt.New(t)
+	token := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, token)
+
+	singleOnlyPlan := *mockEssentialPlan
+	singleOnlyPlan.ID = "prod_test_single_only_minted"
+	singleOnlyPlan.Name = "Single Only (minted)"
+	singleOnlyPlan.StripeMonthlyPriceID = "price_month_test_single_only_minted"
+	singleOnlyPlan.StripeYearlyPriceID = "price_year_test_single_only_minted"
+	singleOnlyPlan.Public = false
+	singleOnlyPlan.VotingTypes.Multiple = false
+	singleOnlyPlan.VotingTypes.Ranked = false
+	c.Assert(testDB.SetPlan(&singleOnlyPlan), qt.IsNil)
+	setOrganizationSubscription(t, orgAddress, singleOnlyPlan.ID)
+
+	members := postOrgMembers(t, token, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	// a ranked ballot over 2 choices; create does not gate voting type, only publish preflight does
+	req := newVotingProcessRequest(orgAddress, ids)
+	req.Questions = req.Questions[:1]
+	req.Questions[0].Type = ""
+	req.Questions[0].TypeSetup = db.QuestionTypeSetup{}
+	req.Questions[0].BallotProtocol = &db.BallotProtocol{MaxCount: 2, MaxValue: 1, UniqueValues: true}
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, token, req, processesCreateEndpoint)
+
+	// before mining: the plan has no Ranked flag, so the unmined question is gated
+	val := requestAndParse[apicommon.VotingProcessValidateResponse](
+		t, http.MethodGet, token, nil, "processes", created.ProcessID, "validation")
+	c.Assert(val.Valid, qt.IsFalse, qt.Commentf("unmined ranked question must be gated"))
+
+	// simulate the question having already mined on chain (UpstreamID set)
+	oid, err := primitive.ObjectIDFromHex(created.ProcessID)
+	c.Assert(err, qt.IsNil)
+	stored, err := testDB.QuestionsByProcess(oid)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stored, qt.HasLen, 1)
+	stored[0].UpstreamID = internal.HexBytes{0xab, 0xcd, 0xef, 0x01}
+	_, err = testDB.SetQuestion(&stored[0])
+	c.Assert(err, qt.IsNil)
+
+	// after mining: the gate skips it (immutable), so validation no longer reports the type — a
+	// resume can still mint the remaining questions
+	val = requestAndParse[apicommon.VotingProcessValidateResponse](
+		t, http.MethodGet, token, nil, "processes", created.ProcessID, "validation")
+	c.Assert(val.Valid, qt.IsTrue, qt.Commentf("a minted question must not block the process: %v", val.Errors))
 }

--- a/api/processes_test.go
+++ b/api/processes_test.go
@@ -317,6 +317,25 @@ func TestVotingProcessAuthoringErrors(t *testing.T) {
 	badType.Questions[0].Type = "quadratic"
 	requestAndAssertError(errors.ErrInvalidData, t, http.MethodPost, adminToken, badType, processesCreateEndpoint)
 
+	// ranked needs at least two choices to rank -> 400
+	rankedTooFew := newVotingProcessRequest(orgAddress, ids)
+	rankedTooFew.Questions[0].Type = db.VotingTypeRanked
+	rankedTooFew.Questions[0].Choices = rankedTooFew.Questions[0].Choices[:1]
+	rankedTooFew.Questions[0].TypeSetup = db.QuestionTypeSetup{}
+	requestAndAssertError(errors.ErrInvalidData, t, http.MethodPost, adminToken, rankedTooFew, processesCreateEndpoint)
+
+	// cumulative needs a budget greater than zero -> 400
+	cumulativeNoBudget := newVotingProcessRequest(orgAddress, ids)
+	cumulativeNoBudget.Questions[0].Type = db.VotingTypeCumulative
+	cumulativeNoBudget.Questions[0].TypeSetup = db.QuestionTypeSetup{Budget: 0, CostExponent: 2}
+	requestAndAssertError(errors.ErrInvalidData, t, http.MethodPost, adminToken, cumulativeNoBudget, processesCreateEndpoint)
+
+	// cumulative costExponent must be 1 (linear) or 2 (quadratic) -> 400
+	cumulativeBadExp := newVotingProcessRequest(orgAddress, ids)
+	cumulativeBadExp.Questions[0].Type = db.VotingTypeCumulative
+	cumulativeBadExp.Questions[0].TypeSetup = db.QuestionTypeSetup{Budget: 10, CostExponent: 3}
+	requestAndAssertError(errors.ErrInvalidData, t, http.MethodPost, adminToken, cumulativeBadExp, processesCreateEndpoint)
+
 	// multichoice + uniqueChoices -> 400. Each choice is its own 0/1 field, so a unique-values
 	// ballot over them admits no vote: the election used to be accepted and then tally every
 	// vote to zero, reporting nothing anywhere (issue #619).
@@ -1032,15 +1051,25 @@ func TestVotingProcessBallotShapeConsistency(t *testing.T) {
 	}
 }
 
-// TestVotingProcessRankedBallotProtocol covers the shape saas-integrator-demo sends for a ranked
-// question: a permutation ballot (n fields, values 0..n-1, all distinct) carried by a raw protocol,
-// labelled singlechoice because the API used to demand a type. That ballot is satisfiable and must
-// keep working — the type it was labelled with is what goes, since it was never true.
+// TestVotingProcessRankedBallotProtocol covers ranked as a named type: a question authored as
+// type "ranked" reads back as ranked, carries the unique-values permutation protocol the type
+// derives, and is publishable under a plan that grants Ranked.
 func TestVotingProcessRankedBallotProtocol(t *testing.T) {
 	c := qt.New(t)
 	adminToken := testCreateUser(t, "adminpassword123")
 	orgAddress := testCreateOrganization(t, adminToken)
-	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID)
+
+	// mockEssentialPlan allows drafts (MaxDrafts 5) but grants no Ranked, so clone it with Ranked
+	// on for this test.
+	rankedPlan := *mockEssentialPlan
+	rankedPlan.ID = "prod_test_ranked"
+	rankedPlan.Name = "Ranked Plan"
+	rankedPlan.StripeMonthlyPriceID = "price_month_test_ranked"
+	rankedPlan.StripeYearlyPriceID = "price_year_test_ranked"
+	rankedPlan.Public = false
+	rankedPlan.VotingTypes.Ranked = true
+	c.Assert(testDB.SetPlan(&rankedPlan), qt.IsNil)
+	setOrganizationSubscription(t, orgAddress, rankedPlan.ID)
 	members := postOrgMembers(t, adminToken, orgAddress, newOrgMembers(2)...)
 	ids := memberIDs(members)
 
@@ -1052,35 +1081,65 @@ func TestVotingProcessRankedBallotProtocol(t *testing.T) {
 		{Title: db.MultiLangString{"default": "B"}, Value: 1},
 		{Title: db.MultiLangString{"default": "C"}, Value: 2},
 	}
-	req.Questions[0].Type = db.VotingTypeSingleChoice
-	req.Questions[0].TypeSetup = db.QuestionTypeSetup{MinChoices: 1, MaxChoices: 1}
-	req.Questions[0].BallotProtocol = ranked
+	req.Questions[0].Type = db.VotingTypeRanked
+	req.Questions[0].TypeSetup = db.QuestionTypeSetup{}
 
 	created := requestAndParse[apicommon.CreateVotingProcessResponse](
 		t, http.MethodPost, adminToken, req, processesCreateEndpoint)
 	got := requestAndParse[apicommon.VotingProcessResponse](
 		t, http.MethodGet, adminToken, nil, "processes", created.ProcessID)
 	c.Assert(got.Questions, qt.HasLen, 1)
-	c.Assert(*got.Questions[0].BallotProtocol, qt.Equals, *ranked)
-	// a ranking has no named type, so the question stops claiming one rather than claiming a
-	// wrong one
-	c.Assert(got.Questions[0].Type, qt.Equals, "")
+	c.Assert(got.Questions[0].Type, qt.Equals, db.VotingTypeRanked)
 	c.Assert(got.Questions[0].TypeSetup, qt.Equals, db.QuestionTypeSetup{})
+	c.Assert(*got.Questions[0].BallotProtocol, qt.Equals, *ranked)
 
-	// and it is still publishable: the plan's voting-type gate gates named types, and this shape
-	// has none (mockEssentialPlan does not grant Ranked either way).
-	// NOTE: ungated is today's behaviour, not a guarantee — plan.VotingTypes.Ranked is enforced
-	// nowhere (see the TODO in subscriptions.OrgAllowsVotingType). This assertion has to flip for
-	// a plan without Ranked once it is.
+	validation := requestAndParse[apicommon.VotingProcessValidateResponse](
+		t, http.MethodGet, adminToken, nil, "processes", created.ProcessID, "validation")
+	c.Assert(validation.Valid, qt.IsTrue, qt.Commentf("errors: %v", validation.Errors))
+}
+
+// TestVotingProcessCumulativeBallotType covers cumulative (budget/quadratic) as a named type: a
+// question authored as type "cumulative" with a budget and costExponent reads back with both, and
+// is publishable under a plan that grants Cumulative.
+func TestVotingProcessCumulativeBallotType(t *testing.T) {
+	c := qt.New(t)
+	adminToken := testCreateUser(t, "adminpassword123")
+	orgAddress := testCreateOrganization(t, adminToken)
+	setOrganizationSubscription(t, orgAddress, mockEssentialPlan.ID) // Cumulative is granted
+	members := postOrgMembers(t, adminToken, orgAddress, newOrgMembers(2)...)
+	ids := memberIDs(members)
+
+	// quadratic: a budget of 12 credits, squared, spread across 3 choices
+	setup := db.QuestionTypeSetup{Budget: 12, CostExponent: 2}
+	quadratic := &db.BallotProtocol{MaxCount: 3, MaxValue: 0, CostExponent: 2, MaxTotalCost: 12}
+	req := newVotingProcessRequest(orgAddress, ids)
+	req.Questions = req.Questions[:1]
+	req.Questions[0].Choices = []db.Choice{
+		{Title: db.MultiLangString{"default": "A"}, Value: 0},
+		{Title: db.MultiLangString{"default": "B"}, Value: 1},
+		{Title: db.MultiLangString{"default": "C"}, Value: 2},
+	}
+	req.Questions[0].Type = db.VotingTypeCumulative
+	req.Questions[0].TypeSetup = setup
+
+	created := requestAndParse[apicommon.CreateVotingProcessResponse](
+		t, http.MethodPost, adminToken, req, processesCreateEndpoint)
+	got := requestAndParse[apicommon.VotingProcessResponse](
+		t, http.MethodGet, adminToken, nil, "processes", created.ProcessID)
+	c.Assert(got.Questions, qt.HasLen, 1)
+	c.Assert(got.Questions[0].Type, qt.Equals, db.VotingTypeCumulative)
+	c.Assert(got.Questions[0].TypeSetup, qt.Equals, setup)
+	c.Assert(*got.Questions[0].BallotProtocol, qt.Equals, *quadratic)
+
 	validation := requestAndParse[apicommon.VotingProcessValidateResponse](
 		t, http.MethodGet, adminToken, nil, "processes", created.ProcessID, "validation")
 	c.Assert(validation.Valid, qt.IsTrue, qt.Commentf("errors: %v", validation.Errors))
 }
 
 // TestVotingProcessPlanGateOnEffectiveType covers the gate a raw ballotProtocol used to walk past:
-// the plan's voting-type limits apply to the ballot a question encodes, not to the label it
-// carries, so an org whose plan forbids multiple-choice cannot mint one by describing it in raw
-// terms. A shape with no named type stays ungated — that is what the raw protocol is for.
+// the plan's voting-type limits apply to the ballot a question encodes, not the label it carries,
+// so an org whose plan forbids a type cannot mint one by describing it in raw terms. Ranked is a
+// named type now, so a raw ranked protocol is gated on plan.VotingTypes.Ranked like any other.
 func TestVotingProcessPlanGateOnEffectiveType(t *testing.T) {
 	c := qt.New(t)
 	token := testCreateUser(t, "adminpassword123")
@@ -1093,13 +1152,14 @@ func TestVotingProcessPlanGateOnEffectiveType(t *testing.T) {
 	singleOnlyPlan.StripeYearlyPriceID = "price_year_test_single_only"
 	singleOnlyPlan.Public = false
 	singleOnlyPlan.VotingTypes.Multiple = false
+	singleOnlyPlan.VotingTypes.Ranked = false
 	c.Assert(testDB.SetPlan(&singleOnlyPlan), qt.IsNil)
 	setOrganizationSubscription(t, orgAddress, singleOnlyPlan.ID)
 
 	members := postOrgMembers(t, token, orgAddress, newOrgMembers(2)...)
 	ids := memberIDs(members)
 
-	// a multichoice ballot, stated in raw terms and with no type at all
+	// a multichoice ballot, stated in raw terms and with no type at all, is gated on multiple
 	rawMulti := newVotingProcessRequest(orgAddress, ids)
 	rawMulti.Questions = rawMulti.Questions[:1]
 	rawMulti.Questions[0].Type = ""
@@ -1113,15 +1173,16 @@ func TestVotingProcessPlanGateOnEffectiveType(t *testing.T) {
 		t, http.MethodGet, token, nil, "processes", created.ProcessID, "validation")
 	c.Assert(val.Valid, qt.IsFalse, qt.Commentf("a plan without multiple-choice must not mint one"))
 
-	// the same org can still publish a ranked ballot: it has no named type to gate
-	ranked := newVotingProcessRequest(orgAddress, ids)
-	ranked.Questions = ranked.Questions[:1]
-	ranked.Questions[0].Type = ""
-	ranked.Questions[0].TypeSetup = db.QuestionTypeSetup{}
-	ranked.Questions[0].BallotProtocol = &db.BallotProtocol{MaxCount: 2, MaxValue: 1, UniqueValues: true}
+	// a ranked ballot stated the same way is gated on ranked: the raw protocol is recognised as
+	// the named type, so dropping the label no longer evades the plan
+	rawRanked := newVotingProcessRequest(orgAddress, ids)
+	rawRanked.Questions = rawRanked.Questions[:1]
+	rawRanked.Questions[0].Type = ""
+	rawRanked.Questions[0].TypeSetup = db.QuestionTypeSetup{}
+	rawRanked.Questions[0].BallotProtocol = &db.BallotProtocol{MaxCount: 2, MaxValue: 1, UniqueValues: true}
 	created = requestAndParse[apicommon.CreateVotingProcessResponse](
-		t, http.MethodPost, token, ranked, processesCreateEndpoint)
+		t, http.MethodPost, token, rawRanked, processesCreateEndpoint)
 	val = requestAndParse[apicommon.VotingProcessValidateResponse](
 		t, http.MethodGet, token, nil, "processes", created.ProcessID, "validation")
-	c.Assert(val.Valid, qt.IsTrue, qt.Commentf("errors: %v", val.Errors))
+	c.Assert(val.Valid, qt.IsFalse, qt.Commentf("a plan without ranked must not mint a ranked ballot: %v", val.Errors))
 }

--- a/db/const.go
+++ b/db/const.go
@@ -36,7 +36,20 @@ const (
 	// Voting-process question ballot types (translated into on-chain vote options).
 	VotingTypeSingleChoice = "singlechoice"
 	VotingTypeMultiChoice  = "multichoice"
+	VotingTypeRanked       = "ranked"
+	VotingTypeCumulative   = "cumulative"
 )
+
+// IsNamedVotingType reports whether t is one of the named question ballot types the question API
+// accepts (singlechoice, multichoice, ranked, cumulative). A raw ballotProtocol is always allowed
+// alongside any of these, so callers use this only to guard a question that carries no protocol.
+func IsNamedVotingType(t string) bool {
+	switch t {
+	case VotingTypeSingleChoice, VotingTypeMultiChoice, VotingTypeRanked, VotingTypeCumulative:
+		return true
+	}
+	return false
+}
 
 // organizationWritePermissions is a map that contains if the role has organization write permission
 var organizationWritePermissions = map[UserRole]bool{

--- a/db/types.go
+++ b/db/types.go
@@ -646,24 +646,30 @@ type ProcessesBundle struct {
 // is the one value that cannot be derived. It is kept as sent for multichoice (clamped to
 // MaxChoices), where a voter may legitimately be asked for at least N; for singlechoice it is
 // always 1, that ballot being the single field a voter fills, so a stated 0 would describe a
-// submission the chain cannot express. UniqueChoices is not supported by either named type
-// and requests setting it on a multichoice are rejected: with one 0/1 field per choice, a
+// submission the chain cannot express. UniqueChoices is not supported by any named type and
+// requests setting it on a multichoice are rejected: with one 0/1 field per choice, a
 // unique-values ballot admits no vote at all (issue #619), while a voter already cannot select
-// the same choice twice. A ranked ballot is expressed as a BallotProtocol instead.
+// the same choice twice. A ranked ballot — the one shape that does use uniqueValues — is its own
+// named type and derives that flag from the type, not from this field.
+//
+// Budget and CostExponent parametrise a cumulative ballot (budget/quadratic): Budget is the total
+// credit a voter may spread across the choices (the protocol's MaxTotalCost) and CostExponent is 1
+// for a linear budget or 2 for quadratic. They are ignored by every other type.
 type QuestionTypeSetup struct {
 	MinChoices    uint32 `json:"minChoices" bson:"minChoices"`
 	MaxChoices    uint32 `json:"maxChoices" bson:"maxChoices"`
 	UniqueChoices bool   `json:"uniqueChoices" bson:"uniqueChoices"`
+	Budget        uint32 `json:"budget" bson:"budget"`
+	CostExponent  uint32 `json:"costExponent" bson:"costExponent"`
 }
 
 // BallotProtocol is the on-chain ballot parameters of a VotingProcessQuestion, mapped directly
 // onto the election envelope and vote options. Every question written since the two halves were
 // reconciled carries one, derived from Type/TypeSetup when the client did not supply it.
 //
-// A client may supply it instead of a named type, which is what enables the ballot shapes that
-// have no name yet (ranked, quadratic). Supplying it alongside a type makes it authoritative —
-// it is what reaches the chain — so the type is re-derived from it, and emptied when it encodes
-// no named shape.
+// A client may supply it instead of a named type, which is what enables ballot shapes beyond the
+// named ones. Supplying it alongside a type makes it authoritative — it is what reaches the chain
+// — so the type is re-derived from it, and emptied when it encodes no named shape.
 type BallotProtocol struct {
 	MaxCount          uint32 `json:"maxCount" bson:"maxCount"`
 	MaxValue          uint32 `json:"maxValue" bson:"maxValue"`

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2351,6 +2351,10 @@ definitions:
     type: object
   db.QuestionTypeSetup:
     properties:
+      budget:
+        type: integer
+      costExponent:
+        type: integer
       maxChoices:
         type: integer
       minChoices:
@@ -5993,13 +5997,17 @@ paths:
         Create a multi-question voting process draft. Requires Manager/Admin role of the org
         (or a scoped API key with `voting:write`). Creates the inline census unpublished.
 
-        Each question must define a named `type` (with `typeSetup` for multichoice), a raw
-        `ballotProtocol`, or both. The two are kept in sync: whichever is supplied, the other
-        is derived, so the stored question always describes the election it will mint. A
-        supplied `ballotProtocol` is authoritative — it is what reaches the chain — so `type`
-        and `typeSetup` are re-derived from it, and come back empty when it encodes a shape
-        with no named type (ranked, quadratic). Sending both halves is fine when they agree;
-        when they describe two different named ballots it is a 400 rather than a silent win
+        Each question must define a named `type` — `singlechoice`, `multichoice`, `ranked`
+        or `cumulative` — a raw `ballotProtocol`, or both. `multichoice` and `cumulative`
+        need a `typeSetup` (maxChoices for the former, budget and costExponent for the
+        latter); `singlechoice` and `ranked` derive their whole protocol from the choices.
+        The two are kept in sync: whichever is supplied, the other is derived, so the
+        stored question always describes the election it will mint. A supplied
+        `ballotProtocol` is authoritative — it is what reaches the chain — so `type`
+        and `typeSetup` are re-derived from it, and come back empty only when it encodes a
+        shape with no named type at all (vote overwrites, weighted cost, or a hand-crafted
+        non-canonical shape). Sending both halves is fine when they agree; when they
+        describe two different named ballots it is a 400 rather than a silent win
         for the protocol. **Omit `ballotProtocol` to author or edit a question through its
         `typeSetup`** — responses always carry a protocol, so echoing one back unchanged
         re-applies it.

--- a/subscriptions/subscriptions.go
+++ b/subscriptions/subscriptions.go
@@ -110,8 +110,13 @@ func hasElectionMetadataPermissions(process *models.NewProcessTx, plan *db.Plan)
 		return false, fmt.Errorf("duration is greater than the allowed")
 	}
 
-	// The election voting type is gated per-question at publish preflight (OrgAllowsVotingType),
-	// not here: this check runs on an already-built tx that has no question type attached.
+	// TODO:future the voting-type plan gate (plan.VotingTypes.{Single,Multiple,Ranked,Cumulative})
+	// runs only at /processes publish preflight (OrgAllowsVotingType), not here — so POST
+	// /transactions and the legacy /process build path, which both build a NewProcessTx and route
+	// through HasTxPermission, bypass it: an org whose plan lacks a flag can still get that ballot
+	// signed. The tx carries the full ballot shape (VoteOptions + EnvelopeType map 1:1 to a
+	// BallotProtocol), so the gate can be closed here by recognising the type from the tx and
+	// checking it against the plan.
 	// TODO:future check if the streamURL is used and allowed by the plan
 
 	return true, nil
@@ -472,8 +477,9 @@ func (p *Subscriptions) OrgCanPublishCensus(census *db.Census, notifyCount, vote
 // census size vs plan MaxCensus, per-org MaxProcesses count (non-managed), weighted allowance
 // and duration — mirroring the NEW_PROCESS checks in HasTxPermission so the /processes publish
 // path can surface them synchronously (as a 400 and in the dry-run) instead of as an opaque
-// async job failure. The authoritative enforcement remains HasTxPermission at build time; this
-// is an early, predictable subset. Anonymous/vote-overwrite are not used by the /processes flow.
+// async job failure. Every check here has a HasTxPermission twin at build time — except the
+// per-question voting type, which is enforced only at this preflight (see the TODO in
+// hasElectionMetadataPermissions). Anonymous/vote-overwrite are not used by the /processes flow.
 // Admin role is verified by the caller.
 //
 //nolint:revive // weighted is an election attribute being validated, not a control flag

--- a/subscriptions/subscriptions.go
+++ b/subscriptions/subscriptions.go
@@ -110,7 +110,8 @@ func hasElectionMetadataPermissions(process *models.NewProcessTx, plan *db.Plan)
 		return false, fmt.Errorf("duration is greater than the allowed")
 	}
 
-	// TODO:future check if the election voting type is supported by the plan
+	// The election voting type is gated per-question at publish preflight (OrgAllowsVotingType),
+	// not here: this check runs on an already-built tx that has no question type attached.
 	// TODO:future check if the streamURL is used and allowed by the plan
 
 	return true, nil
@@ -319,11 +320,11 @@ func (p *Subscriptions) OrgCanCreateVotingProcessDraft(orgAddress common.Address
 
 // OrgAllowsVotingType checks that the organization's plan permits the given question ballot
 // type. It maps the friendly type to the plan's VotingTypes feature flags. An empty type is
-// allowed (it is validated elsewhere), which is also how a ballot shape with no named type —
-// ranked, quadratic, expressed as a raw ballotProtocol — passes: there is no flag for it.
-// Callers pass account.EffectiveQuestionType, so a question is gated on the ballot it encodes
-// rather than the type it is labelled with. Weighted elections stay gated separately via
-// CostFromWeight in hasElectionMetadataPermissions.
+// allowed (it is validated elsewhere), which is how a ballot shape with no named type at all
+// (vote overwrites, weighted cost, or a hand-crafted non-canonical protocol) passes: there is no
+// flag for a shape that carries no name. Callers pass account.EffectiveQuestionType, so a
+// question is gated on the ballot it encodes rather than the type it is labelled with. Weighted
+// elections stay gated separately via CostFromWeight in hasElectionMetadataPermissions.
 func (p *Subscriptions) OrgAllowsVotingType(orgAddress common.Address, voteType string) error {
 	if voteType == "" {
 		return nil
@@ -336,16 +337,14 @@ func (p *Subscriptions) OrgAllowsVotingType(orgAddress common.Address, voteType 
 	if err != nil {
 		return err
 	}
-	// TODO:future the remaining plan.VotingTypes flags (Ranked, Approval, Cumulative) have no
-	// entry here because db has no type constant for them, so nothing can ever resolve to one and
-	// the flags are permissive by omission: an org whose plan lacks Ranked can still mint a ranked
-	// ballot through a raw ballotProtocol. Same gap as the type check noted in
-	// hasElectionMetadataPermissions above. Approval may not belong here at all — the multichoice
-	// dense layout is an approval ballot, so that flag may be subsumed by Multiple rather than
-	// missing; worth settling with whoever defined the plan tiers before adding it.
+	// Approval is intentionally absent: the multichoice dense layout is an approval ballot, so an
+	// org allowed to mint multichoice can already mint approval. The flag is subsumed by Multiple
+	// rather than gating anything itself.
 	allowed := map[string]bool{
 		db.VotingTypeSingleChoice: plan.VotingTypes.Single,
 		db.VotingTypeMultiChoice:  plan.VotingTypes.Multiple,
+		db.VotingTypeRanked:       plan.VotingTypes.Ranked,
+		db.VotingTypeCumulative:   plan.VotingTypes.Cumulative,
 	}
 	ok, known := allowed[voteType]
 	if !known {

--- a/subscriptions/subscriptions_test.go
+++ b/subscriptions/subscriptions_test.go
@@ -569,8 +569,10 @@ func TestOrgAllowsVotingType(t *testing.T) {
 	const planID = "plan-types"
 	mockDB := &mockMongoStorage{
 		plans: map[string]*db.Plan{planID: {
-			ID:          planID,
-			VotingTypes: db.VotingTypes{Single: true, Multiple: false},
+			ID: planID,
+			VotingTypes: db.VotingTypes{
+				Single: true, Multiple: false, Ranked: true, Cumulative: true,
+			},
 		}},
 		orgs: map[string]*db.Organization{addr.String(): {
 			Address:      addr,
@@ -580,10 +582,12 @@ func TestOrgAllowsVotingType(t *testing.T) {
 	subs := &Subscriptions{db: mockDB}
 
 	c.Assert(subs.OrgAllowsVotingType(addr, db.VotingTypeSingleChoice), qt.IsNil) // allowed
-	c.Assert(subs.OrgAllowsVotingType(addr, ""), qt.IsNil)                        // empty (ballotProtocol) skips
+	c.Assert(subs.OrgAllowsVotingType(addr, db.VotingTypeRanked), qt.IsNil)       // allowed
+	c.Assert(subs.OrgAllowsVotingType(addr, db.VotingTypeCumulative), qt.IsNil)   // allowed
+	c.Assert(subs.OrgAllowsVotingType(addr, ""), qt.IsNil)                        // empty (unnamed protocol) skips
 	c.Assert(subs.OrgAllowsVotingType(addr, db.VotingTypeMultiChoice),            // plan disallows
 		qt.ErrorIs, errors.ErrVotingTypeNotAllowed)
-	c.Assert(subs.OrgAllowsVotingType(addr, "quadratic"), qt.ErrorIs, errors.ErrInvalidData) // unknown
+	c.Assert(subs.OrgAllowsVotingType(addr, "quadratic"), qt.ErrorIs, errors.ErrInvalidData) // unknown type name
 }
 
 // Mock implementation of the necessary db.MongoStorage methods for testing


### PR DESCRIPTION
Closes #632.

## Problem

The plan model advertises six voting types, but the question API implemented only two
(`singlechoice`, `multichoice`). `ranked` and `cumulative`/quadratic were reachable only as a raw
`ballotProtocol`, with two consequences:

1. **Plan entitlements did not gate.** `OrgAllowsVotingType` mapped only the named types, so an org
   whose plan lacked `Ranked`/`Cumulative` could mint one anyway by sending a raw protocol. The flags
   sold nothing.
2. **The ballot type was not recoverable downstream.** A raw protocol carries no type label, so the
   integrator-sdk cannot decode it correctly, and every integrator keeps a private sidecar of what the
   API declined to record.

## Change

Gives `ranked` and `cumulative` named types by extending the forward/reverse machinery from #620
(`BallotProtocolFromType` / `QuestionTypeFromBallotProtocol`), then wires them into the plan gate.
Recognition stays "exact equality against the forward table," so the gate closes automatically once
the reverse function knows the shapes.

The four named types now have disjoint protocol images (pinned by `TestBallotShapeUnambiguous`):

| type | protocol image (N = choices) |
|---|---|
| `singlechoice` | `{maxCount:1, maxValue:max(value)}` |
| `multichoice` | `{maxCount:N, maxValue:1, costExponent:1, maxTotalCost:maxChoices}` |
| `ranked` | `{maxCount:N, maxValue:N-1, uniqueValues:true}` |
| `cumulative` | `{maxCount:N, maxValue:0, costExponent:1|2, maxTotalCost:budget}` |

- **ranked** — `maxValue 0` is unused; uniqueValues distinguishes it. Direction (highest-value-wins)
  is a global convention matching integrator-sdk docs, not encoded.
- **cumulative** — covers budget (`costExponent:1`) and quadratic (`costExponent:2`) via new
  `typeSetup.budget` / `typeSetup.costExponent` fields; one `Cumulative` plan flag.
- **approval** — intentionally no type: it is byte-identical to the multichoice dense layout, so the
  plan flag is documented as subsumed by `Multiple` rather than gating anything itself.
- **uniqueChoices** — kept (still rejected for multichoice); its error now points at `type: ranked`.

## Breaking changes

- **`saas-integrator-demo`'s current request is rejected.** It sends `type:"singlechoice"` + raw
  `{maxCount:3,maxValue:2,uniqueValues:true}`; the protocol now resolves to `ranked`, contradicting
  the `singlechoice` label → 400. Fix: send `type:"ranked"` (or omit `type`).
- A raw ranked/cumulative protocol now reads back with a **named `type`** (was `""`) and is **gated**
  by `plan.VotingTypes.Ranked`/`Cumulative`. No migration (same stance as #620).

## Verification

`go build`/`go vet` clean; `golangci-lint` 0 issues; `make swagger` regenerated. Unit tests in
`account/` (forward/reverse/`ResolveBallotShape`/`EffectiveQuestionType`/`TestBallotShapeUnambiguous`)
and `subscriptions/` pass; full `./api/` + `./db/` suites pass.

## Deploy note

`plan.VotingTypes` is parsed from Stripe product metadata (`stripe/service.go`); products whose
`votingTypes` JSON omits `ranked`/`cumulative` unmarshal them to `false`. Those flags gated nothing
before this PR, so live metadata may not set them. Already-minted questions are grandfathered (the
publish voting-type gate skips questions with an `upstreamId`), but for **new** questions the
relevant Stripe product metadata must be audited/updated to grant `ranked`/`cumulative` where
intended.

## Follow-up (deferred)

The voting-type gate runs only at `/processes` publish preflight. `POST /transactions` and the
legacy `/process` build path route through `HasTxPermission`, which does not (yet) check voting type
— so an org whose plan lacks a flag can still get that ballot signed through those doors. Feasible to
close (the tx carries the full ballot shape); tracked as a `TODO:future` in `hasElectionMetadataPermissions`.
